### PR TITLE
docs: Alembic migration troubleshooting + un-stamped DB repair (#29)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,6 +57,19 @@ Then restart the backend and frontend development servers.
 - Always back up the SQLite file before running migrations.
 - Do not edit the SQLite file directly while the API container is running.
 
+## Troubleshooting Migrations
+
+- **`No module named alembic.__main__`** — run migrations with the `alembic`
+  console script (`docker compose run --rm api uv run alembic upgrade head`), not
+  `python -m alembic`. Don't hand-edit the Compose `command:` to call
+  `python -m alembic …`; the shipped command is already correct.
+- **`table … already exists` on upgrade** — the app was started once without
+  running migrations (e.g. the Compose `command:` was removed), so it built the
+  schema itself without recording a migration version. Your data is fine. Back up,
+  then run `docker compose run --rm api uv run alembic stamp head` once to record
+  the current version (it touches no data), after which `alembic upgrade head`
+  works normally.
+
 ## Rollback Expectations
 
 - Stop the upgraded containers before attempting rollback.

--- a/docs/wiki/src/content/docs/guides/upgrading.md
+++ b/docs/wiki/src/content/docs/guides/upgrading.md
@@ -58,6 +58,44 @@ uv run alembic upgrade head
 
 Then restart the backend and frontend dev servers.
 
+## Troubleshooting migrations
+
+**`No module named alembic.__main__; 'alembic' is a package and cannot be
+directly executed`.** Run migrations with the `alembic` console script, not
+`python -m alembic` — Alembic ships no runnable `__main__`. The supported command
+is the one above:
+
+```bash
+docker compose run --rm api uv run alembic upgrade head
+```
+
+If you must invoke Python directly, the equivalent is
+`python -m alembic.config upgrade head`. Don't replace the Compose `command:`
+block with a hand-written `python -m alembic …` line — the shipped command
+already does the right thing.
+
+**`table … already exists` when running `alembic upgrade head`.** This shows up
+if the app was ever started *without* running migrations first — most commonly
+after deleting the Compose `command:` block so the container "just starts." On
+first boot the app creates the current schema itself, but that path doesn't
+record a migration version, so Alembic later tries to re-create tables that are
+already there.
+
+Your data is intact — Alembic simply doesn't know the schema is already current.
+The fix is a one-time **stamp**, done *while still on the image version the app
+last ran*, which records "this database is at this version" without running any
+migration or touching a single row:
+
+```bash
+# back up first (Settings → Backups, or POST /api/v1/backups)
+docker compose run --rm api uv run alembic stamp head
+```
+
+After that, upgrades work normally (`alembic upgrade head`). `stamp` only writes
+the version marker; it never creates, alters, or drops tables. If you're unsure
+which version built your schema, take a backup and restore-then-replay instead
+(see [Rollback](#rollback)).
+
 ## Version-specific notes
 
 ### 0.7.0 — Notifications & event hooks


### PR DESCRIPTION
## What & why

A user in #29 hit `No module named alembic.__main__` at startup. Root cause: the shipped Compose command (`uv run alembic upgrade head`) is correct, but a hand-written `python -m alembic …` substitution isn't — Alembic ships no runnable `__main__`. They then "fixed" it by deleting the `command:` block, which lets the app bootstrap the schema via `create_all()` **without recording a migration version** — a latent `table already exists` failure on the next `alembic upgrade head`.

## Change (docs only)

Adds a **Troubleshooting migrations** section to the published upgrade guide and a matching note in repo-root `UPGRADE.md`:

- Correct command is `uv run alembic upgrade head` (console script) / `python -m alembic.config …` — never `python -m alembic`.
- Data-safe one-time repair for an un-stamped DB: `alembic stamp head` (writes only the version marker, touches no data), then upgrade normally.

No runtime, Dockerfile, or Compose changes. The entrypoint hardening (run migrations in the image + remove the Compose command + auto-stamp guard) is intentionally left for a separate, tested change.