### PR TITLE
fix(web): keep collection context on delete and logo navigation

### DIFF
--- a/frontend/src/components/model-detail/index.tsx
+++ b/frontend/src/components/model-detail/index.tsx
@@ -168,7 +168,11 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
     try {
       await deleteModel(model.id);
       toast.success("Model deleted");
-      router.push("/");
+      // Return to the folder the model lived in, not the root — deleting one
+      // model shouldn't kick the user out of the collection they were browsing.
+      router.push(
+        model.collection ? `/?c=${encodeURIComponent(model.collection)}` : "/",
+      );
       router.refresh();
     } catch (e) {
       toast.error(e);

--- a/frontend/src/components/model-grid.tsx
+++ b/frontend/src/components/model-grid.tsx
@@ -28,6 +28,7 @@ import { useRequireAuth } from "@/lib/use-require-auth";
 import { useAuth } from "@/lib/auth-context";
 import { Link } from "@/lib/navigation";
 import { timeAgo } from "@/lib/format";
+import { rememberLastCollection } from "@/lib/last-collection";
 import { useAuthenticatedAssetUrl } from "@/lib/use-authenticated-asset-url";
 
 type SortKey = "date-desc" | "date-asc" | "name-asc" | "name-desc";
@@ -164,6 +165,9 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
       hasLoadedModels.current = false;
       setSelectedCollection(next);
     }
+    // Remember the folder we're in so the logo / post-delete nav can return
+    // here instead of resetting to the root once the `?c=` param is dropped.
+    rememberLastCollection(next);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collectionParam]);
 

--- a/frontend/src/components/top-bar.tsx
+++ b/frontend/src/components/top-bar.tsx
@@ -19,6 +19,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
+import { lastVaultHref } from "@/lib/last-collection";
 import { BrandMark } from "@/components/brand-mark";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
@@ -107,6 +108,14 @@ export function TopBar() {
   const [profileOpen, setProfileOpen] = useState(false);
   const tasksRef = useRef<HTMLDivElement>(null);
   const profileRef = useRef<HTMLDivElement>(null);
+  // The logo returns to the model browser, restoring the last folder the user
+  // was in rather than always resetting to "All Models". Recomputed whenever the
+  // route changes (e.g. arriving on Settings) so it reflects the remembered
+  // collection at click time.
+  const [homeHref, setHomeHref] = useState("/");
+  useEffect(() => {
+    setHomeHref(lastVaultHref());
+  }, [pathname]);
 
   useEffect(() => {
     setTasks(listTasks());
@@ -132,7 +141,7 @@ export function TopBar() {
   return (
     <header className="h-16 bg-background border-b border-border flex items-center justify-between px-4 z-40 relative">
       {/* Logo */}
-      <Link href="/" className="flex items-center space-x-2 hover:opacity-80 transition-opacity">
+      <Link href={homeHref} className="flex items-center space-x-2 hover:opacity-80 transition-opacity">
         <div className="w-8 h-8 bg-blue-600 dark:bg-orange-600 rounded flex items-center justify-center flex-shrink-0">
           <BrandMark className="h-6 w-6 text-white" />
         </div>

--- a/frontend/src/lib/__tests__/last-collection.test.ts
+++ b/frontend/src/lib/__tests__/last-collection.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  LAST_COLLECTION_STORAGE_KEY,
+  lastVaultHref,
+  readLastCollection,
+  rememberLastCollection,
+} from "@/lib/last-collection";
+
+afterEach(() => {
+  window.localStorage.removeItem(LAST_COLLECTION_STORAGE_KEY);
+});
+
+describe("last collection persistence", () => {
+  it("returns null and the root href when nothing is stored", () => {
+    expect(readLastCollection()).toBeNull();
+    expect(lastVaultHref()).toBe("/");
+  });
+
+  it("remembers a collection path and builds a restoring href", () => {
+    rememberLastCollection("spoolers");
+    expect(readLastCollection()).toBe("spoolers");
+    expect(lastVaultHref()).toBe("/?c=spoolers");
+  });
+
+  it("encodes paths with nesting and spaces", () => {
+    rememberLastCollection("spoolers/old prints");
+    expect(lastVaultHref()).toBe("/?c=spoolers%2Fold%20prints");
+  });
+
+  it("clears the remembered collection at the root", () => {
+    rememberLastCollection("spoolers");
+    rememberLastCollection(null);
+    expect(readLastCollection()).toBeNull();
+    expect(lastVaultHref()).toBe("/");
+  });
+});

--- a/frontend/src/lib/last-collection.ts
+++ b/frontend/src/lib/last-collection.ts
@@ -1,0 +1,34 @@
+// Remembers the last vault collection (folder) the user was browsing so the
+// PrintStash logo and post-delete navigation return there instead of resetting
+// to "All Models". Collection selection lives in the URL as `?c=<path>`, but
+// that param is dropped when the user navigates to Settings, a model, etc. —
+// persisting it here lets us restore the context on the way back.
+export const LAST_COLLECTION_STORAGE_KEY = "printstash.last.collection";
+
+/** Persist the current collection path (or clear it at the root). Best-effort. */
+export function rememberLastCollection(path: string | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (path) window.localStorage.setItem(LAST_COLLECTION_STORAGE_KEY, path);
+    else window.localStorage.removeItem(LAST_COLLECTION_STORAGE_KEY);
+  } catch {
+    // Storage unavailable (private mode / disabled) — context restore is a
+    // nicety, not a requirement, so silently skip it.
+  }
+}
+
+/** Read the remembered collection path, or null if none/unavailable. */
+export function readLastCollection(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(LAST_COLLECTION_STORAGE_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Home URL that restores the last collection, e.g. `/?c=spoolers` (or `/`). */
+export function lastVaultHref(): string {
+  const path = readLastCollection();
+  return path ? `/?c=${encodeURIComponent(path)}` : "/";
+}


### PR DESCRIPTION
## Problem

Two navigation papercuts kicked users out of the folder they were browsing:

1. **Deleting a model** returned to **All Models** instead of staying in the model's collection. Removing one model from `spoolers` dumped you at the root.
2. **The PrintStash logo** always linked to `/`, so going **Settings → logo** landed on All Models rather than the collection you came from (the user expected browser-back-like behavior).

## Fix

Collection selection lives in the URL as `?c=<path>` but is dropped when you leave the browser (Settings, a model, etc.). This remembers the last-browsed collection so we can restore it:

- New `src/lib/last-collection.ts` helper (`rememberLastCollection` / `readLastCollection` / `lastVaultHref`), backed by `localStorage`, best-effort (guards private mode).
- The model grid records the active folder whenever it changes.
- **Logo** (`top-bar.tsx`) now restores the last collection instead of hard-linking to `/`, recomputed on route change.
- **Post-delete** (`model-detail/index.tsx`) navigates to `/?c=<model.collection>` (or `/` if uncollected).

## Tests

- Unit tests for the helper (roundtrip, encoding of nested/spaced paths, clear-at-root).
- `tsc` clean; eslint clean on changed files (only pre-existing warnings remain).
- Existing `app-routes` e2e navigation spec still passes (6/6).

Note: from within the model browser the logo still effectively reflects the folder you arrived on; the reported case (returning from Settings/other pages) is what this restores.