### PR TITLE
0.6.5 — First-run polish: interactive UI right after setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.6.5 - First-run polish
+
+### Fixed
+
+- **The UI is interactive immediately after first-run setup.** Completing the
+  setup wizard logged you in by writing the token to local storage and firing an
+  in-tab auth event, but the auth provider only subscribed to that event when a
+  token already existed *at mount* — which is never the case on a brand-new
+  install. So the freshly created admin session wasn't observed: the app showed
+  the vault but treated you as signed out, leaving Upload, New collection, and
+  the admin/settings menu unresponsive until the JWT was picked up on the next
+  full page load (a reload, or the ~2 minute window before the next probe). The
+  provider now subscribes to auth changes unconditionally, so the setup login is
+  reflected right away. Covered by a regression test.
+
+### Changed
+
+- **Faster first paint.** Route components are now code-split with lazy imports,
+  so the initial load only ships the shell plus the landing route instead of
+  every page up front.
+- **React Query Devtools no longer ship in production.** They're lazily loaded
+  and gated to dev builds, trimming the production bundle.
+
 ## 0.6.4 - Backup restore and download
 
 ### Added

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -79,7 +79,7 @@ class Settings(BaseSettings):
     backup_s3_secret_key: str = ""
 
     app_name: str = "PrintStash"
-    app_version: str = "0.6.4"
+    app_version: str = "0.6.5"
 
     @property
     def incoming_dir(self) -> Path:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printstash"
-version = "0.6.4"
+version = "0.6.5"
 description = "PrintStash — self-hosted 3D printing asset manager"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "printstash-frontend",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/__tests__/auth-context.test.tsx
+++ b/frontend/src/lib/__tests__/auth-context.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { AuthProvider, useAuth } from "@/lib/auth-context";
+import { storeLogin } from "@/lib/auth-store";
+
+vi.mock("@/lib/api", () => ({
+  getMe: vi.fn(),
+  login: vi.fn(),
+}));
+
+function AuthProbe() {
+  const { loading, user } = useAuth();
+  if (loading) return <div>loading</div>;
+  return <div>{user ? `signed in:${user.username}` : "signed out"}</div>;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("AuthProvider", () => {
+  it("observes first-run setup login in the same tab", async () => {
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await screen.findByText("signed out");
+
+    storeLogin("setup-token", {
+      id: 1,
+      username: "admin",
+      email: null,
+      is_superuser: true,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("signed in:admin")).toBeTruthy();
+    });
+  });
+});

--- a/frontend/src/lib/auth-context.tsx
+++ b/frontend/src/lib/auth-context.tsx
@@ -39,12 +39,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    let alive = true;
+    const off = onAuthChange(() => {
+      setUser(getUser());
+    });
+
     if (!isLoggedIn()) {
       setLoading(false);
-      return;
+      return off;
     }
