### PR TITLE
[codex] Add G-code revision workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install backend dependencies
+        run: uv sync --extra dev --frozen
+
+      - name: Lint backend
+        run: uv run ruff check app/ tests/
+
+      - name: Test backend
+        run: uv run pytest tests -v
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck frontend
+        run: pnpm exec tsc --noEmit
+
+      - name: Build frontend
+        run: pnpm build

--- a/.opencode/skills/nexus3d-vault/SKILL.md
+++ b/.opencode/skills/nexus3d-vault/SKILL.md
@@ -29,6 +29,7 @@ Stage 4 is now active. See AGENTS.md roadmap and `docs/stage4.md` for the execut
 - **Frontend types split** — domain files under `types/`; `index.ts` is a barrel re-export.
 - **First-run setup expanded** — setup now captures local vs S3/R2 storage plus backup retention/off-site backup settings.
 - **External print sentinel rows are lazy** — `__external__` model/file rows are created only when the printer hub captures a non-vault print job.
+- **G-code revisions** — `File` rows for G-code can carry an outcome label, notes, and a per-model recommended marker. Comparison remains metadata-first; no raw G-code diffs or delta storage in 1.0.
 
 ---
 
@@ -139,6 +140,14 @@ model/file rows are created lazily at that moment, not during first startup.
 | `/api/v1/printers/{id}/status` | GET | — | One-shot snapshot |
 | `/api/v1/printers/{id}/jobs` | GET | — | Print history |
 | `/api/v1/printers/{id}/ws` | WS | — | Live status stream |
+| `/api/v1/models/{model_id}/files/{file_id}/revision` | PATCH | yes | Update G-code revision status, notes, recommended marker |
+
+### G-code revision fields
+
+On `files`:
+- `revision_status`: nullable (`known_good`, `needs_test`, `failed`, `archived`)
+- `revision_notes`: nullable text
+- `is_recommended`: boolean; only one live G-code file per model should be marked recommended
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ What works today:
 - OrcaSlicer post-processing hook with no Python dependencies
 - Metadata extraction from G-code, including slicer settings and filament info
 - Content-hash deduplication and model version history
+- G-code revision notes, outcome labels, recommended version, and metadata compare
 - Categories, tags, search, thumbnails, and an in-browser STL viewer
 - First-run setup wizard, API key auth for scripts, JWT login for the UI
 - Moonraker/Klipper printer integration with live status and send-to-print
@@ -121,6 +122,7 @@ Common endpoints:
 | `GET` | `/api/v1/models` | List and search models |
 | `GET` | `/api/v1/models/{id}` | Read one model with files and metadata |
 | `PATCH` | `/api/v1/models/{id}` | Update name, description, category, tags |
+| `PATCH` | `/api/v1/models/{id}/files/{file_id}/revision` | Update G-code revision status, notes, recommended marker |
 | `GET` | `/api/v1/files/{id}/raw` | Download a stored file |
 | `GET` | `/api/v1/printers` | List registered printers |
 | `POST` | `/api/v1/printers/{id}/send` | Send vault G-code to a printer |
@@ -219,7 +221,7 @@ The repository keeps most decisions documented in [CONTEXT.md](./CONTEXT.md) and
 
 The living roadmap is in [docs/roadmap.md](./docs/roadmap.md). The short version:
 
-- Finish provider maturity, especially Bambu LAN upload/send support
+- Polish G-code revision history and provider maturity, especially Bambu LAN upload/send support
 - Harden backup/restore and operational monitoring
 - Improve printer-farm workflows and scheduling
 - Keep cloud-style features optional, not required for home installs

