### PR TITLE
Redesign PrintStash logo as bold P + extruder mark

### DIFF
--- a/frontend/public/icon-dark.svg
+++ b/frontend/public/icon-dark.svg
@@ -1,5 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <rect width="32" height="32" rx="7" fill="#ea580c"/>
-  <path d="M9.3 24.1 L9.3 22.2 A2.2 2.2 0 1 1 11.5 20 L11.5 7 H15.5 A4.6 4.6 0 0 1 15.5 16.2 H11.5" fill="none" stroke="#fff" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="9.3" cy="24.1" r="1.7" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="268 118 426 426" width="32" height="32" fill="none" role="img" aria-label="PrintStash">
+  <defs>
+    <linearGradient id="ps-icon-dark" x1="272" y1="118" x2="690" y2="544" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#fb923c"/>
+      <stop offset="1" stop-color="#ea580c"/>
+    </linearGradient>
+  </defs>
+  <rect x="272" y="118" width="418" height="426" rx="69" fill="url(#ps-icon-dark)"/>
+  <g stroke="#fff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M397 350 V165 H485 A80 80 0 0 1 485 325 H397" stroke-width="56"/>
+    <path d="M397 450 C397 470 381 480 363 480 C345 480 335 490 335 502 C335 514 347 520 361 520 H492" stroke-width="30"/>
+  </g>
+  <rect x="335" y="330" width="124" height="48" rx="14" fill="#fff"/>
+  <rect x="375" y="382" width="44" height="22" rx="6" fill="#fff"/>
+  <path d="M367 404 H427 L409 432 L397 442 L385 432 Z" fill="#fff"/>
 </svg>

--- a/frontend/public/icon-light.svg
+++ b/frontend/public/icon-light.svg
@@ -1,5 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <rect width="32" height="32" rx="7" fill="#2563eb"/>
-  <path d="M9.3 24.1 L9.3 22.2 A2.2 2.2 0 1 1 11.5 20 L11.5 7 H15.5 A4.6 4.6 0 0 1 15.5 16.2 H11.5" fill="none" stroke="#fff" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round"/>
-  <circle cx="9.3" cy="24.1" r="1.7" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="268 118 426 426" width="32" height="32" fill="none" role="img" aria-label="PrintStash">
+  <defs>
+    <linearGradient id="ps-icon-light" x1="272" y1="118" x2="690" y2="544" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2767FF"/>
+      <stop offset="1" stop-color="#0E48F0"/>
+    </linearGradient>
+  </defs>
+  <rect x="272" y="118" width="418" height="426" rx="69" fill="url(#ps-icon-light)"/>
+  <g stroke="#fff" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M397 350 V165 H485 A80 80 0 0 1 485 325 H397" stroke-width="56"/>
+    <path d="M397 450 C397 470 381 480 363 480 C345 480 335 490 335 502 C335 514 347 520 361 520 H492" stroke-width="30"/>
+  </g>
+  <rect x="335" y="330" width="124" height="48" rx="14" fill="#fff"/>
+  <rect x="375" y="382" width="44" height="22" rx="6" fill="#fff"/>
+  <path d="M367 404 H427 L409 432 L397 442 L385 432 Z" fill="#fff"/>
 </svg>

--- a/frontend/public/logo-dark.svg
+++ b/frontend/public/logo-dark.svg
@@ -1,11 +1,38 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 128" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="683" viewBox="0 0 2048 683" fill="none" role="img" aria-labelledby="title desc">
   <title id="title">PrintStash</title>
-  <desc id="desc">PrintStash logo: an extruded-filament "P" monogram wordmark.</desc>
-  <rect x="2" y="2" width="124" height="124" rx="28" fill="#2563eb"/>
-  <g transform="translate(2 2) scale(3.875)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M9.3 24.1 L9.3 22.2 A2.2 2.2 0 1 1 11.5 20 L11.5 7 H15.5 A4.6 4.6 0 0 1 15.5 16.2 H11.5" stroke-width="2.3"/>
-    <circle cx="9.3" cy="24.1" r="1.7" fill="#fff" stroke="none"/>
+  <desc id="desc">PrintStash logo: a "P" monogram drawn as a 3D-printer extruder laying a filament bead, beside the wordmark.</desc>
+  <defs>
+    <linearGradient id="ps-bg" x1="0" y1="0" x2="2048" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#020A17"/>
+      <stop offset="0.5" stop-color="#04142D"/>
+      <stop offset="1" stop-color="#020A17"/>
+    </linearGradient>
+    <linearGradient id="ps-icon" x1="272" y1="118" x2="690" y2="544" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2767FF"/>
+      <stop offset="1" stop-color="#0E48F0"/>
+    </linearGradient>
+    <filter id="ps-shadow" x="0" y="0" width="100%" height="100%">
+      <feDropShadow dx="0" dy="10" stdDeviation="20" flood-color="#000814" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <rect width="2048" height="683" fill="url(#ps-bg)"/>
+
+  <!-- Icon tile -->
+  <rect x="272" y="118" width="418" height="426" rx="69" fill="url(#ps-icon)" filter="url(#ps-shadow)"/>
+
+  <!-- Stylized P + extruder mark -->
+  <g stroke="white" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M397 350 V165 H485 A80 80 0 0 1 485 325 H397" stroke-width="56"/>
+    <path d="M397 450 C397 470 381 480 363 480 C345 480 335 490 335 502 C335 514 347 520 361 520 H492" stroke-width="30"/>
   </g>
