### PR TITLE
test: cover backup download restore round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.6.4 - Backup restore and download
+
+### Added
+
+- **Restore from the UI.** Settings -> Storage now lists available backups and
+  lets an admin restore one with a destructive confirmation step.
+- **Download backups to your computer.** Each listed backup has a Download
+  action, and admins can also fetch an archive from
+  `/api/v1/backups/{id}/download`.
+
 ## 0.6.3 - Reliability & correctness hardening
 
 A maintenance release focused on edge-case correctness across importing,

--- a/backend/app/api/v1/backup.py
+++ b/backend/app/api/v1/backup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi.responses import FileResponse
 
 from app.core.logging import get_logger
 from app.core.security import require_superuser
@@ -80,6 +81,26 @@ def get_backup(backup_id: str) -> dict:
         "app_version": meta.app_version,
         "location": meta.location,
     }
+
+
+@router.get(
+    "/{backup_id}/download",
+    dependencies=[Depends(require_superuser)],
+    summary="Download a backup archive",
+)
+def download_backup(backup_id: str) -> FileResponse:
+    try:
+        archive_path = backup.get_backup_archive_path(backup_id)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="backup_not_found")
+    except Exception as exc:
+        logger.exception("backup %s download failed", backup_id)
+        raise HTTPException(status_code=500, detail=str(exc))
+    return FileResponse(
+        archive_path,
+        media_type="application/gzip",
+        filename=archive_path.name,
+    )
 
 
 @router.delete(

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
     backup_s3_secret_key: str = ""
 
     app_name: str = "PrintStash"
-    app_version: str = "0.6.3"
+    app_version: str = "0.6.4"
 
     @property
     def incoming_dir(self) -> Path:

--- a/backend/app/services/backup.py
+++ b/backend/app/services/backup.py
@@ -392,6 +392,14 @@ def get_backup(backup_id: str) -> BackupMeta | None:
     return None
 
 
+def get_backup_archive_path(backup_id: str) -> Path:
+    """Return a local archive path, downloading cloud-only backups first."""
+    meta = get_backup(backup_id)
+    if meta is None:
+        raise FileNotFoundError(f"backup {backup_id} not found")
+    return _download_backup_to_local(meta)
+
+
 # ---------------------------------------------------------------------------
 # Delete
 # ---------------------------------------------------------------------------

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printstash"
-version = "0.6.3"
+version = "0.6.4"
 description = "PrintStash — self-hosted 3D printing asset manager"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_backup_restore.py
+++ b/backend/tests/test_backup_restore.py
@@ -260,6 +260,42 @@ def test_restore_recovers_blob_bytes(backup_env: BackupEnv):
     assert Path(key).read_bytes() == content
 
 
+def test_download_then_restore_endpoint_round_trip(
+    client: TestClient, backup_env: BackupEnv
+):
+    content = b"solid endpoint widget\nendsolid\n"
+    _model_id, key = _seed_model_with_blob(
+        backup_env, name="Endpoint Widget", content=content
+    )
+    headers = _auth_headers(backup_env)
+
+    create = client.post("/api/v1/backups", headers=headers)
+    assert create.status_code == 202, create.text
+    backup_id = create.json()["backup_id"]
+
+    download = client.get(f"/api/v1/backups/{backup_id}/download", headers=headers)
+    assert download.status_code == 200, download.text
+    assert download.content.startswith(b"\x1f\x8b")
+    assert f"{backup_id}.tar.gz" in download.headers["content-disposition"]
+
+    # Disaster: remove both catalog row and stored bytes, then restore via API.
+    with backup_env.new_session() as session:
+        for m in session.exec(select(Model).where(Model.name == "Endpoint Widget")):
+            session.delete(m)
+        session.commit()
+    Path(key).unlink()
+
+    assert "Endpoint Widget" not in _read_model_names(backup_env)
+    assert not Path(key).exists()
+
+    restore = client.post(f"/api/v1/backups/{backup_id}/restore", headers=headers)
+    assert restore.status_code == 200, restore.text
+    assert restore.json() == {"backup_id": backup_id, "restored_files": 1}
+
+    assert "Endpoint Widget" in _read_model_names(backup_env)
+    assert Path(key).read_bytes() == content
+
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_backup_restore.py
+++ b/backend/tests/test_backup_restore.py
@@ -18,13 +18,15 @@ from pathlib import Path
 from typing import Iterator
 
 import pytest
+from fastapi.testclient import TestClient
 from sqlmodel import Session, SQLModel, create_engine, select
 
 import app.services.backup as backup
 import app.services.storage_backend as storage_backend
 from app.core.config import _overlay
-from app.db.models import File, FileType, Model
+from app.db.models import File, FileType, Model, User
 from app.db.session import SQLiteSessionFactory, override_session_factory
+from app.services.auth import create_access_token, hash_password
 from app.services.storage_backend import get_backend
 
 
@@ -128,6 +130,21 @@ def _read_model_names(env: BackupEnv) -> list[str]:
         eng.dispose()
 
 
+def _auth_headers(env: BackupEnv) -> dict[str, str]:
+    with env.new_session() as session:
+        user = User(
+            username="backup-admin",
+            hashed_password=hash_password("Password123"),
+            is_active=True,
+            is_superuser=True,
+        )
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+        token = create_access_token(user.id, user.username, scope="admin")
+    return {"Authorization": f"Bearer {token}"}
+
+
 # ---------------------------------------------------------------------------
 # Create
 # ---------------------------------------------------------------------------
@@ -187,6 +204,20 @@ def test_backup_appears_in_list_and_get(backup_env: BackupEnv):
     assert fetched is not None
     assert fetched.id == meta.id
     assert fetched.file_count == 1
+
+
+def test_download_backup_archive_endpoint(client: TestClient, backup_env: BackupEnv):
+    _seed_model_with_blob(backup_env, name="Widget", content=b"x")
+    meta = backup.create_backup()
+
+    resp = client.get(
+        f"/api/v1/backups/{meta.id}/download",
+        headers=_auth_headers(backup_env),
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.content.startswith(b"\x1f\x8b")
+    assert Path(meta.path).name in resp.headers["content-disposition"]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "printstash"
-version = "0.6.2"
+version = "0.6.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docs/wiki/src/content/docs/guides/backup-and-restore.md
+++ b/docs/wiki/src/content/docs/guides/backup-and-restore.md
@@ -29,8 +29,8 @@ shipped nightly to R2.
 
 Always take a fresh one before anything risky — upgrades especially.
 
-From the UI: **Settings → Storage**, review the backup destination, and trigger a
-full backup.
+From the UI: **Settings -> Storage**, review the backup destination, trigger a
+full backup, or download an existing archive to your computer.
 
 From the API:
 
@@ -40,6 +40,13 @@ curl -X POST \
   http://localhost:8000/api/v1/backups
 ```
 
+```bash
+curl -L \
+  -H "Authorization: Bearer <admin-token>" \
+  -o printstash-backup.tar.gz \
+  http://localhost:8000/api/v1/backups/<backup-id>/download
+```
+
 Old archives are pruned according to `VAULT_BACKUP_RETENTION_DAYS` (default 30;
 set `0` to keep them forever).
 
@@ -47,6 +54,15 @@ set `0` to keep them forever).
 
 Restoring **replaces** the current database and files with the contents of an
 archive, so treat it as a deliberate operation:
+
+1. Stop slicer hooks and any automation that uploads files, so nothing arrives
+   mid-restore.
+2. Open **Settings -> Storage**, refresh the backup list, and restore the
+   archive you want to recover.
+3. Restart the full stack.
+4. Run the smoke checks below.
+
+For API-only recovery:
 
 1. Stop slicer hooks and any automation that uploads files, so nothing arrives
    mid-restore.

--- a/docs/wiki/src/content/docs/reference/api.md
+++ b/docs/wiki/src/content/docs/reference/api.md
@@ -69,6 +69,7 @@ password, which is exactly why the Orca hook uses one.
 | `GET`  | `/api/v1/filament-profiles`         | List filament presets.                   |
 | `GET`  | `/api/v1/printer-profiles`          | List printer presets.                    |
 | `POST` | `/api/v1/backups`                   | Create a full backup (admin).            |
+| `GET`  | `/api/v1/backups/{id}/download`     | Download a backup archive (admin).       |
 | `GET`  | `/api/v1/admin/users`               | User administration (superuser).         |
 
 ## Health check

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "printstash-frontend",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/settings-panel.tsx
+++ b/frontend/src/components/settings-panel.tsx
@@ -40,8 +40,10 @@ import {
   createBackup,
   deactivateAdminUser,
   deleteCollectionPermission,
+  downloadBackup,
   downloadModelExport,
   getVaultConfig,
+  listBackups,
   listCollectionPermissions,
   listCollections,
   listApiKeys,
@@ -50,12 +52,14 @@ import {
   purgeExpiredTrash,
   purgeModel,
   resetAdminUserPassword,
+  restoreBackup,
   restoreModel,
   revokeApiKey,
   updateCollectionPermission,
   updateAdminUser,
   updateVaultConfig,
 } from "@/lib/api";
+import type { BackupMeta } from "@/lib/api";
 import { useAuth } from "@/lib/auth-context";
 import { useVaultStats } from "@/lib/queries";
 import {
@@ -219,6 +223,11 @@ export function SettingsPanel() {
   const [currencyBusy, setCurrencyBusy] = useState(false);
   const [purgeTarget, setPurgeTarget] = useState<number | null>(null);
   const [backingUp, setBackingUp] = useState(false);
+  const [backups, setBackups] = useState<BackupMeta[]>([]);
+  const [backupsLoading, setBackupsLoading] = useState(false);
+  const [restoreTarget, setRestoreTarget] = useState<BackupMeta | null>(null);
+  const [restoringBackup, setRestoringBackup] = useState(false);
+  const [downloadingBackup, setDownloadingBackup] = useState<string | null>(null);
   const [metadataPrefs, setMetadataPrefs] = useState<MetadataPreferences>(
     DEFAULT_METADATA_PREFERENCES,
   );
@@ -293,6 +302,27 @@ export function SettingsPanel() {
     }
   }, [activeSection, loadTrash]);
 
+  const loadBackups = useCallback(async () => {
+    if (!user?.is_superuser) {
+      setBackups([]);
+      return;
+    }
+    setBackupsLoading(true);
+    try {
+      setBackups(await listBackups());
+    } catch (e) {
+      toast.error(e);
+    } finally {
+      setBackupsLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (activeSection === "storage") {
+      loadBackups();
+    }
+  }, [activeSection, loadBackups]);
+
   useEffect(() => {
     if (activeSection !== "design" || !user) return;
     let cancelled = false;
@@ -345,11 +375,43 @@ export function SettingsPanel() {
     try {
       const meta = await createBackup();
       const mb = (meta.size_bytes / 1024 / 1024).toFixed(1);
+      setBackups((current) => [
+        meta,
+        ...current.filter((item) => item.backup_id !== meta.backup_id),
+      ]);
       toast.success(`Backup created — ${meta.file_count} files, ${mb} MB`);
     } catch (e) {
       toast.error(e);
     } finally {
       setBackingUp(false);
+    }
+  }
+
+  async function confirmRestoreBackup() {
+    if (!restoreTarget) return;
+    const target = restoreTarget;
+    setRestoringBackup(true);
+    try {
+      const result = await restoreBackup(target.backup_id);
+      toast.success(`Backup restored — ${result.restored_files} files`);
+      setRestoreTarget(null);
+      window.setTimeout(() => window.location.reload(), 800);
+    } catch (e) {
+      toast.error(e);
+    } finally {
+      setRestoringBackup(false);
+    }
+  }
+
+  async function handleDownloadBackup(backupId: string) {
+    setDownloadingBackup(backupId);
+    try {
+      await downloadBackup(backupId);
+      toast.success("Backup download started.");
+    } catch (e) {
+      toast.error(e);
+    } finally {
+      setDownloadingBackup(null);
     }
   }
 
@@ -654,6 +716,15 @@ export function SettingsPanel() {
         title="Permanently delete?"
         description="This will delete the model and all its files immediately. This cannot be undone."
         confirmLabel="Delete forever"
+      />
+      <ConfirmModal
+        open={restoreTarget !== null}
+        onClose={() => setRestoreTarget(null)}
+        onConfirm={confirmRestoreBackup}
+        busy={restoringBackup}
+        title="Restore backup?"
+        description="This replaces the current database and stored files with the selected backup."
+        confirmLabel="Restore"
       />
 
       <div>
@@ -1139,7 +1210,7 @@ export function SettingsPanel() {
               <button
                 type="button"
                 onClick={handleBackupNow}
-                disabled={backingUp}
+                disabled={!user?.is_superuser || backingUp}
                 className={BTN_PRIMARY}
               >
                 {backingUp ? (
@@ -1150,6 +1221,97 @@ export function SettingsPanel() {
               </button>
             }
           />
+          <SettingsCard
+            icon={RotateCcw}
+            title="Restore backup"
+            description="Recover the vault database and stored files from a previous backup."
+            action={
+              <button
+                type="button"
+                onClick={loadBackups}
+                disabled={!user?.is_superuser || backupsLoading}
+                className={BTN_ICON}
+                title="Refresh backups"
+              >
+                <RefreshCw className={`h-4 w-4 ${backupsLoading ? "animate-spin" : ""}`} />
+              </button>
+            }
+          >
+            <div className="divide-y divide-border">
+              {!user?.is_superuser ? (
+                <p className="p-4 sm:p-5 text-sm text-muted-foreground">
+                  Superuser access is required.
+                </p>
+              ) : backupsLoading ? (
+                <p className="p-4 sm:p-5 text-sm text-muted-foreground">
+                  Loading...
+                </p>
+              ) : backups.length === 0 ? (
+                <p className="p-4 sm:p-5 text-sm text-muted-foreground">
+                  No backups found.
+                </p>
+              ) : (
+                backups.map((backup) => (
+                  <div
+                    key={backup.backup_id}
+                    className="grid gap-3 p-4 sm:p-5 lg:grid-cols-[1fr_auto] lg:items-center"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-sm font-medium text-foreground">
+                          {formatDate(backup.created_at)}
+                        </p>
+                        <span className="font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border border-border text-muted-foreground">
+                          {backup.location}
+                        </span>
+                        <span className="font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border border-border text-muted-foreground">
+                          v{backup.app_version}
+                        </span>
+                      </div>
+                      <p className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
+                        {backup.backup_id}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {backup.file_count} files · {formatBytes(backup.size_bytes)} · {backup.storage_backend}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap gap-2 lg:justify-end">
+                      <button
+                        type="button"
+                        onClick={() => handleDownloadBackup(backup.backup_id)}
+                        disabled={
+                          downloadingBackup !== null ||
+                          restoringBackup ||
+                          backingUp
+                        }
+                        className={BTN_SECONDARY}
+                      >
+                        {downloadingBackup === backup.backup_id ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <Download className="h-3.5 w-3.5" />
+                        )}
+                        Download
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setRestoreTarget(backup)}
+                        disabled={
+                          downloadingBackup !== null ||
+                          restoringBackup ||
+                          backingUp
+                        }
+                        className="inline-flex items-center gap-1.5 px-3 py-2 rounded border border-red-500/30 text-red-500 hover:bg-red-500/10 transition-colors text-xs font-medium uppercase tracking-wider disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        <RotateCcw className="h-3.5 w-3.5" />
+                        Restore
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </SettingsCard>
         </div>
       )}
 

--- a/frontend/src/lib/api/backup.ts
+++ b/frontend/src/lib/api/backup.ts
@@ -1,4 +1,10 @@
-import { getJson, sendJson } from "@/lib/api/request";
+import {
+  authHeaders,
+  expectOk,
+  getJson,
+  getUrl,
+  sendJson,
+} from "@/lib/api/request";
 
 export interface BackupMeta {
   backup_id: string;
@@ -10,10 +16,47 @@ export interface BackupMeta {
   location: string;
 }
 
+export interface BackupRestoreResult {
+  backup_id: string;
+  restored_files: number;
+}
+
 export function createBackup(): Promise<BackupMeta> {
   return sendJson<BackupMeta>("/api/v1/backups", "POST", undefined);
 }
 
 export function listBackups(): Promise<BackupMeta[]> {
   return getJson<BackupMeta[]>("/api/v1/backups");
+}
+
+export function restoreBackup(backupId: string): Promise<BackupRestoreResult> {
+  return sendJson<BackupRestoreResult>(
+    `/api/v1/backups/${encodeURIComponent(backupId)}/restore`,
+    "POST",
+    {},
+  );
+}
+
+export async function downloadBackup(backupId: string): Promise<void> {
+  const res = await fetch(
+    getUrl(`/api/v1/backups/${encodeURIComponent(backupId)}/download`),
+    {
+      headers: authHeaders(),
+      cache: "no-store",
+    },
+  );
+  await expectOk(res);
+  const blob = await res.blob();
+  const disposition = res.headers.get("content-disposition") ?? "";
+  const filename =
+    disposition.match(/filename="([^"]+)"/)?.[1] ??
+    `printstash-backup-${backupId}.tar.gz`;
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
 }

--- a/frontend/src/lib/changelog.ts
+++ b/frontend/src/lib/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.4",
+    date: "Jun 2026",
+    changes: [
+      "Settings -> Storage now lists available backups with one-click download to your computer",
+      "Backups can be restored from the UI with a destructive confirmation step",
+      "Admins can download backup archives through the API at /api/v1/backups/{id}/download",
+    ],
+  },
+  {
     version: "0.6.3",
     date: "Jun 2026",
     changes: [


### PR DESCRIPTION
## Summary
- add API-level backup download then restore roundtrip coverage
- verify restored DB row and blob bytes after simulated loss

## Tests
- uv run pytest tests/test_backup_restore.py -v