--- a/backend/alembic/versions/1f9c2e7a4b6d_add_gcode_revision_fields.py
+++ b/backend/alembic/versions/1f9c2e7a4b6d_add_gcode_revision_fields.py
@@ -1,0 +1,48 @@
+"""add gcode revision fields
+
+Revision ID: 1f9c2e7a4b6d
+Revises: 4f0f8e06df71
+Create Date: 2026-05-31 00:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "1f9c2e7a4b6d"
+down_revision = "4f0f8e06df71"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "files",
+        sa.Column("revision_status", sa.String(length=32), nullable=True),
+    )
+    op.add_column("files", sa.Column("revision_notes", sa.Text(), nullable=True))
+    op.add_column(
+        "files",
+        sa.Column(
+            "is_recommended",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.create_index(
+        "ix_files_revision_status", "files", ["revision_status"], unique=False
+    )
+    op.create_index(
+        "ix_files_is_recommended", "files", ["is_recommended"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_files_is_recommended", table_name="files")
+    op.drop_index("ix_files_revision_status", table_name="files")
+    op.drop_column("files", "is_recommended")
+    op.drop_column("files", "revision_notes")
+    op.drop_column("files", "revision_status")

--- a/backend/app/api/v1/models.py
+++ b/backend/app/api/v1/models.py
@@ -12,10 +12,11 @@ from sqlmodel import Session, delete, select
 
 from app.core.security import require_auth
 from app.core.time import utcnow
-from app.db.models import Category, File, Metadata, Model, ModelTagLink, Tag
+from app.db.models import Category, File, FileType, Metadata, Model, ModelTagLink, Tag
 from app.db.session import get_session
 from app.schemas.models import (
     FileRead,
+    FileRevisionUpdate,
     MetadataRead,
     ModelListItem,
     ModelRead,
@@ -141,6 +142,7 @@ def _build_model_read(session: Session, model_id: int) -> ModelRead:
         select(File, Metadata)
         .where(File.model_id == model_id)
         .outerjoin(Metadata, Metadata.file_id == File.id)
+        .order_by(File.version.asc())  # type: ignore[attr-defined]
     ).all()
     file_reads = [
         FileRead(
@@ -151,6 +153,9 @@ def _build_model_read(session: Session, model_id: int) -> ModelRead:
             version=f.version,
             size_bytes=f.size_bytes,
             sha256=f.sha256,
+            revision_status=f.revision_status,
+            revision_notes=f.revision_notes,
+            is_recommended=f.is_recommended,
             uploaded_at=f.uploaded_at,
             metadata=MetadataRead(**md.model_dump()) if md else None,
         )
@@ -216,6 +221,62 @@ def update_model(
                 session.add(ModelTagLink(model_id=model_id, tag_id=t.id))
 
     m.updated_at = utcnow()
+    session.add(m)
+    session.commit()
+    return _build_model_read(session, model_id)
+
+
+@router.patch(
+    "/{model_id}/files/{file_id}/revision",
+    response_model=ModelRead,
+    dependencies=[Depends(require_auth)],
+    summary="Update G-code revision status, notes, or recommended marker",
+    description=(
+        "Updates 1.0 G-code revision fields for a file under a model. Only G-code "
+        "files are supported. Marking a file recommended clears the marker from "
+        "other G-code files on the same model."
+    ),
+)
+def update_file_revision(
+    model_id: int,
+    file_id: int,
+    payload: FileRevisionUpdate,
+    session: Session = Depends(get_session),
+) -> ModelRead:
+    m = _live_model(session, model_id)
+    file_row = session.get(File, file_id)
+    if (
+        file_row is None
+        or file_row.model_id != model_id
+        or file_row.deleted_at is not None
+    ):
+        raise HTTPException(status_code=404, detail="file_not_found")
+    if file_row.file_type != FileType.GCODE:
+        raise HTTPException(status_code=400, detail="revision_not_supported")
+
+    fields = payload.model_fields_set
+    if "revision_status" in fields:
+        file_row.revision_status = payload.revision_status
+    if "revision_notes" in fields:
+        notes = payload.revision_notes
+        file_row.revision_notes = notes.strip() if notes and notes.strip() else None
+    if "is_recommended" in fields:
+        file_row.is_recommended = bool(payload.is_recommended)
+        if file_row.is_recommended:
+            other_gcode = session.exec(
+                select(File).where(
+                    File.model_id == model_id,
+                    File.id != file_id,
+                    File.file_type == FileType.GCODE,
+                    File.deleted_at.is_(None),  # type: ignore[union-attr]
+                )
+            ).all()
+            for other in other_gcode:
+                other.is_recommended = False
+                session.add(other)
+
+    m.updated_at = utcnow()
+    session.add(file_row)
     session.add(m)
     session.commit()
     return _build_model_read(session, model_id)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -26,6 +26,13 @@ class FileType(str, Enum):
     OBJ = "obj"
 
 
+class FileRevisionStatus(str, Enum):
+    KNOWN_GOOD = "known_good"
+    NEEDS_TEST = "needs_test"
+    FAILED = "failed"
+    ARCHIVED = "archived"
+
+
 # Mapping from filesystem suffix to ``FileType``. Used by ingest routers.
 SUFFIX_TO_FILE_TYPE: dict[str, FileType] = {
     ".stl": FileType.STL,
@@ -112,6 +119,9 @@ class File(SQLModel, table=True):
     version: int = Field(default=1)
     size_bytes: int
     sha256: str = Field(index=True, max_length=64)
+    revision_status: Optional[FileRevisionStatus] = Field(default=None, index=True)
+    revision_notes: Optional[str] = None
+    is_recommended: bool = Field(default=False, index=True)
 
     uploaded_at: datetime = Field(default_factory=utcnow)
     deleted_at: Optional[datetime] = Field(default=None, index=True)

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel
 
-from app.db.models import FileType
+from app.db.models import FileRevisionStatus, FileType
 
 
 class MetadataRead(BaseModel):
@@ -38,8 +38,17 @@ class FileRead(BaseModel):
     version: int
     size_bytes: int
     sha256: str
+    revision_status: Optional[FileRevisionStatus] = None
+    revision_notes: Optional[str] = None
+    is_recommended: bool = False
     uploaded_at: datetime
     metadata: Optional[MetadataRead] = None
+
+
+class FileRevisionUpdate(BaseModel):
+    revision_status: Optional[FileRevisionStatus] = None
+    revision_notes: Optional[str] = None
+    is_recommended: Optional[bool] = None
 
 
 class ModelRead(BaseModel):

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -23,3 +23,10 @@ def test_alembic_upgrade_creates_expected_schema(tmp_path: Path, monkeypatch) ->
     assert "files" in tables
     assert "print_jobs" in tables
     assert "refresh_tokens" in tables
+
+    files_columns = {col["name"]: col for col in inspector.get_columns("files")}
+    assert "revision_status" in files_columns
+    assert "revision_notes" in files_columns
+    assert "is_recommended" in files_columns
+    assert files_columns["is_recommended"]["nullable"] is False
+    assert files_columns["is_recommended"]["default"] is not None

--- a/backend/tests/test_model_revisions_api.py
+++ b/backend/tests/test_model_revisions_api.py
@@ -1,0 +1,223 @@
+"""Tests for G-code revision metadata on model files."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.core.time import utcnow
+from app.db.models import File, FileType, Model
+
+
+def _model(db_session: Session, *, slug: str = "bracket") -> Model:
+    model = Model(name="Bracket", slug=slug, hash=f"{slug:0<64}"[:64])
+    db_session.add(model)
+    db_session.commit()
+    db_session.refresh(model)
+    return model
+
+
+def _file(
+    db_session: Session,
+    model: Model,
+    *,
+    file_type: FileType = FileType.GCODE,
+    version: int = 1,
+    sha: str = "a",
+) -> File:
+    file_row = File(
+        model_id=model.id,
+        path=f"/data/files/{model.slug}/v{version}/file-{version}.gcode",
+        original_filename=f"file-{version}.gcode",
+        file_type=file_type,
+        version=version,
+        size_bytes=123,
+        sha256=sha * 64,
+    )
+    db_session.add(file_row)
+    db_session.commit()
+    db_session.refresh(file_row)
+    return file_row
+
+
+def test_update_revision_status_notes_and_recommended(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    model = _model(db_session)
+    file_row = _file(db_session, model)
+
+    resp = client.patch(
+        f"/api/v1/models/{model.id}/files/{file_row.id}/revision",
+        json={
+            "revision_status": "known_good",
+            "revision_notes": "Printed cleanly in PETG",
+            "is_recommended": True,
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    revision = body["files"][0]
+    assert revision["revision_status"] == "known_good"
+    assert revision["revision_notes"] == "Printed cleanly in PETG"
+    assert revision["is_recommended"] is True
+
+
+def test_update_revision_can_clear_status_notes_and_recommended(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    model = _model(db_session)
+    file_row = _file(db_session, model)
+    file_row.revision_status = "known_good"
+    file_row.revision_notes = "Old note"
+    file_row.is_recommended = True
+    db_session.add(file_row)
+    db_session.commit()
+
+    resp = client.patch(
+        f"/api/v1/models/{model.id}/files/{file_row.id}/revision",
+        json={
+            "revision_status": None,
+            "revision_notes": "   ",
+            "is_recommended": False,
+        },
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    revision = resp.json()["files"][0]
+    assert revision["revision_status"] is None
+    assert revision["revision_notes"] is None
+    assert revision["is_recommended"] is False
+
+
+def test_update_revision_requires_auth(
+    client: TestClient, db_session: Session
+) -> None:
+    model = _model(db_session)
+    file_row = _file(db_session, model)
+
+    resp = client.patch(
+        f"/api/v1/models/{model.id}/files/{file_row.id}/revision",
+        json={"revision_status": "failed"},
+    )
+
+    assert resp.status_code == 401
+
+
+def test_update_revision_rejects_invalid_status(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    model = _model(db_session)
+    file_row = _file(db_session, model)
+
+    resp = client.patch(
+        f"/api/v1/models/{model.id}/files/{file_row.id}/revision",
+        json={"revision_status": "perfect_enough"},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 422
+
+
+def test_update_revision_rejects_non_gcode(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    model = _model(db_session)
+    file_row = _file(db_session, model, file_type=FileType.STL)
+
+    resp = client.patch(
+        f"/api/v1/models/{model.id}/files/{file_row.id}/revision",
+        json={"revision_status": "known_good"},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "revision_not_supported"
+
+
+def test_update_revision_rejects_soft_deleted_file(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    model = _model(db_session)
+    file_row = _file(db_session, model)
+    file_row.deleted_at = utcnow()
+    db_session.add(file_row)
+    db_session.commit()
+
+    resp = client.patch(
+        f"/api/v1/models/{model.id}/files/{file_row.id}/revision",
+        json={"revision_status": "failed"},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "file_not_found"
+
+
+def test_recommended_revision_is_unique_per_model(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    model = _model(db_session)
+    first = _file(db_session, model, version=1, sha="a")
+    second = _file(db_session, model, version=2, sha="b")
+
+    resp1 = client.patch(
+        f"/api/v1/models/{model.id}/files/{first.id}/revision",
+        json={"is_recommended": True},
+        headers=auth_headers,
+    )
+    assert resp1.status_code == 200
+
+    resp2 = client.patch(
+        f"/api/v1/models/{model.id}/files/{second.id}/revision",
+        json={"is_recommended": True},
+        headers=auth_headers,
+    )
+    assert resp2.status_code == 200
+
+    files = {f["id"]: f for f in resp2.json()["files"]}
+    assert files[first.id]["is_recommended"] is False
+    assert files[second.id]["is_recommended"] is True
+
+
+def test_recommended_revision_does_not_clear_other_models(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    first_model = _model(db_session, slug="one")
+    second_model = _model(db_session, slug="two")
+    first_file = _file(db_session, first_model, version=1, sha="a")
+    second_file = _file(db_session, second_model, version=1, sha="b")
+    first_file.is_recommended = True
+    db_session.add(first_file)
+    db_session.commit()
+
+    resp = client.patch(
+        f"/api/v1/models/{second_model.id}/files/{second_file.id}/revision",
+        json={"is_recommended": True},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 200
+    db_session.refresh(first_file)
+    db_session.refresh(second_file)
+    assert first_file.is_recommended is True
+    assert second_file.is_recommended is True
+
+
+def test_revision_file_must_belong_to_model(
+    client: TestClient, auth_headers: dict[str, str], db_session: Session
+) -> None:
+    first_model = _model(db_session, slug="one")
+    second_model = _model(db_session, slug="two")
+    file_row = _file(db_session, second_model)
+
+    resp = client.patch(
+        f"/api/v1/models/{first_model.id}/files/{file_row.id}/revision",
+        json={"revision_status": "failed"},
+        headers=auth_headers,
+    )
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "file_not_found"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,7 @@ for real home use.
 
 - Publish clearer install docs and contribution paths
 - Collect real-world feedback from Docker/NAS/homelab installs
+- Ship practical G-code revisions: outcome labels, notes, recommended version, and metadata compare
 - Add parser fixtures from more slicers and printer profiles
 - Improve first-run setup and error messages where new users get stuck
 - Tag the first release once install/upgrade notes are repeatable
@@ -43,9 +44,9 @@ Goal: make backup, restore, upgrades, and monitoring less scary.
 
 Goal: make the vault better as a daily-use 3D print library.
 
-- Better bulk editing for tags/categories
+- Better bulk editing for tags/categories and revision labels
 - Saved filters or views for common searches
-- Cleaner model/version comparison
+- Cleaner model/version comparison beyond the initial G-code metadata compare
 - More useful model detail pages for repeated reprints
 - Import/export paths for people migrating from folders or other tools
 

--- a/docs/stage4.md
+++ b/docs/stage4.md
@@ -17,6 +17,7 @@ default path; Postgres and S3 stay optional adapters for larger installs.
 ### Open-source launch prep
 
 - [x] Refresh public-facing docs for a self-hosted release: README, roadmap, contribution guidance, issue templates, and GitHub discussion surface.
+- [x] Add practical G-code revisions for 1.0: outcome labels, notes, recommended version, and metadata compare.
 
 ### Phase 4a — Schema and upgrade safety
 

--- a/frontend/src/components/model-detail.tsx
+++ b/frontend/src/components/model-detail.tsx
@@ -4,7 +4,14 @@ import { Suspense, useEffect, useMemo, useRef, useState } from "react";
 import type { STLViewerControls } from "@/components/stl-viewer";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { CategoryRead, ModelRead, PrinterRead, TagRead } from "@/types";
+import {
+  CategoryRead,
+  FileRead,
+  FileRevisionStatus,
+  ModelRead,
+  PrinterRead,
+  TagRead,
+} from "@/types";
 
 const STLViewer = dynamic(
   () => import("@/components/stl-viewer").then((m) => ({ default: m.STLViewer })),
@@ -18,6 +25,7 @@ import {
   listPrinters,
   listTags,
   sendToPrinter,
+  updateFileRevision,
   updateModel,
 } from "@/lib/api";
 import { toast } from "@/lib/toast";
@@ -29,12 +37,14 @@ import {
   ChevronDown,
   Download,
   FileText,
+  GitCompare,
   Loader2,
   Minus,
   Pencil,
   Plus,
   RotateCcw,
   Send,
+  Star,
   Trash2,
   Wifi,
   WifiOff,
@@ -68,9 +78,36 @@ function timeAgo(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
+const REVISION_STATUS_LABELS: Record<FileRevisionStatus, string> = {
+  known_good: "Known good",
+  needs_test: "Needs test",
+  failed: "Failed",
+  archived: "Archived",
+};
+
+function revisionStatusClass(status: FileRevisionStatus | null): string {
+  switch (status) {
+    case "known_good":
+      return "bg-emerald-500/15 text-emerald-600 border-emerald-500/30";
+    case "needs_test":
+      return "bg-amber-500/15 text-amber-600 border-amber-500/30";
+    case "failed":
+      return "bg-[var(--error-container)]/40 text-[var(--error)] border-[var(--error)]/30";
+    case "archived":
+      return "bg-[var(--surface-container-high)] text-[var(--on-surface-variant)] border-[var(--outline-variant)]";
+    default:
+      return "bg-[var(--surface-container-low)] text-[var(--on-surface-variant)] border-[var(--outline-variant)]";
+  }
+}
+
+function revisionStatusLabel(status: FileRevisionStatus | null): string {
+  return status ? REVISION_STATUS_LABELS[status] : "Unmarked";
+}
+
 export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
   const router = useRouter();
   const auth = useRequireAuth();
+  const initialGcodeFiles = initialModel.files.filter((f) => f.file_type === "gcode");
   const [model, setModel] = useState(initialModel);
   const [deleting, setDeleting] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -84,6 +121,13 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
   const [categories, setCategories] = useState<CategoryRead[]>([]);
   const [tags, setTags] = useState<TagRead[]>([]);
   const [catLoaded, setCatLoaded] = useState(false);
+  const [revisionSaving, setRevisionSaving] = useState<number | null>(null);
+  const [editingRevisionId, setEditingRevisionId] = useState<number | null>(null);
+  const [revisionStatus, setRevisionStatus] = useState<FileRevisionStatus | "">("");
+  const [revisionNotes, setRevisionNotes] = useState("");
+  const [revisionRecommended, setRevisionRecommended] = useState(false);
+  const [compareLeftId, setCompareLeftId] = useState<number>(initialGcodeFiles.at(-1)?.id ?? 0);
+  const [compareRightId, setCompareRightId] = useState<number>(initialGcodeFiles.at(-2)?.id ?? initialGcodeFiles.at(-1)?.id ?? 0);
   const viewerControls = useRef<STLViewerControls | null>(null);
 
   async function doDelete() {
@@ -178,14 +222,57 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
       (t) => t.name.toLowerCase() === tagInput.trim().toLowerCase(),
     );
 
-  const latestFile = model.files[model.files.length - 1];
+  const sortedFiles = useMemo(
+    () => [...model.files].sort((a, b) => a.version - b.version),
+    [model.files],
+  );
+  const gcodeFiles = useMemo(
+    () => sortedFiles.filter((f) => f.file_type === "gcode"),
+    [sortedFiles],
+  );
+  const sourceFiles = useMemo(
+    () => sortedFiles.filter((f) => f.file_type !== "gcode"),
+    [sortedFiles],
+  );
+  const recommendedGcode = gcodeFiles.find((f) => f.is_recommended) ?? null;
+  const latestFile = recommendedGcode ?? gcodeFiles[gcodeFiles.length - 1] ?? sortedFiles[sortedFiles.length - 1];
   const meta = latestFile?.metadata;
   const meshFile = model.files.find(
     (f) => f.file_type === "stl" || f.file_type === "3mf" || f.file_type === "obj",
   );
-  const gcodeFiles = model.files.filter((f) => f.file_type === "gcode");
   const hasGcode = gcodeFiles.length > 0;
+  const compareLeft = gcodeFiles.find((f) => f.id === compareLeftId) ?? gcodeFiles[gcodeFiles.length - 1] ?? null;
+  const compareRight = gcodeFiles.find((f) => f.id === compareRightId) ?? gcodeFiles[gcodeFiles.length - 2] ?? null;
   const thumbUrl = model.thumbnail_url ? getAssetUrl(model.thumbnail_url) : null;
+
+  function startRevisionEdit(file: FileRead) {
+    if (!auth.isAuthenticated) {
+      auth.showAuthRequiredToast();
+      return;
+    }
+    setEditingRevisionId(file.id);
+    setRevisionStatus(file.revision_status ?? "");
+    setRevisionNotes(file.revision_notes ?? "");
+    setRevisionRecommended(file.is_recommended);
+  }
+
+  async function saveRevision(file: FileRead) {
+    setRevisionSaving(file.id);
+    try {
+      const updated = await updateFileRevision(model.id, file.id, {
+        revision_status: revisionStatus || null,
+        revision_notes: revisionNotes,
+        is_recommended: revisionRecommended,
+      });
+      setModel(updated);
+      setEditingRevisionId(null);
+      toast.success("Revision updated");
+    } catch (e) {
+      toast.error(e);
+    } finally {
+      setRevisionSaving(null);
+    }
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -521,28 +608,172 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
               </div>
             )}
 
-            {/* Associated Files */}
+            {/* G-code Revisions */}
             <section>
               <h2 className="text-lg font-semibold text-[var(--on-surface)] mb-4 pb-1 border-b border-[var(--outline-variant)]">
-                Associated Files
+                G-code Revisions
               </h2>
-              <div className="space-y-2">
-                {model.files.map((f) => {
-                  const isGcode = f.file_type === "gcode";
+              <div className="space-y-3">
+                {gcodeFiles.length === 0 && (
+                  <p className="font-mono text-xs text-[var(--on-surface-variant)]">
+                    No sliced G-code revisions yet.
+                  </p>
+                )}
+                {gcodeFiles.map((f) => {
+                  const isEditingRevision = editingRevisionId === f.id;
+                  const fileMeta = f.metadata;
                   return (
-                    <div
-                      key={f.id}
-                      className={`flex items-center justify-between p-3 border rounded hover:shadow-sm transition-all group bg-[var(--surface)] ${isGcode ? "border-[var(--primary)]/30 bg-[var(--primary-fixed)]/20 hover:border-[var(--primary)]" : "border-[var(--outline-variant)] hover:border-[var(--primary)]"}`}
+                    <div key={f.id} className="p-3 border border-[var(--primary)]/30 bg-[var(--primary-fixed)]/15 rounded space-y-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-1.5 mb-1">
+                            <span className="font-mono text-[11px] text-[var(--primary)] font-bold uppercase tracking-wider">
+                              v{f.version}
+                            </span>
+                            <span className={`border rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider ${revisionStatusClass(f.revision_status)}`}>
+                              {revisionStatusLabel(f.revision_status)}
+                            </span>
+                            {f.is_recommended && (
+                              <span className="inline-flex items-center gap-1 border border-[var(--primary)]/30 bg-[var(--secondary-container)] text-[var(--on-secondary-container)] rounded px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wider">
+                                <Star className="h-3 w-3 fill-current" /> Recommended
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-sm text-[var(--on-surface)] font-medium truncate">
+                            {f.original_filename}
+                          </p>
+                          <p className="font-mono text-[11px] text-[var(--on-surface-variant)]">
+                            {formatBytes(f.size_bytes)} · {timeAgo(f.uploaded_at)}
+                            {fileMeta?.layer_height_mm ? ` · ${fileMeta.layer_height_mm}mm` : ""}
+                            {fileMeta?.material_type ? ` · ${fileMeta.material_type}` : ""}
+                            {fileMeta?.estimated_time_s ? ` · ${formatDuration(fileMeta.estimated_time_s)}` : ""}
+                          </p>
+                          {f.revision_notes && !isEditingRevision && (
+                            <p className="mt-2 text-xs text-[var(--on-surface-variant)] leading-relaxed">
+                              {f.revision_notes}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-1 shrink-0">
+                          <button
+                            onClick={() => startRevisionEdit(f)}
+                            disabled={!auth.isAuthenticated}
+                            title={auth.blockReason ?? "Edit revision"}
+                            className="text-[var(--on-surface-variant)] hover:text-[var(--primary)] p-2 rounded hover:bg-[var(--surface-container-high)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <a
+                            href={getAssetUrl(`/api/v1/files/${f.id}/download`)}
+                            download={f.original_filename}
+                            className="text-[var(--on-surface-variant)] hover:text-[var(--primary)] p-2 rounded hover:bg-[var(--surface-container-high)] transition-colors"
+                          >
+                            <Download className="h-4 w-4" />
+                          </a>
+                        </div>
+                      </div>
+
+                      {isEditingRevision && (
+                        <div className="space-y-2 border-t border-[var(--outline-variant)] pt-3">
+                          <select
+                            value={revisionStatus}
+                            onChange={(e) => setRevisionStatus(e.target.value as FileRevisionStatus | "")}
+                            className="w-full bg-[var(--surface-container-lowest)] border border-[var(--outline-variant)] rounded px-3 py-2 font-mono text-xs text-[var(--on-surface)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                          >
+                            <option value="">Unmarked</option>
+                            <option value="known_good">Known good</option>
+                            <option value="needs_test">Needs test</option>
+                            <option value="failed">Failed</option>
+                            <option value="archived">Archived</option>
+                          </select>
+                          <textarea
+                            value={revisionNotes}
+                            onChange={(e) => setRevisionNotes(e.target.value)}
+                            rows={2}
+                            placeholder="Notes about print outcome, fit, filament, or what to try next"
+                            className="w-full bg-[var(--surface-container-lowest)] border border-[var(--outline-variant)] rounded px-3 py-2 font-mono text-xs text-[var(--on-surface)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)] resize-none"
+                          />
+                          <label className="flex items-center gap-2 text-xs font-mono text-[var(--on-surface-variant)]">
+                            <input
+                              type="checkbox"
+                              checked={revisionRecommended}
+                              onChange={(e) => setRevisionRecommended(e.target.checked)}
+                              className="rounded"
+                            />
+                            Mark as recommended G-code for this model
+                          </label>
+                          <div className="flex gap-2">
+                            <button
+                              onClick={() => setEditingRevisionId(null)}
+                              disabled={revisionSaving === f.id}
+                              className="flex-1 py-2 rounded border border-[var(--outline-variant)] text-[var(--on-surface-variant)] font-mono text-xs uppercase tracking-wider hover:bg-[var(--surface-container-low)] transition-colors disabled:opacity-50"
+                            >
+                              Cancel
+                            </button>
+                            <button
+                              onClick={() => saveRevision(f)}
+                              disabled={revisionSaving === f.id}
+                              className="flex-1 py-2 rounded bg-[var(--primary)] text-[var(--primary-foreground)] font-mono text-xs uppercase tracking-wider hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center gap-1.5"
+                            >
+                              {revisionSaving === f.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+                              {revisionSaving === f.id ? "Saving..." : "Save"}
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            {gcodeFiles.length >= 2 && compareLeft && compareRight && (
+              <section>
+                <h2 className="text-lg font-semibold text-[var(--on-surface)] mb-4 pb-1 border-b border-[var(--outline-variant)] flex items-center gap-2">
+                  <GitCompare className="h-4 w-4" /> Compare Revisions
+                </h2>
+                <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-2">
+                    <select
+                      value={compareLeft?.id ?? ""}
+                      onChange={(e) => setCompareLeftId(Number(e.target.value))}
+                      className="bg-[var(--surface)] border border-[var(--outline-variant)] rounded px-2 py-2 font-mono text-xs text-[var(--on-surface)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
                     >
+                      {gcodeFiles.map((f) => (
+                        <option key={f.id} value={f.id}>v{f.version}</option>
+                      ))}
+                    </select>
+                    <select
+                      value={compareRight?.id ?? ""}
+                      onChange={(e) => setCompareRightId(Number(e.target.value))}
+                      className="bg-[var(--surface)] border border-[var(--outline-variant)] rounded px-2 py-2 font-mono text-xs text-[var(--on-surface)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
+                    >
+                      {gcodeFiles.map((f) => (
+                        <option key={f.id} value={f.id}>v{f.version}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <RevisionCompare left={compareLeft} right={compareRight} />
+                </div>
+              </section>
+            )}
+
+            {sourceFiles.length > 0 && (
+              <section>
+                <h2 className="text-lg font-semibold text-[var(--on-surface)] mb-4 pb-1 border-b border-[var(--outline-variant)]">
+                  Source Files
+                </h2>
+                <div className="space-y-2">
+                  {sourceFiles.map((f) => (
+                    <div key={f.id} className="flex items-center justify-between p-3 border border-[var(--outline-variant)] rounded hover:border-[var(--primary)] hover:shadow-sm transition-all group bg-[var(--surface)]">
                       <div className="flex items-center gap-3 min-w-0">
-                        <FileText className={`h-5 w-5 flex-shrink-0 ${isGcode ? "text-[var(--primary)]" : "text-[var(--outline)] group-hover:text-[var(--primary)]"}`} />
+                        <FileText className="h-5 w-5 flex-shrink-0 text-[var(--outline)] group-hover:text-[var(--primary)]" />
                         <div className="min-w-0">
                           <p className="text-sm text-[var(--on-surface)] font-medium truncate">
                             {f.original_filename}
                           </p>
                           <p className="font-mono text-[11px] text-[var(--on-surface-variant)]">
-                            {formatBytes(f.size_bytes)} · v{f.version}
-                            {isGcode ? " · Sliced" : " · Source"}
+                            {formatBytes(f.size_bytes)} · v{f.version} · Source
                           </p>
                         </div>
                       </div>
@@ -554,10 +785,10 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
                         <Download className="h-5 w-5" />
                       </a>
                     </div>
-                  );
-                })}
-              </div>
-            </section>
+                  ))}
+                </div>
+              </section>
+            )}
           </div>
 
           {/* Klipper Sync Panel */}
@@ -595,10 +826,87 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
   );
 }
 
-function SendToButtons({ modelId, gcodeFiles }: { modelId: number; gcodeFiles: { id: number; original_filename: string; version: number }[] }) {
+function RevisionCompare({ left, right }: { left: FileRead; right: FileRead }) {
+  const leftSlicer =
+    [left.metadata?.slicer_name, left.metadata?.slicer_version]
+      .filter(Boolean)
+      .join(" ") || "—";
+  const rightSlicer =
+    [right.metadata?.slicer_name, right.metadata?.slicer_version]
+      .filter(Boolean)
+      .join(" ") || "—";
+  const rows = [
+    [
+      "Status",
+      revisionStatusLabel(left.revision_status),
+      revisionStatusLabel(right.revision_status),
+    ],
+    [
+      "Layer height",
+      left.metadata?.layer_height_mm ? `${left.metadata.layer_height_mm}mm` : "—",
+      right.metadata?.layer_height_mm ? `${right.metadata.layer_height_mm}mm` : "—",
+    ],
+    [
+      "Nozzle",
+      left.metadata?.nozzle_diameter_mm ? `${left.metadata.nozzle_diameter_mm}mm` : "—",
+      right.metadata?.nozzle_diameter_mm ? `${right.metadata.nozzle_diameter_mm}mm` : "—",
+    ],
+    [
+      "Infill",
+      left.metadata?.infill_percent ? `${left.metadata.infill_percent}%` : "—",
+      right.metadata?.infill_percent ? `${right.metadata.infill_percent}%` : "—",
+    ],
+    ["Material", left.metadata?.material_type ?? "—", right.metadata?.material_type ?? "—"],
+    [
+      "Filament",
+      left.metadata?.filament_weight_g ? `${left.metadata.filament_weight_g}g` : "—",
+      right.metadata?.filament_weight_g ? `${right.metadata.filament_weight_g}g` : "—",
+    ],
+    [
+      "Est. time",
+      formatDuration(left.metadata?.estimated_time_s ?? null),
+      formatDuration(right.metadata?.estimated_time_s ?? null),
+    ],
+    ["Printer", left.metadata?.printer_model ?? "—", right.metadata?.printer_model ?? "—"],
+    ["Slicer", leftSlicer, rightSlicer],
+    ["Size", formatBytes(left.size_bytes), formatBytes(right.size_bytes)],
+    ["SHA-256", left.sha256.slice(0, 12), right.sha256.slice(0, 12)],
+  ];
+
+  return (
+    <div className="bg-[var(--surface)] border border-[var(--outline-variant)] rounded overflow-hidden">
+      <div className="grid grid-cols-[1fr_1fr_1fr] border-b border-[var(--outline-variant)] bg-[var(--surface-container-low)]">
+        <span className="px-2 py-2 font-mono text-[10px] uppercase tracking-wider text-[var(--on-surface-variant)]">Field</span>
+        <span className="px-2 py-2 font-mono text-[10px] uppercase tracking-wider text-[var(--on-surface)]">v{left.version}</span>
+        <span className="px-2 py-2 font-mono text-[10px] uppercase tracking-wider text-[var(--on-surface)]">v{right.version}</span>
+      </div>
+      {rows.map(([label, leftValue, rightValue], index) => (
+        <div
+          key={label}
+          className={`grid grid-cols-[1fr_1fr_1fr] ${index === rows.length - 1 ? "" : "border-b border-[var(--surface-container-high)]"}`}
+        >
+          <span className="px-2 py-2 font-mono text-[10px] uppercase tracking-wider text-[var(--on-surface-variant)]">{label}</span>
+          <span className="px-2 py-2 font-mono text-[11px] text-[var(--on-surface)] break-words">{leftValue}</span>
+          <span className={`px-2 py-2 font-mono text-[11px] break-words ${leftValue === rightValue ? "text-[var(--on-surface)]" : "text-[var(--primary)] font-semibold"}`}>
+            {rightValue}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SendToButtons({
+  modelId,
+  gcodeFiles,
+}: {
+  modelId: number;
+  gcodeFiles: Pick<FileRead, "id" | "original_filename" | "version" | "is_recommended">[];
+}) {
   const auth = useRequireAuth();
   const [showSend, setShowSend] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<number>(gcodeFiles[gcodeFiles.length - 1]?.id ?? 0);
+  const defaultFile = gcodeFiles.find((f) => f.is_recommended) ?? gcodeFiles[gcodeFiles.length - 1];
+  const [selectedFile, setSelectedFile] = useState<number>(defaultFile?.id ?? 0);
   const [startPrint, setStartPrint] = useState(false);
   const [printers, setPrinters] = useState<PrinterRead[]>([]);
   const [printerId, setPrinterId] = useState<number | null>(null);
@@ -692,7 +1000,7 @@ function SendToButtons({ modelId, gcodeFiles }: { modelId: number; gcodeFiles: {
             className="w-full bg-[var(--surface-container-lowest)] border border-[var(--outline-variant)] rounded px-3 py-2 font-mono text-xs text-[var(--on-surface)] focus:outline-none focus:ring-2 focus:ring-[var(--primary)]"
           >
             {gcodeFiles.map((f) => (
-              <option key={f.id} value={f.id}>{f.original_filename} (v{f.version})</option>
+              <option key={f.id} value={f.id}>{f.original_filename} (v{f.version}{f.is_recommended ? ", recommended" : ""})</option>
             ))}
           </select>
           <label className="flex items-center gap-2 text-xs font-mono text-[var(--on-surface-variant)]">

--- a/frontend/src/lib/api/models.ts
+++ b/frontend/src/lib/api/models.ts
@@ -5,6 +5,7 @@ import {
   sendJson,
 } from "@/lib/api/request";
 import {
+  FileRevisionUpdate,
   IngestJobStatus,
   IngestResponse,
   ListModelsParams,
@@ -43,6 +44,20 @@ export function updateModel(
 
 export function deleteModel(id: number, apiKey?: string): Promise<void> {
   return sendAction(`/api/v1/models/${id}`, "DELETE", apiKey);
+}
+
+export function updateFileRevision(
+  modelId: number,
+  fileId: number,
+  payload: FileRevisionUpdate,
+  apiKey?: string,
+): Promise<ModelRead> {
+  return sendJson<ModelRead>(
+    `/api/v1/models/${modelId}/files/${fileId}/revision`,
+    "PATCH",
+    payload,
+    apiKey,
+  );
 }
 
 export function ingestOrca(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,8 @@
 export type {
   MetadataRead,
   FileRead,
+  FileRevisionStatus,
+  FileRevisionUpdate,
   ModelRead,
   ModelListItem,
   ModelUpdate,

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -18,6 +18,12 @@ export interface MetadataRead {
   triangle_count: number | null;
 }
 
+export type FileRevisionStatus =
+  | "known_good"
+  | "needs_test"
+  | "failed"
+  | "archived";
+
 export interface FileRead {
   id: number;
   model_id: number;
@@ -26,8 +32,17 @@ export interface FileRead {
   version: number;
   size_bytes: number;
   sha256: string;
+  revision_status: FileRevisionStatus | null;
+  revision_notes: string | null;
+  is_recommended: boolean;
   uploaded_at: string;
   metadata: MetadataRead | null;
+}
+
+export interface FileRevisionUpdate {
+  revision_status?: FileRevisionStatus | null;
+  revision_notes?: string | null;
+  is_recommended?: boolean;
 }
 
 export interface ModelRead {


### PR DESCRIPTION
## Summary

Adds the practical 1.0 G-code revisions workflow:

- stores revision status, notes, and a per-model recommended marker on G-code files
- exposes an authenticated revision update endpoint under model files
- separates G-code revisions from source files in the model detail UI
- adds metadata-first revision comparison and makes send-to-printer prefer the recommended G-code
- documents the feature in README, roadmap, stage notes, and the local project skill

## Validation

- `git diff --check`
- `cd backend && uv run ruff check app/ tests/`
- `cd backend && uv run pytest -s tests -v` — 126 passed
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run build`

## Notes

This intentionally does not add raw G-code diffs, branching, merge concepts, or delta storage. The 1.0 shape stays metadata-first and additive to the existing model/file version structure.