-  <text x="154" y="76" fill="#f1f5f9" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="46" font-weight="800" letter-spacing="0">PrintStash</text>
-  <text x="156" y="101" fill="#93a4bd" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Consolas, monospace" font-size="14" font-weight="600" letter-spacing="1.4">SELF-HOSTED 3D PRINT VAULT</text>
+  <rect x="335" y="330" width="124" height="48" rx="14" fill="white"/>
+  <rect x="375" y="382" width="44" height="22" rx="6" fill="white"/>
+  <path d="M367 404 H427 L409 432 L397 442 L385 432 Z" fill="white"/>
+
+  <!-- Wordmark -->
+  <text x="770" y="378" fill="white" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="170" font-weight="800" letter-spacing="-4">PrintStash</text>
+
+  <!-- Tagline -->
+  <text x="775" y="456" fill="#A9BFE5" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="52" font-weight="700" letter-spacing="10">SELF-HOSTED 3D PRINT VAULT</text>
 </svg>

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,11 +1,38 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 128" role="img" aria-labelledby="title desc">
+<svg xmlns="http://www.w3.org/2000/svg" width="2048" height="683" viewBox="0 0 2048 683" fill="none" role="img" aria-labelledby="title desc">
   <title id="title">PrintStash</title>
-  <desc id="desc">PrintStash logo: an extruded-filament "P" monogram wordmark.</desc>
-  <rect x="2" y="2" width="124" height="124" rx="28" fill="#2563eb"/>
-  <g transform="translate(2 2) scale(3.875)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M9.3 24.1 L9.3 22.2 A2.2 2.2 0 1 1 11.5 20 L11.5 7 H15.5 A4.6 4.6 0 0 1 15.5 16.2 H11.5" stroke-width="2.3"/>
-    <circle cx="9.3" cy="24.1" r="1.7" fill="#fff" stroke="none"/>
+  <desc id="desc">PrintStash logo: a "P" monogram drawn as a 3D-printer extruder laying a filament bead, beside the wordmark.</desc>
+  <defs>
+    <linearGradient id="ps-bg" x1="0" y1="0" x2="2048" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#020A17"/>
+      <stop offset="0.5" stop-color="#04142D"/>
+      <stop offset="1" stop-color="#020A17"/>
+    </linearGradient>
+    <linearGradient id="ps-icon" x1="272" y1="118" x2="690" y2="544" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2767FF"/>
+      <stop offset="1" stop-color="#0E48F0"/>
+    </linearGradient>
+    <filter id="ps-shadow" x="0" y="0" width="100%" height="100%">
+      <feDropShadow dx="0" dy="10" stdDeviation="20" flood-color="#000814" flood-opacity="0.25"/>
+    </filter>
+  </defs>
+
+  <rect width="2048" height="683" fill="url(#ps-bg)"/>
+
+  <!-- Icon tile -->
+  <rect x="272" y="118" width="418" height="426" rx="69" fill="url(#ps-icon)" filter="url(#ps-shadow)"/>
+
+  <!-- Stylized P + extruder mark -->
+  <g stroke="white" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M397 350 V165 H485 A80 80 0 0 1 485 325 H397" stroke-width="56"/>
+    <path d="M397 450 C397 470 381 480 363 480 C345 480 335 490 335 502 C335 514 347 520 361 520 H492" stroke-width="30"/>
   </g>
-  <text x="154" y="76" fill="#0f172a" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="46" font-weight="800" letter-spacing="0">PrintStash</text>
-  <text x="156" y="101" fill="#475569" font-family="'JetBrains Mono', ui-monospace, SFMono-Regular, Consolas, monospace" font-size="14" font-weight="600" letter-spacing="1.4">SELF-HOSTED 3D PRINT VAULT</text>
+  <rect x="335" y="330" width="124" height="48" rx="14" fill="white"/>
+  <rect x="375" y="382" width="44" height="22" rx="6" fill="white"/>
+  <path d="M367 404 H427 L409 432 L397 442 L385 432 Z" fill="white"/>
+
+  <!-- Wordmark -->
+  <text x="770" y="378" fill="white" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="170" font-weight="800" letter-spacing="-4">PrintStash</text>
+
+  <!-- Tagline -->
+  <text x="775" y="456" fill="#A9BFE5" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="52" font-weight="700" letter-spacing="10">SELF-HOSTED 3D PRINT VAULT</text>
 </svg>


### PR DESCRIPTION
Redraw the icon and wordmark so the P reads as a solid bold letterform (thick stroked stem + rounded bowl) with a centered extruder carriage, nozzle, and filament curl, on a brighter blue gradient tile. Replaces the previous hollow stroked-outline mark. Updates icon-light/dark.svg and logo/logo-dark.svg.

## Summary

- 

## Testing

- [ ] Backend tests added/updated, or not needed
- [ ] Frontend checks run, or not needed
- [ ] Manual test notes included, or not needed

## Notes

Mention any schema, API, storage, or printer-provider behavior changes.
