### PR TITLE
[codex] Improve print metadata settings

### DIFF
--- a/backend/alembic/versions/d4a7c2e9b6f1_add_richer_print_metadata.py
+++ b/backend/alembic/versions/d4a7c2e9b6f1_add_richer_print_metadata.py
@@ -1,0 +1,66 @@
+"""add richer print metadata and filament profiles
+
+Revision ID: d4a7c2e9b6f1
+Revises: c2f6a3e9b8d4
+Create Date: 2026-06-07 12:00:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "d4a7c2e9b6f1"
+down_revision = "c2f6a3e9b8d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("metadata", sa.Column("first_layer_height_mm", sa.Float(), nullable=True))
+    op.add_column("metadata", sa.Column("wall_loops", sa.Integer(), nullable=True))
+    op.add_column("metadata", sa.Column("top_shell_layers", sa.Integer(), nullable=True))
+    op.add_column("metadata", sa.Column("bottom_shell_layers", sa.Integer(), nullable=True))
+    op.add_column("metadata", sa.Column("support_material", sa.Boolean(), nullable=True))
+    op.add_column("metadata", sa.Column("nozzle_temperature_c", sa.Float(), nullable=True))
+    op.add_column("metadata", sa.Column("bed_temperature_c", sa.Float(), nullable=True))
+    op.create_table(
+        "filament_profiles",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("material_type", sa.String(length=64), nullable=True),
+        sa.Column("material_brand", sa.String(length=128), nullable=True),
+        sa.Column("cost_per_kg", sa.Float(), nullable=True),
+        sa.Column("notes", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_filament_profiles_name", "filament_profiles", ["name"], unique=True)
+    op.create_index(
+        "ix_filament_profiles_material_type",
+        "filament_profiles",
+        ["material_type"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_filament_profiles_material_brand",
+        "filament_profiles",
+        ["material_brand"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_filament_profiles_material_brand", table_name="filament_profiles")
+    op.drop_index("ix_filament_profiles_material_type", table_name="filament_profiles")
+    op.drop_index("ix_filament_profiles_name", table_name="filament_profiles")
+    op.drop_table("filament_profiles")
+    op.drop_column("metadata", "bed_temperature_c")
+    op.drop_column("metadata", "nozzle_temperature_c")
+    op.drop_column("metadata", "support_material")
+    op.drop_column("metadata", "bottom_shell_layers")
+    op.drop_column("metadata", "top_shell_layers")
+    op.drop_column("metadata", "wall_loops")
+    op.drop_column("metadata", "first_layer_height_mm")

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -8,6 +8,7 @@ from app.api.v1 import (
     backup,
     config,
     files,
+    filaments,
     health,
     ingest,
     models,
@@ -24,6 +25,7 @@ api_router.include_router(admin.router)
 api_router.include_router(ingest.router)
 api_router.include_router(models.router)
 api_router.include_router(files.router)
+api_router.include_router(filaments.router)
 api_router.include_router(taxonomy.router)
 api_router.include_router(printers.router)
 api_router.include_router(backup.router)

--- a/backend/app/api/v1/filaments.py
+++ b/backend/app/api/v1/filaments.py
@@ -1,0 +1,136 @@
+"""Local filament preset catalog used for cost estimates."""
+
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from sqlmodel import Session, select
+
+from app.core.http import get_or_404
+from app.core.security import require_auth
+from app.core.time import utcnow
+from app.db.models import FilamentProfile
+from app.db.session import get_session
+from app.schemas.models import (
+    FilamentProfileCreate,
+    FilamentProfileRead,
+    FilamentProfileUpdate,
+)
+
+router = APIRouter(prefix="/filament-profiles", tags=["filament-profiles"])
+
+
+def _clean(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _read(profile: FilamentProfile) -> FilamentProfileRead:
+    return FilamentProfileRead(**profile.model_dump())
+
+
+@router.get(
+    "",
+    response_model=List[FilamentProfileRead],
+    summary="List local filament presets",
+)
+def list_filament_profiles(
+    session: Session = Depends(get_session),
+) -> List[FilamentProfileRead]:
+    profiles = session.exec(
+        select(FilamentProfile).order_by(FilamentProfile.name.asc())  # type: ignore[attr-defined]
+    ).all()
+    return [_read(profile) for profile in profiles]
+
+
+@router.post(
+    "",
+    response_model=FilamentProfileRead,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_auth)],
+    summary="Create a local filament preset",
+)
+def create_filament_profile(
+    payload: FilamentProfileCreate,
+    session: Session = Depends(get_session),
+) -> FilamentProfileRead:
+    name = payload.name.strip()
+    existing = session.exec(
+        select(FilamentProfile).where(FilamentProfile.name == name)
+    ).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="filament_profile_already_exists")
+
+    profile = FilamentProfile(
+        name=name,
+        material_type=_clean(payload.material_type),
+        material_brand=_clean(payload.material_brand),
+        cost_per_kg=payload.cost_per_kg,
+        notes=_clean(payload.notes),
+    )
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return _read(profile)
+
+
+@router.patch(
+    "/{profile_id}",
+    response_model=FilamentProfileRead,
+    dependencies=[Depends(require_auth)],
+    summary="Update a local filament preset",
+)
+def update_filament_profile(
+    profile_id: int,
+    payload: FilamentProfileUpdate,
+    session: Session = Depends(get_session),
+) -> FilamentProfileRead:
+    profile = get_or_404(session, FilamentProfile, profile_id, "filament_profile_not_found")
+
+    if payload.name is not None:
+        name = payload.name.strip()
+        existing = session.exec(
+            select(FilamentProfile).where(
+                FilamentProfile.name == name,
+                FilamentProfile.id != profile_id,
+            )
+        ).first()
+        if existing:
+            raise HTTPException(status_code=409, detail="filament_profile_already_exists")
+        profile.name = name
+
+    fields_set = payload.model_fields_set
+    if "material_type" in fields_set:
+        profile.material_type = _clean(payload.material_type)
+    if "material_brand" in fields_set:
+        profile.material_brand = _clean(payload.material_brand)
+    if "cost_per_kg" in fields_set:
+        profile.cost_per_kg = payload.cost_per_kg
+    if "notes" in fields_set:
+        profile.notes = _clean(payload.notes)
+
+    profile.updated_at = utcnow()
+    session.add(profile)
+    session.commit()
+    session.refresh(profile)
+    return _read(profile)
+
+
+@router.delete(
+    "/{profile_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    dependencies=[Depends(require_auth)],
+    summary="Delete a local filament preset",
+)
+def delete_filament_profile(
+    profile_id: int,
+    session: Session = Depends(get_session),
+) -> Response:
+    profile = get_or_404(session, FilamentProfile, profile_id, "filament_profile_not_found")
+    session.delete(profile)
+    session.commit()
+    return Response(status_code=204)

--- a/backend/app/api/v1/models.py
+++ b/backend/app/api/v1/models.py
@@ -33,6 +33,7 @@ from app.db.models import (
     File,
     FileRevisionStatus,
     FileType,
+    FilamentProfile,
     Metadata,
     Model,
     ModelTagLink,
@@ -81,7 +82,14 @@ _EXPORT_CSV_FIELDS = [
     "printer_model",
     "nozzle_diameter_mm",
     "layer_height_mm",
+    "first_layer_height_mm",
     "infill_percent",
+    "wall_loops",
+    "top_shell_layers",
+    "bottom_shell_layers",
+    "support_material",
+    "nozzle_temperature_c",
+    "bed_temperature_c",
     "estimated_time_s",
     "filament_weight_g",
     "filament_length_mm",
@@ -175,6 +183,57 @@ def _printer_presence_for(
         )
         for printer_id, printer_name, file_count in rows
     ]
+
+
+def _normalise_profile_key(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip().lower()
+    return stripped or None
+
+
+def _matching_filament_profile(
+    session: Session,
+    metadata: Metadata,
+) -> FilamentProfile | None:
+    candidates = [
+        _normalise_profile_key(metadata.material_brand),
+        _normalise_profile_key(metadata.material_type),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        profile = session.exec(
+            select(FilamentProfile).where(func.lower(FilamentProfile.name) == candidate)
+        ).first()
+        if profile is not None:
+            return profile
+
+    material_type = _normalise_profile_key(metadata.material_type)
+    material_brand = _normalise_profile_key(metadata.material_brand)
+    if material_type is None:
+        return None
+
+    stmt = select(FilamentProfile).where(
+        func.lower(FilamentProfile.material_type) == material_type
+    )
+    if material_brand is not None:
+        stmt = stmt.where(func.lower(FilamentProfile.material_brand) == material_brand)
+    else:
+        stmt = stmt.where(FilamentProfile.material_brand.is_(None))
+    return session.exec(stmt).first()
+
+
+def _metadata_read(session: Session, metadata: Metadata) -> MetadataRead:
+    data = metadata.model_dump()
+    if data.get("filament_cost") is None and metadata.filament_weight_g:
+        profile = _matching_filament_profile(session, metadata)
+        if profile and profile.cost_per_kg is not None:
+            data["filament_cost"] = round(
+                metadata.filament_weight_g * profile.cost_per_kg / 1000,
+                4,
+            )
+    return MetadataRead(**data)
 
 
 @router.get(
@@ -306,7 +365,7 @@ def _build_model_read(session: Session, model_id: int) -> ModelRead:
             revision_notes=f.revision_notes,
             is_recommended=f.is_recommended,
             uploaded_at=f.uploaded_at,
-            metadata=MetadataRead(**md.model_dump()) if md else None,
+            metadata=_metadata_read(session, md) if md else None,
         )
         for f, md in files_with_meta
     ]
@@ -392,7 +451,7 @@ def _export_models(session: Session) -> dict:
                     revision_notes=file_row.revision_notes,
                     is_recommended=file_row.is_recommended,
                     uploaded_at=file_row.uploaded_at,
-                    metadata=MetadataRead(**metadata.model_dump()) if metadata else None,
+                    metadata=_metadata_read(session, metadata) if metadata else None,
                 ).model_dump(mode="json")
             )
 
@@ -467,7 +526,16 @@ def _export_models_csv(payload: dict) -> str:
                     "printer_model": metadata.get("printer_model") or "",
                     "nozzle_diameter_mm": metadata.get("nozzle_diameter_mm") or "",
                     "layer_height_mm": metadata.get("layer_height_mm") or "",
+                    "first_layer_height_mm": metadata.get("first_layer_height_mm") or "",
                     "infill_percent": metadata.get("infill_percent") or "",
+                    "wall_loops": metadata.get("wall_loops") or "",
+                    "top_shell_layers": metadata.get("top_shell_layers") or "",
+                    "bottom_shell_layers": metadata.get("bottom_shell_layers") or "",
+                    "support_material": metadata.get("support_material")
+                    if metadata.get("support_material") is not None
+                    else "",
+                    "nozzle_temperature_c": metadata.get("nozzle_temperature_c") or "",
+                    "bed_temperature_c": metadata.get("bed_temperature_c") or "",
                     "estimated_time_s": metadata.get("estimated_time_s") or "",
                     "filament_weight_g": metadata.get("filament_weight_g") or "",
                     "filament_length_mm": metadata.get("filament_length_mm") or "",

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -83,7 +83,14 @@ class Metadata(SQLModel, table=True):
     printer_model: Optional[str] = Field(default=None, max_length=128)
     nozzle_diameter_mm: Optional[float] = None
     layer_height_mm: Optional[float] = None
+    first_layer_height_mm: Optional[float] = None
     infill_percent: Optional[float] = None
+    wall_loops: Optional[int] = None
+    top_shell_layers: Optional[int] = None
+    bottom_shell_layers: Optional[int] = None
+    support_material: Optional[bool] = None
+    nozzle_temperature_c: Optional[float] = None
+    bed_temperature_c: Optional[float] = None
 
     # Print stats
     estimated_time_s: Optional[int] = None
@@ -103,6 +110,22 @@ class Metadata(SQLModel, table=True):
     created_at: datetime = Field(default_factory=utcnow)
 
     file: Optional["File"] = Relationship(back_populates="file_metadata")
+
+
+class FilamentProfile(SQLModel, table=True):
+    """Local slicer filament preset with cost data for per-part estimates."""
+
+    __tablename__ = "filament_profiles"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str = Field(max_length=128, unique=True, index=True)
+    material_type: Optional[str] = Field(default=None, max_length=64, index=True)
+    material_brand: Optional[str] = Field(default=None, max_length=128, index=True)
+    cost_per_kg: Optional[float] = None
+    notes: Optional[str] = None
+
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(default_factory=utcnow)
 
 
 class File(SQLModel, table=True):

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -14,7 +14,14 @@ class MetadataRead(BaseModel):
     printer_model: Optional[str] = None
     nozzle_diameter_mm: Optional[float] = None
     layer_height_mm: Optional[float] = None
+    first_layer_height_mm: Optional[float] = None
     infill_percent: Optional[float] = None
+    wall_loops: Optional[int] = None
+    top_shell_layers: Optional[int] = None
+    bottom_shell_layers: Optional[int] = None
+    support_material: Optional[bool] = None
+    nozzle_temperature_c: Optional[float] = None
+    bed_temperature_c: Optional[float] = None
 
     estimated_time_s: Optional[int] = None
     filament_weight_g: Optional[float] = None
@@ -136,3 +143,31 @@ class TagRead(BaseModel):
     name: str
     slug: str
     model_count: int = 0
+
+
+class FilamentProfileBase(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    material_type: Optional[str] = Field(default=None, max_length=64)
+    material_brand: Optional[str] = Field(default=None, max_length=128)
+    cost_per_kg: Optional[float] = Field(default=None, ge=0)
+    notes: Optional[str] = Field(default=None, max_length=4096)
+
+
+class FilamentProfileCreate(FilamentProfileBase):
+    model_config = ConfigDict(extra="forbid")
+
+
+class FilamentProfileUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: Optional[str] = Field(default=None, min_length=1, max_length=128)
+    material_type: Optional[str] = Field(default=None, max_length=64)
+    material_brand: Optional[str] = Field(default=None, max_length=128)
+    cost_per_kg: Optional[float] = Field(default=None, ge=0)
+    notes: Optional[str] = Field(default=None, max_length=4096)
+
+
+class FilamentProfileRead(FilamentProfileBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/gcode_parser.py
+++ b/backend/app/services/gcode_parser.py
@@ -36,12 +36,53 @@ _PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
         re.compile(r";\s*layer_height\s*=\s*([\d.]+)", re.IGNORECASE),
         re.compile(r";\s*layer height\s*[:=]\s*([\d.]+)", re.IGNORECASE),
     ),
+    "first_layer_height_mm": (
+        re.compile(r";\s*first_layer_height\s*=\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*first layer height\s*[:=]\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*initial_layer_print_height\s*=\s*([\d.]+)", re.IGNORECASE),
+    ),
     "infill_percent": (
         re.compile(
             r";\s*sparse_infill_density\s*=\s*([\d.]+)\s*%?", re.IGNORECASE
         ),
         re.compile(r";\s*infill_density\s*=\s*([\d.]+)\s*%?", re.IGNORECASE),
         re.compile(r";\s*fill density\s*[:=]\s*([\d.]+)\s*%?", re.IGNORECASE),
+    ),
+    "wall_loops": (
+        re.compile(r";\s*wall_loops\s*=\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*wall loops\s*[:=]\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*perimeters\s*=\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*wall_line_count\s*=\s*(\d+)", re.IGNORECASE),
+    ),
+    "top_shell_layers": (
+        re.compile(r";\s*top_shell_layers\s*=\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*top shell layers\s*[:=]\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*top_solid_layers\s*=\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*top_layers\s*=\s*(\d+)", re.IGNORECASE),
+    ),
+    "bottom_shell_layers": (
+        re.compile(r";\s*bottom_shell_layers\s*=\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*bottom shell layers\s*[:=]\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*bottom_solid_layers\s*=\s*(\d+)", re.IGNORECASE),
+        re.compile(r";\s*bottom_layers\s*=\s*(\d+)", re.IGNORECASE),
+    ),
+    "support_material_raw": (
+        re.compile(r";\s*enable_support\s*=\s*([^\r\n;]+)", re.IGNORECASE),
+        re.compile(r";\s*support_material\s*=\s*([^\r\n;]+)", re.IGNORECASE),
+        re.compile(r";\s*support_enable\s*=\s*([^\r\n;]+)", re.IGNORECASE),
+        re.compile(r";\s*support\s*[:=]\s*([^\r\n;]+)", re.IGNORECASE),
+    ),
+    "nozzle_temperature_c": (
+        re.compile(r";\s*nozzle_temperature\s*=\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*filament_temperature\s*=\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*temperature\s*[:=]\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*print_temperature\s*=\s*([\d.]+)", re.IGNORECASE),
+    ),
+    "bed_temperature_c": (
+        re.compile(r";\s*bed_temperature\s*=\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*filament_bed_temperature\s*=\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*bed temperature\s*[:=]\s*([\d.]+)", re.IGNORECASE),
+        re.compile(r";\s*print_bed_temperature\s*=\s*([\d.]+)", re.IGNORECASE),
     ),
     "estimated_time_raw": (
         re.compile(r";\s*estimated printing time.*?=\s*(.+)", re.IGNORECASE),
@@ -68,6 +109,11 @@ _PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
     "material_type": (
         re.compile(r";\s*filament_type\s*=\s*([^\n;]+)", re.IGNORECASE),
         re.compile(r";\s*filament type\s*[:=]\s*([^\n;]+)", re.IGNORECASE),
+    ),
+    "material_brand": (
+        re.compile(r";\s*filament_brand\s*=\s*([^\n;]+)", re.IGNORECASE),
+        re.compile(r";\s*filament_vendor\s*=\s*([^\n;]+)", re.IGNORECASE),
+        re.compile(r";\s*filament_settings_id\s*=\s*([^\n;]+)", re.IGNORECASE),
     ),
 }
 
@@ -115,14 +161,30 @@ def _first_match(text: str, patterns: tuple[re.Pattern[str], ...]) -> str | None
 
 
 def _to_float(value: str) -> float | None:
-    try:
-        return float(value.split(",", 1)[0].strip().rstrip("%"))
-    except ValueError:
+    match = re.search(r"[-+]?\d+(?:\.\d+)?", value)
+    if not match:
         return None
+    return float(match.group(0))
 
 
 def _normalise_material(value: str) -> str:
     return value.split(";", 1)[0].split(",", 1)[0].strip()
+
+
+def _to_int(value: str) -> int | None:
+    try:
+        return int(float(value.split(",", 1)[0].strip()))
+    except ValueError:
+        return None
+
+
+def _to_bool(value: str) -> bool | None:
+    normalised = value.split(",", 1)[0].strip().lower()
+    if normalised in {"1", "true", "yes", "on", "enabled", "generated"}:
+        return True
+    if normalised in {"0", "false", "no", "off", "disabled", "none", "not generated"}:
+        return False
+    return None
 
 
 def parse(path: Path) -> Dict[str, Any]:
@@ -133,12 +195,20 @@ def parse(path: Path) -> Dict[str, Any]:
         "printer_model": None,
         "nozzle_diameter_mm": None,
         "layer_height_mm": None,
+        "first_layer_height_mm": None,
         "infill_percent": None,
+        "wall_loops": None,
+        "top_shell_layers": None,
+        "bottom_shell_layers": None,
+        "support_material": None,
+        "nozzle_temperature_c": None,
+        "bed_temperature_c": None,
         "estimated_time_s": None,
         "filament_weight_g": None,
         "filament_length_mm": None,
         "filament_cost": None,
         "material_type": None,
+        "material_brand": None,
     }
 
     try:
@@ -154,6 +224,8 @@ def parse(path: Path) -> Dict[str, Any]:
 
         if key == "estimated_time_raw":
             out["estimated_time_s"] = parse_duration(value)
+        elif key == "support_material_raw":
+            out["support_material"] = _to_bool(value)
         elif key == "slicer_version":
             out["slicer_version"] = value
             # Try to also derive slicer_name from the same line.
@@ -171,12 +243,15 @@ def parse(path: Path) -> Dict[str, Any]:
         elif (
             key.endswith("_mm")
             or key.endswith("_g")
+            or key.endswith("_c")
             or key in {"filament_cost", "infill_percent"}
         ):
             out[key] = _to_float(value)
             if key == "filament_length_mm" and "filament used:" in text.lower():
                 out[key] = out[key] * 1000 if out[key] is not None else None
-        elif key == "material_type":
+        elif key in {"wall_loops", "top_shell_layers", "bottom_shell_layers"}:
+            out[key] = _to_int(value)
+        elif key in {"material_type", "material_brand"}:
             out[key] = _normalise_material(value)
         else:
             out[key] = value

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,6 +41,7 @@ _TRUNCATE_TABLES_ORDER = [
     "printer_files",
     "print_jobs",
     "printers",
+    "filament_profiles",
     "files",
     "model_tags",
     "tags",

--- a/backend/tests/fixtures/sample.gcode
+++ b/backend/tests/fixtures/sample.gcode
@@ -2,11 +2,19 @@
 ; printer_model = Ender-3 V3 SE
 ; nozzle_diameter = 0.4
 ; layer_height = 0.2
+; first_layer_height = 0.24
 ; sparse_infill_density = 15%
+; wall_loops = 3
+; top_shell_layers = 4
+; bottom_shell_layers = 3
+; enable_support = 0
+; nozzle_temperature = 215
+; bed_temperature = 60
 ; total filament used [g] = 12.5
 ; total filament length [mm] = 4200.0
 ; total filament cost = 0.35
 ; filament_type = PLA
+; filament_brand = Generic PLA
 ; estimated printing time (normal mode) = 1h 23m 45s
 ;
 ; thumbnail begin 32x32 128

--- a/backend/tests/test_filament_profiles.py
+++ b/backend/tests/test_filament_profiles.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.db.models import File, FileType, FilamentProfile, Metadata, Model
+
+
+def test_filament_profile_crud(client: TestClient, auth_headers: dict[str, str]) -> None:
+    created = client.post(
+        "/api/v1/filament-profiles",
+        headers=auth_headers,
+        json={
+            "name": "Generic PLA",
+            "material_type": "PLA",
+            "material_brand": "Generic",
+            "cost_per_kg": 20,
+        },
+    )
+    assert created.status_code == 201
+    assert created.json()["name"] == "Generic PLA"
+
+    listed = client.get("/api/v1/filament-profiles")
+    assert listed.status_code == 200
+    assert listed.json()[0]["cost_per_kg"] == 20
+
+
+def test_model_metadata_estimates_cost_from_local_filament_profile(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    model = Model(name="Bracket", slug="bracket", hash="a" * 64)
+    db_session.add(model)
+    db_session.commit()
+    db_session.refresh(model)
+
+    file_row = File(
+        model_id=model.id,
+        path="/tmp/bracket.gcode",
+        original_filename="bracket.gcode",
+        file_type=FileType.GCODE,
+        version=1,
+        size_bytes=123,
+        sha256="b" * 64,
+    )
+    db_session.add(file_row)
+    db_session.commit()
+    db_session.refresh(file_row)
+
+    db_session.add(
+        Metadata(
+            file_id=file_row.id,
+            material_type="PLA",
+            material_brand="Generic PLA",
+            filament_weight_g=10,
+        )
+    )
+    db_session.add(
+        FilamentProfile(
+            name="Generic PLA",
+            material_type="PLA",
+            material_brand="Generic",
+            cost_per_kg=20,
+        )
+    )
+    db_session.commit()
+
+    response = client.get(f"/api/v1/models/{model.id}")
+    assert response.status_code == 200
+    metadata = response.json()["files"][0]["metadata"]
+    assert metadata["filament_cost"] == 0.2

--- a/backend/tests/test_gcode_parser.py
+++ b/backend/tests/test_gcode_parser.py
@@ -39,12 +39,20 @@ class TestParse:
         assert result["printer_model"] == "Ender-3 V3 SE"
         assert result["nozzle_diameter_mm"] == 0.4
         assert result["layer_height_mm"] == 0.2
+        assert result["first_layer_height_mm"] == 0.24
         assert result["infill_percent"] == 15.0
+        assert result["wall_loops"] == 3
+        assert result["top_shell_layers"] == 4
+        assert result["bottom_shell_layers"] == 3
+        assert result["support_material"] is False
+        assert result["nozzle_temperature_c"] == 215.0
+        assert result["bed_temperature_c"] == 60.0
         assert result["estimated_time_s"] == 5025
         assert result["filament_weight_g"] == 12.5
         assert result["filament_length_mm"] == 4200.0
         assert result["filament_cost"] == 0.35
         assert result["material_type"] == "PLA"
+        assert result["material_brand"] == "Generic PLA"
 
     def test_parse_prusaslicer_fixture(self) -> None:
         fixture = Path(__file__).parent / "fixtures" / "prusaslicer_sample.gcode"

--- a/frontend/src/components/filament-profiles-card.tsx
+++ b/frontend/src/components/filament-profiles-card.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FilamentProfileRead } from "@/types";
+import {
+  createFilamentProfile,
+  deleteFilamentProfile,
+  listFilamentProfiles,
+} from "@/lib/api";
+import { toast } from "@/lib/toast";
+import { useRequireAuth } from "@/lib/use-require-auth";
+import { DollarSign, Plus, X } from "lucide-react";
+
+function formatCost(value: number | null): string {
+  return value == null ? "—" : `${value.toFixed(2)}/kg`;
+}
+
+export function FilamentProfilesCard() {
+  const auth = useRequireAuth();
+  const [profiles, setProfiles] = useState<FilamentProfileRead[]>([]);
+  const [name, setName] = useState("");
+  const [materialType, setMaterialType] = useState("");
+  const [materialBrand, setMaterialBrand] = useState("");
+  const [costPerKg, setCostPerKg] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    try {
+      setProfiles(await listFilamentProfiles());
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { refresh(); }, []);
+
+  async function handleCreate() {
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    if (!auth.isAuthenticated) { auth.showAuthRequiredToast(); return; }
+
+    const parsedCost = costPerKg.trim() ? Number(costPerKg) : null;
+    if (parsedCost !== null && (!Number.isFinite(parsedCost) || parsedCost < 0)) {
+      toast.error("Invalid filament cost");
+      return;
+    }
+
+    try {
+      await createFilamentProfile({
+        name: trimmedName,
+        material_type: materialType.trim() || null,
+        material_brand: materialBrand.trim() || null,
+        cost_per_kg: parsedCost,
+      });
+      setName("");
+      setMaterialType("");
+      setMaterialBrand("");
+      setCostPerKg("");
+      toast.success(`Filament preset "${trimmedName}" saved`);
+      refresh();
+    } catch (e: any) {
+      setError(e.message);
+      toast.error(e);
+    }
+  }
+
+  async function handleDelete(id: number) {
+    if (!auth.isAuthenticated) { auth.showAuthRequiredToast(); return; }
+    try {
+      await deleteFilamentProfile(id);
+      toast.success("Filament preset removed");
+      refresh();
+    } catch (e: any) {
+      setError(e.message);
+      toast.error(e);
+    }
+  }
+
+  return (
+    <div className="bg-[var(--surface-container-lowest)] border border-[var(--outline-variant)] rounded overflow-hidden">
+      <div className="px-4 sm:px-6 py-3 sm:py-4 border-b border-[var(--outline-variant)] flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <DollarSign className="h-4 w-4 text-[var(--on-surface-variant)] flex-shrink-0" />
+          <h3 className="text-sm font-semibold text-[var(--on-surface)]">
+            Filament presets
+          </h3>
+          <span className="font-mono text-xs text-[var(--on-surface-variant)]">
+            ({profiles.length})
+          </span>
+        </div>
+        <form
+          onSubmit={(e) => { e.preventDefault(); handleCreate(); }}
+          className="grid grid-cols-1 sm:grid-cols-[1.2fr_0.7fr_0.9fr_0.7fr_auto] gap-2"
+        >
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            disabled={!auth.isAuthenticated}
+            placeholder={auth.isAuthenticated ? "Preset name..." : "Sign in to add"}
+            className="bg-[var(--surface-container-lowest)] text-[var(--on-surface)] font-mono text-xs border border-[var(--outline-variant)] rounded px-3 py-[6px] focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:border-transparent disabled:opacity-50"
+          />
+          <input
+            value={materialType}
+            onChange={(e) => setMaterialType(e.target.value)}
+            disabled={!auth.isAuthenticated}
+            placeholder="PLA"
+            className="bg-[var(--surface-container-lowest)] text-[var(--on-surface)] font-mono text-xs border border-[var(--outline-variant)] rounded px-3 py-[6px] focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:border-transparent disabled:opacity-50"
+          />
+          <input
+            value={materialBrand}
+            onChange={(e) => setMaterialBrand(e.target.value)}
+            disabled={!auth.isAuthenticated}
+            placeholder="Brand"
+            className="bg-[var(--surface-container-lowest)] text-[var(--on-surface)] font-mono text-xs border border-[var(--outline-variant)] rounded px-3 py-[6px] focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:border-transparent disabled:opacity-50"
+          />
+          <input
+            value={costPerKg}
+            onChange={(e) => setCostPerKg(e.target.value)}
+            disabled={!auth.isAuthenticated}
+            inputMode="decimal"
+            placeholder="Cost/kg"
+            className="bg-[var(--surface-container-lowest)] text-[var(--on-surface)] font-mono text-xs border border-[var(--outline-variant)] rounded px-3 py-[6px] focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:border-transparent disabled:opacity-50"
+          />
+          <button
+            type="submit"
+            disabled={!name.trim() || !auth.isAuthenticated}
+            className="p-1.5 rounded bg-[var(--primary)] text-[var(--primary-foreground)] hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center"
+          >
+            <Plus className="h-3.5 w-3.5" />
+          </button>
+        </form>
+      </div>
+
+      <div className="p-3 sm:p-4">
+        {error && (
+          <div className="mb-3 rounded border border-[var(--error)]/30 bg-[var(--error-container)]/20 p-2 text-xs text-[var(--error)] font-mono">
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <p className="text-xs text-[var(--on-surface-variant)] font-mono">Loading...</p>
+        ) : profiles.length === 0 ? (
+          <p className="text-xs text-[var(--on-surface-variant)] font-mono">
+            No filament presets saved yet.
+          </p>
+        ) : (
+          <div className="space-y-1">
+            {profiles.map((profile) => (
+              <div
+                key={profile.id}
+                className="flex items-center justify-between py-1.5 px-2 rounded hover:bg-[var(--surface-container-low)] group gap-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm text-[var(--on-surface)] truncate">
+                    {profile.name}
+                  </p>
+                  <p className="font-mono text-[10px] text-[var(--on-surface-variant)] truncate">
+                    {[profile.material_type, profile.material_brand].filter(Boolean).join(" · ") || "No material data"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-xs text-[var(--on-surface)]">
+                    {formatCost(profile.cost_per_kg)}
+                  </span>
+                  <button
+                    onClick={() => handleDelete(profile.id)}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-[var(--error-container)]/30 text-[var(--error)]"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/model-detail.tsx
+++ b/frontend/src/components/model-detail.tsx
@@ -8,6 +8,7 @@ import {
   CategoryRead,
   FileRead,
   FileRevisionStatus,
+  MetadataRead,
   ModelRead,
   ModelPrinterFileRead,
   PrinterRead,
@@ -70,6 +71,26 @@ function formatDuration(seconds: number | null): string {
   return `${h}h ${m}m`;
 }
 
+function formatMillimeters(value: number | null | undefined): string {
+  return value ? `${value}mm` : "—";
+}
+
+function formatPercent(value: number | null | undefined): string {
+  return value ? `${value}%` : "—";
+}
+
+function formatGrams(value: number | null | undefined): string {
+  return value ? `${value}g` : "—";
+}
+
+function formatTemperature(value: number | null | undefined): string {
+  return value ? `${value}°C` : "—";
+}
+
+function formatCost(value: number | null | undefined): string {
+  return value ? value.toFixed(2) : "—";
+}
+
 function timeAgo(dateStr: string): string {
   const diff = Date.now() - new Date(dateStr).getTime();
   const mins = Math.floor(diff / 60000);
@@ -106,6 +127,85 @@ function revisionStatusClass(status: FileRevisionStatus | null): string {
 
 function revisionStatusLabel(status: FileRevisionStatus | null): string {
   return status ? REVISION_STATUS_LABELS[status] : "Unmarked";
+}
+
+type PrintSettingRow = {
+  label: string;
+  value: string;
+  chip?: boolean;
+  highlight?: boolean;
+};
+
+function buildPrintSettingRows(meta: MetadataRead | null | undefined): PrintSettingRow[] {
+  const rows: PrintSettingRow[] = [
+    { label: "PRINTER PROFILE", value: meta?.printer_model ?? "—" },
+    {
+      label: "MATERIAL",
+      value: meta?.material_type ?? "—",
+      chip: true,
+    },
+  ];
+
+  if (meta?.material_brand) {
+    rows.push({ label: "FILAMENT PROFILE", value: meta.material_brand });
+  }
+
+  rows.push(
+    { label: "LAYER HEIGHT", value: formatMillimeters(meta?.layer_height_mm) },
+  );
+
+  if (meta?.first_layer_height_mm) {
+    rows.push({
+      label: "FIRST LAYER",
+      value: formatMillimeters(meta.first_layer_height_mm),
+    });
+  }
+
+  rows.push(
+    { label: "NOZZLE", value: formatMillimeters(meta?.nozzle_diameter_mm) },
+    { label: "INFILL", value: formatPercent(meta?.infill_percent) },
+  );
+
+  if (meta?.wall_loops) {
+    rows.push({ label: "WALLS", value: String(meta.wall_loops) });
+  }
+
+  if (meta?.top_shell_layers || meta?.bottom_shell_layers) {
+    rows.push({
+      label: "TOP / BOTTOM",
+      value: `${meta?.top_shell_layers ?? "—"} / ${meta?.bottom_shell_layers ?? "—"}`,
+    });
+  }
+
+  if (meta?.support_material !== null && meta?.support_material !== undefined) {
+    rows.push({ label: "SUPPORTS", value: meta.support_material ? "Yes" : "No" });
+  }
+
+  if (meta?.nozzle_temperature_c) {
+    rows.push({
+      label: "NOZZLE TEMP",
+      value: formatTemperature(meta.nozzle_temperature_c),
+    });
+  }
+
+  if (meta?.bed_temperature_c) {
+    rows.push({ label: "BED TEMP", value: formatTemperature(meta.bed_temperature_c) });
+  }
+
+  rows.push(
+    {
+      label: "EST. TIME",
+      value: formatDuration(meta?.estimated_time_s ?? null),
+      highlight: true,
+    },
+    { label: "FILAMENT", value: formatGrams(meta?.filament_weight_g) },
+  );
+
+  if (meta?.filament_cost) {
+    rows.push({ label: "FILAMENT COST", value: formatCost(meta.filament_cost) });
+  }
+
+  return rows;
 }
 
 export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
@@ -248,6 +348,7 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
   const recommendedGcode = gcodeFiles.find((f) => f.is_recommended) ?? null;
   const latestFile = recommendedGcode ?? gcodeFiles[gcodeFiles.length - 1] ?? sortedFiles[sortedFiles.length - 1];
   const meta = latestFile?.metadata;
+  const printSettingRows = useMemo(() => buildPrintSettingRows(meta), [meta]);
   const meshFile = model.files.find(
     (f) => f.file_type === "stl" || f.file_type === "3mf" || f.file_type === "obj",
   );
@@ -462,13 +563,16 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
                 Print Settings
               </h2>
               <div className="bg-[var(--surface)] border border-[var(--outline-variant)] rounded flex flex-col">
-                <SettingRow label="PRINTER PROFILE" value={meta?.printer_model ?? "—"} />
-                <SettingRow label="MATERIAL" value={meta?.material_type ?? "—"} chip />
-                <SettingRow label="LAYER HEIGHT" value={meta?.layer_height_mm ? `${meta.layer_height_mm}mm` : "—"} />
-                <SettingRow label="NOZZLE" value={meta?.nozzle_diameter_mm ? `${meta.nozzle_diameter_mm}mm` : "—"} />
-                <SettingRow label="INFILL" value={meta?.infill_percent ? `${meta.infill_percent}%` : "—"} />
-                <SettingRow label="EST. TIME" value={formatDuration(meta?.estimated_time_s ?? null)} highlight />
-                <SettingRow label="FILAMENT" value={meta?.filament_weight_g ? `${meta.filament_weight_g}g` : "—"} last />
+                {printSettingRows.map((row, index) => (
+                  <SettingRow
+                    key={row.label}
+                    label={row.label}
+                    value={row.value}
+                    chip={row.chip}
+                    highlight={row.highlight}
+                    last={index === printSettingRows.length - 1}
+                  />
+                ))}
               </div>
             </section>
 
@@ -1028,24 +1132,72 @@ function RevisionCompare({ left, right }: { left: FileRead; right: FileRead }) {
     ],
     [
       "Layer height",
-      left.metadata?.layer_height_mm ? `${left.metadata.layer_height_mm}mm` : "—",
-      right.metadata?.layer_height_mm ? `${right.metadata.layer_height_mm}mm` : "—",
+      formatMillimeters(left.metadata?.layer_height_mm),
+      formatMillimeters(right.metadata?.layer_height_mm),
+    ],
+    [
+      "First layer",
+      formatMillimeters(left.metadata?.first_layer_height_mm),
+      formatMillimeters(right.metadata?.first_layer_height_mm),
     ],
     [
       "Nozzle",
-      left.metadata?.nozzle_diameter_mm ? `${left.metadata.nozzle_diameter_mm}mm` : "—",
-      right.metadata?.nozzle_diameter_mm ? `${right.metadata.nozzle_diameter_mm}mm` : "—",
+      formatMillimeters(left.metadata?.nozzle_diameter_mm),
+      formatMillimeters(right.metadata?.nozzle_diameter_mm),
     ],
     [
       "Infill",
-      left.metadata?.infill_percent ? `${left.metadata.infill_percent}%` : "—",
-      right.metadata?.infill_percent ? `${right.metadata.infill_percent}%` : "—",
+      formatPercent(left.metadata?.infill_percent),
+      formatPercent(right.metadata?.infill_percent),
+    ],
+    [
+      "Walls",
+      left.metadata?.wall_loops ? String(left.metadata.wall_loops) : "—",
+      right.metadata?.wall_loops ? String(right.metadata.wall_loops) : "—",
+    ],
+    [
+      "Top / bottom",
+      left.metadata?.top_shell_layers || left.metadata?.bottom_shell_layers
+        ? `${left.metadata?.top_shell_layers ?? "—"} / ${left.metadata?.bottom_shell_layers ?? "—"}`
+        : "—",
+      right.metadata?.top_shell_layers || right.metadata?.bottom_shell_layers
+        ? `${right.metadata?.top_shell_layers ?? "—"} / ${right.metadata?.bottom_shell_layers ?? "—"}`
+        : "—",
+    ],
+    [
+      "Supports",
+      left.metadata?.support_material === null || left.metadata?.support_material === undefined
+        ? "—"
+        : left.metadata.support_material
+          ? "Yes"
+          : "No",
+      right.metadata?.support_material === null || right.metadata?.support_material === undefined
+        ? "—"
+        : right.metadata.support_material
+          ? "Yes"
+          : "No",
+    ],
+    [
+      "Nozzle temp",
+      formatTemperature(left.metadata?.nozzle_temperature_c),
+      formatTemperature(right.metadata?.nozzle_temperature_c),
+    ],
+    [
+      "Bed temp",
+      formatTemperature(left.metadata?.bed_temperature_c),
+      formatTemperature(right.metadata?.bed_temperature_c),
     ],
     ["Material", left.metadata?.material_type ?? "—", right.metadata?.material_type ?? "—"],
+    ["Filament profile", left.metadata?.material_brand ?? "—", right.metadata?.material_brand ?? "—"],
     [
       "Filament",
-      left.metadata?.filament_weight_g ? `${left.metadata.filament_weight_g}g` : "—",
-      right.metadata?.filament_weight_g ? `${right.metadata.filament_weight_g}g` : "—",
+      formatGrams(left.metadata?.filament_weight_g),
+      formatGrams(right.metadata?.filament_weight_g),
+    ],
+    [
+      "Filament cost",
+      formatCost(left.metadata?.filament_cost),
+      formatCost(right.metadata?.filament_cost),
     ],
     [
       "Est. time",

--- a/frontend/src/components/settings-panel.tsx
+++ b/frontend/src/components/settings-panel.tsx
@@ -1,9 +1,20 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Server, Database, HardDrive, Tag, Folder, User, Download } from "lucide-react";
+import {
+  Database,
+  DollarSign,
+  Download,
+  Folder,
+  HardDrive,
+  KeyRound,
+  Server,
+  Tag,
+  User,
+} from "lucide-react";
 import { TaxonomyManager } from "@/components/taxonomy-manager";
 import { ApiKeyCard } from "@/components/api-key-card";
+import { FilamentProfilesCard } from "@/components/filament-profiles-card";
 import { StorageConfigCard } from "@/components/storage-config-card";
 import { downloadModelExport } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
@@ -15,8 +26,23 @@ interface HealthResponse {
   version: string;
 }
 
+type SettingsSection = "overview" | "access" | "storage" | "filaments" | "organize";
+
+const SETTINGS_SECTIONS: {
+  id: SettingsSection;
+  label: string;
+  icon: typeof Server;
+}[] = [
+  { id: "overview", label: "Overview", icon: Server },
+  { id: "access", label: "Access", icon: KeyRound },
+  { id: "storage", label: "Storage", icon: HardDrive },
+  { id: "filaments", label: "Filaments", icon: DollarSign },
+  { id: "organize", label: "Organize", icon: Folder },
+];
+
 export function SettingsPanel() {
   const { user } = useAuth();
+  const [activeSection, setActiveSection] = useState<SettingsSection>("overview");
   const [health, setHealth] = useState<HealthResponse | null>(null);
   const [categoryCount, setCategoryCount] = useState<number | null>(null);
   const [tagCount, setTagCount] = useState<number | null>(null);
@@ -60,9 +86,32 @@ export function SettingsPanel() {
     <div className="w-full space-y-4 sm:space-y-6 lg:space-y-8">
       <h2 className="text-xl font-semibold text-[var(--on-surface)]">Settings</h2>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4 sm:gap-6 lg:gap-8">
-        {/* Left column — read-only system info */}
-        <div className="md:col-span-1 lg:col-span-2 space-y-4 sm:space-y-6 lg:space-y-8">
+      <div className="bg-[var(--surface-container-lowest)] border border-[var(--outline-variant)] rounded overflow-hidden">
+        <div className="flex flex-wrap gap-1 p-1">
+          {SETTINGS_SECTIONS.map((section) => {
+            const Icon = section.icon;
+            const active = activeSection === section.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => setActiveSection(section.id)}
+                className={`inline-flex items-center gap-2 rounded px-3 py-2 font-mono text-xs uppercase tracking-wider transition-colors ${
+                  active
+                    ? "bg-[var(--secondary-container)] text-[var(--on-secondary-container)]"
+                    : "text-[var(--on-surface-variant)] hover:bg-[var(--surface-container-low)]"
+                }`}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {section.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {activeSection === "overview" && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 lg:gap-8">
           {user && (
             <div className="bg-[var(--surface-container-lowest)] border border-[var(--outline-variant)] rounded overflow-hidden">
               <div className="px-4 sm:px-6 lg:px-8 py-4 sm:py-5 border-b border-[var(--outline-variant)] flex items-center gap-2 sm:gap-3">
@@ -158,14 +207,31 @@ export function SettingsPanel() {
             </div>
           </div>
         </div>
+      )}
 
-        {/* Right column — active configuration */}
-        <div className="md:col-span-1 lg:col-span-3 space-y-4 sm:space-y-6 lg:space-y-8">
+      {activeSection === "access" && (
+        <div className="max-w-3xl">
           <ApiKeyCard />
+        </div>
+      )}
+
+      {activeSection === "storage" && (
+        <div className="max-w-3xl">
           <StorageConfigCard />
+        </div>
+      )}
+
+      {activeSection === "filaments" && (
+        <div className="max-w-5xl">
+          <FilamentProfilesCard />
+        </div>
+      )}
+
+      {activeSection === "organize" && (
+        <div className="max-w-5xl">
           <TaxonomyManager />
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/api/filaments.ts
+++ b/frontend/src/lib/api/filaments.ts
@@ -1,0 +1,39 @@
+import { getJson, sendAction, sendJson } from "@/lib/api/request";
+import {
+  FilamentProfileCreate,
+  FilamentProfileRead,
+  FilamentProfileUpdate,
+} from "@/types";
+
+export function listFilamentProfiles(): Promise<FilamentProfileRead[]> {
+  return getJson<FilamentProfileRead[]>("/api/v1/filament-profiles");
+}
+
+export function createFilamentProfile(
+  payload: FilamentProfileCreate,
+  apiKey?: string,
+): Promise<FilamentProfileRead> {
+  return sendJson<FilamentProfileRead>(
+    "/api/v1/filament-profiles",
+    "POST",
+    payload,
+    apiKey,
+  );
+}
+
+export function updateFilamentProfile(
+  id: number,
+  payload: FilamentProfileUpdate,
+  apiKey?: string,
+): Promise<FilamentProfileRead> {
+  return sendJson<FilamentProfileRead>(
+    `/api/v1/filament-profiles/${id}`,
+    "PATCH",
+    payload,
+    apiKey,
+  );
+}
+
+export function deleteFilamentProfile(id: number, apiKey?: string): Promise<void> {
+  return sendAction(`/api/v1/filament-profiles/${id}`, "DELETE", apiKey);
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -1,6 +1,7 @@
 export { getAssetUrl, getUrl, getWsUrl } from "@/lib/api/request";
 export * from "@/lib/api/auth";
 export * from "@/lib/api/config";
+export * from "@/lib/api/filaments";
 export * from "@/lib/api/models";
 export * from "@/lib/api/printers";
 export * from "@/lib/api/taxonomy";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -15,6 +15,9 @@ export type {
   TagCreate,
   CategoryRead,
   TagRead,
+  FilamentProfileRead,
+  FilamentProfileCreate,
+  FilamentProfileUpdate,
 } from "./models";
 
 export type {

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -4,7 +4,14 @@ export interface MetadataRead {
   printer_model: string | null;
   nozzle_diameter_mm: number | null;
   layer_height_mm: number | null;
+  first_layer_height_mm: number | null;
   infill_percent: number | null;
+  wall_loops: number | null;
+  top_shell_layers: number | null;
+  bottom_shell_layers: number | null;
+  support_material: boolean | null;
+  nozzle_temperature_c: number | null;
+  bed_temperature_c: number | null;
   estimated_time_s: number | null;
   filament_weight_g: number | null;
   filament_length_mm: number | null;
@@ -141,6 +148,33 @@ export interface CategoryRead {
   path: string;
   parent_id: number | null;
   model_count: number;
+}
+
+export interface FilamentProfileRead {
+  id: number;
+  name: string;
+  material_type: string | null;
+  material_brand: string | null;
+  cost_per_kg: number | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface FilamentProfileCreate {
+  name: string;
+  material_type?: string | null;
+  material_brand?: string | null;
+  cost_per_kg?: number | null;
+  notes?: string | null;
+}
+
+export interface FilamentProfileUpdate {
+  name?: string;
+  material_type?: string | null;
+  material_brand?: string | null;
+  cost_per_kg?: number | null;
+  notes?: string | null;
 }
 
 export interface TagRead {

--- a/frontend/tests/e2e/mock-api.ts
+++ b/frontend/tests/e2e/mock-api.ts
@@ -8,13 +8,20 @@ const metadata = {
   printer_model: "Creality Ender-3 V3 SE",
   nozzle_diameter_mm: 0.4,
   layer_height_mm: 0.2,
+  first_layer_height_mm: 0.24,
   infill_percent: 15,
+  wall_loops: 3,
+  top_shell_layers: 4,
+  bottom_shell_layers: 3,
+  support_material: false,
+  nozzle_temperature_c: 215,
+  bed_temperature_c: 60,
   estimated_time_s: 1812,
   filament_weight_g: 6.8,
-  filament_length_mm: null,
+  filament_length_mm: 2280,
   filament_cost: 0.14,
   material_type: "PLA",
-  material_brand: null,
+  material_brand: "Generic PLA",
   bbox_x_mm: null,
   bbox_y_mm: null,
   bbox_z_mm: null,
@@ -99,6 +106,19 @@ const printer = {
   created_at: "2026-05-31T18:51:39.627384",
   updated_at: now,
 };
+
+const filamentProfiles = [
+  {
+    id: 1,
+    name: "Generic PLA",
+    material_type: "PLA",
+    material_brand: "Generic",
+    cost_per_kg: 21,
+    notes: null,
+    created_at: now,
+    updated_at: now,
+  },
+];
 
 const printerDiagnostics = {
   printer_id: printer.id,
@@ -193,6 +213,11 @@ function sendPng(res: ServerResponse): void {
   res.end(pixel);
 }
 
+function drainRequest(req: IncomingMessage, done: () => void): void {
+  req.resume();
+  req.on("end", done);
+}
+
 function handle(req: IncomingMessage, res: ServerResponse): void {
   const url = new URL(req.url ?? "/", "http://127.0.0.1");
   if (req.method === "OPTIONS") {
@@ -207,6 +232,24 @@ function handle(req: IncomingMessage, res: ServerResponse): void {
 
   if (url.pathname === "/api/v1/setup/status") {
     sendJson(res, { configured: true, has_users: true });
+    return;
+  }
+  if (url.pathname === "/api/v1/auth/me") {
+    sendJson(res, {
+      id: 1,
+      username: "tester",
+      email: null,
+      is_superuser: true,
+      created_at: now,
+    });
+    return;
+  }
+  if (url.pathname === "/api/v1/categories") {
+    sendJson(res, []);
+    return;
+  }
+  if (url.pathname === "/api/v1/tags") {
+    sendJson(res, []);
     return;
   }
   if (url.pathname === "/api/v1/models") {
@@ -229,6 +272,10 @@ function handle(req: IncomingMessage, res: ServerResponse): void {
         missing_since: null,
       },
     ]);
+    return;
+  }
+  if (url.pathname === "/api/v1/filament-profiles") {
+    sendJson(res, filamentProfiles);
     return;
   }
   if (url.pathname === "/api/v1/printers") {
@@ -269,6 +316,24 @@ function handle(req: IncomingMessage, res: ServerResponse): void {
         updated_at: now,
       },
     ]);
+    return;
+  }
+  if (req.method === "POST" && url.pathname === "/api/v1/ingest/orca") {
+    drainRequest(req, () => {
+      sendJson(res, { job_id: "gcode-job-1", state: "pending", message: "ingestion queued" }, 202);
+    });
+    return;
+  }
+  if (url.pathname === "/api/v1/ingest/jobs/gcode-job-1") {
+    sendJson(res, {
+      job_id: "gcode-job-1",
+      state: "completed",
+      model_id: model.id,
+      file_id: 2,
+      error: null,
+      started_at: now,
+      finished_at: now,
+    });
     return;
   }
   if (url.pathname === "/api/v1/files/1/thumbnail") {


### PR DESCRIPTION
## Summary
- Add richer G-code print metadata extraction and API fields for first layer, shells, supports, temperatures, and filament preset data.
- Add local filament preset management with cost/kg and per-piece cost estimation when slicer cost is missing.
- Split Settings into focused sections so unrelated configuration no longer appears on one long page.

## Validation
- `uv run pytest tests/test_gcode_parser.py tests/test_filament_profiles.py tests/test_migrations.py`
- `PATH=/home/local/.nvm/versions/node/v24.14.0/bin:$PATH pnpm exec tsc --noEmit`
- `PATH=/home/local/.nvm/versions/node/v24.14.0/bin:$PATH pnpm lint` (existing warnings only)