+
     getMe()
       .then((u) => {
+        if (!alive) return;
         const stored: StoredUser = {
           id: u.id,
           username: u.username,
@@ -55,13 +62,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setUser(stored);
       })
       .catch(() => {
+        if (!alive) return;
         clearLogin();
       })
-      .finally(() => setLoading(false));
-    const off = onAuthChange(() => {
-      setUser(getUser());
-    });
-    return off;
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+      off();
+    };
   }, []);
 
   const login = useCallback(async (username: string, password: string) => {

--- a/frontend/src/lib/changelog.ts
+++ b/frontend/src/lib/changelog.ts
@@ -21,6 +21,15 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.6.5",
+    date: "Jun 2026",
+    changes: [
+      "Fixed the app being unresponsive right after first-run setup — Upload, New collection, and the admin/settings menu now work immediately instead of needing a page reload",
+      "Faster first load: pages are code-split so the initial visit only downloads the screen you're on",
+      "Smaller production build — developer tooling no longer ships to end users",
+    ],
+  },
+  {
     version: "0.6.4",
     date: "Jun 2026",
     changes: [

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,7 @@
-import { StrictMode } from "react";
+import { lazy, StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { queryClient } from "@/lib/query-client";
 
@@ -17,11 +16,23 @@ import "@fontsource/jetbrains-mono/600.css";
 import "@/globals.css";
 import { router } from "@/router";
 
+const ReactQueryDevtools = import.meta.env.DEV
+  ? lazy(() =>
+      import("@tanstack/react-query-devtools").then((m) => ({
+        default: m.ReactQueryDevtools,
+      })),
+    )
+  : null;
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <ReactQueryDevtools initialIsOpen={false} />
+      {ReactQueryDevtools ? (
+        <Suspense fallback={null}>
+          <ReactQueryDevtools initialIsOpen={false} />
+        </Suspense>
+      ) : null}
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,37 +1,52 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createBrowserRouter } from "react-router-dom";
+import { Suspense, lazy } from "react";
 
 import RootLayout from "@/root-layout";
-import HomePage from "@/pages/home";
-import ModelDetailPage from "@/pages/model-detail";
-import LoginPage from "@/pages/login";
-import SetupPage from "@/pages/setup";
-import OrganizePage from "@/pages/organize";
-import ProfilesPage from "@/pages/profiles";
-import StatisticsPage from "@/pages/statistics";
-import SettingsPage from "@/pages/settings";
-import PrintersRoute from "@/pages/printers";
-import PrinterDetailRoute from "@/pages/printer-detail";
-import SharePage from "@/pages/share";
-import NotFound from "@/pages/not-found";
+
+const HomePage = lazy(() => import("@/pages/home"));
+const ModelDetailPage = lazy(() => import("@/pages/model-detail"));
+const LoginPage = lazy(() => import("@/pages/login"));
+const SetupPage = lazy(() => import("@/pages/setup"));
+const OrganizePage = lazy(() => import("@/pages/organize"));
+const ProfilesPage = lazy(() => import("@/pages/profiles"));
+const StatisticsPage = lazy(() => import("@/pages/statistics"));
+const SettingsPage = lazy(() => import("@/pages/settings"));
+const PrintersRoute = lazy(() => import("@/pages/printers"));
+const PrinterDetailRoute = lazy(() => import("@/pages/printer-detail"));
+const SharePage = lazy(() => import("@/pages/share"));
+const NotFound = lazy(() => import("@/pages/not-found"));
+
+function RouteChunk({ children }: { children: React.ReactNode }) {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen w-full bg-background" aria-busy="true" />
+      }
+    >
+      {children}
+    </Suspense>
+  );
+}
 
 export const router = createBrowserRouter([
   // Public, unauthenticated share viewer — deliberately mounted OUTSIDE
   // RootLayout so it bypasses auth/setup gating and the app chrome.
-  { path: "share/:token", element: <SharePage /> },
+  { path: "share/:token", element: <RouteChunk><SharePage /></RouteChunk> },
   {
     element: <RootLayout />,
     children: [
-      { index: true, element: <HomePage /> },
-      { path: "models/:id", element: <ModelDetailPage /> },
-      { path: "login", element: <LoginPage /> },
-      { path: "setup", element: <SetupPage /> },
-      { path: "organize", element: <OrganizePage /> },
-      { path: "profiles", element: <ProfilesPage /> },
-      { path: "statistics", element: <StatisticsPage /> },
-      { path: "settings", element: <SettingsPage /> },
-      { path: "printers", element: <PrintersRoute /> },
-      { path: "printers/:id", element: <PrinterDetailRoute /> },
-      { path: "*", element: <NotFound /> },
+      { index: true, element: <RouteChunk><HomePage /></RouteChunk> },
+      { path: "models/:id", element: <RouteChunk><ModelDetailPage /></RouteChunk> },
+      { path: "login", element: <RouteChunk><LoginPage /></RouteChunk> },
+      { path: "setup", element: <RouteChunk><SetupPage /></RouteChunk> },
+      { path: "organize", element: <RouteChunk><OrganizePage /></RouteChunk> },
+      { path: "profiles", element: <RouteChunk><ProfilesPage /></RouteChunk> },
+      { path: "statistics", element: <RouteChunk><StatisticsPage /></RouteChunk> },
+      { path: "settings", element: <RouteChunk><SettingsPage /></RouteChunk> },
+      { path: "printers", element: <RouteChunk><PrintersRoute /></RouteChunk> },
+      { path: "printers/:id", element: <RouteChunk><PrinterDetailRoute /></RouteChunk> },
+      { path: "*", element: <RouteChunk><NotFound /></RouteChunk> },
     ],
   },
 ]);


### PR DESCRIPTION
## Problem

On a brand-new install, completing the setup wizard dropped you onto the vault, but the **UI was frozen** — Upload, New collection, and the admin/settings menu didn't respond. The only workarounds were reloading the tab or waiting ~2 minutes. A bad first impression for new users.

## Root cause

The setup wizard logs the new admin in by writing the JWT to local storage and firing an in-tab `printstash:auth-changed` event. But `AuthProvider` only subscribed to that event **when a token already existed at mount** — which is never the case on a fresh install (no token yet when the app first loads):

```ts
if (!isLoggedIn()) {
  setLoading(false);
  return;            // <-- early return, onAuthChange never wired up
}
```

So the freshly created session went unobserved. The context still reported the user as signed out, which is what gated the buttons. A reload fixed it because by then the token exists at mount and the *other* branch (getMe + subscribe) runs; the ~2 minute self-heal was just the next setup-status probe re-rendering with the now-present token.

## Fix

- Subscribe to `onAuthChange` **unconditionally**, before the not-logged-in early return, so the same-tab setup login is reflected immediately.
- Guard the bootstrap `getMe()` against unmount with an `alive` flag.
- **Regression test** (`auth-context.test.tsx`): mounts `AuthProvider` signed-out, calls `storeLogin`, asserts the context flips to signed-in without a remount.

## Also in this release (first-load polish)

- **Code-split route components** with lazy imports — the initial visit only downloads the shell + landing route instead of every page.
- **React Query Devtools** are lazy-loaded and dev-gated, so they no longer ship in the production bundle.

## Release

Bumped to **0.6.5** across `backend/pyproject.toml`, `backend/app/core/config.py`, `frontend/package.json`, plus `CHANGELOG.md` and the in-app Settings → About changelog.

## Verification

- `vitest run` — 95 passed (includes the new regression test + changelog version-match test)
- `tsc --noEmit` — clean
- `eslint .` — 0 errors
- `vite build` — succeeds; route chunks now emitted separately