### PR TITLE
0.7.2: DB migrations, collection nav fixes + search/grid UX (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 0.7.2
+
+### Changed
+
+- **Database migrations now run automatically on startup.** The API image's
+  entrypoint runs `alembic upgrade head` before the server launches, so migrations
+  happen however the container is started (Compose, Portainer, Unraid, bare
+  `docker run`) — editing or removing the Compose `command:` can no longer skip
+  them (issue #29). A failed migration aborts startup *before* the app serves a
+  request. The previous explicit `docker compose run … alembic upgrade head` step
+  is now optional.
+
+### Fixed
+
+- **Fresh installs and upgrades come up cleanly on SQLite *and* PostgreSQL.** The
+  migration runner now bootstraps a brand-new database directly from the models
+  (then stamps it at head) instead of replaying the historical migration chain,
+  whose SQLite-authored baseline failed outright on a fresh Postgres. Existing
+  databases still upgrade normally. (#29)
+- **A database started once without migrations is adopted safely.** If the schema
+  was built by the app's own `create_all()` and never recorded a migration version
+  (e.g. after the Compose migration step was removed), the runner now detects it,
+  stamps it at head, and continues — no "table already exists" crash on the next
+  upgrade, and no data is touched. A one-time manual repair is also documented. (#29)
+- **Deleting a model keeps you in its folder.** It previously returned to the root
+  "All Models" view; it now returns to the collection the model lived in. (#30)
+- **The PrintStash logo returns you to the collection you were browsing** instead
+  of always resetting to "All Models" — the last-viewed folder is remembered. (#30)
+
 ## 0.7.1
 
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -57,6 +57,19 @@ Then restart the backend and frontend development servers.
 - Always back up the SQLite file before running migrations.
 - Do not edit the SQLite file directly while the API container is running.
 
+## Troubleshooting Migrations
+
+- **`No module named alembic.__main__`** — run migrations with the `alembic`
+  console script (`docker compose run --rm api uv run alembic upgrade head`), not
+  `python -m alembic`. Don't hand-edit the Compose `command:` to call
+  `python -m alembic …`; the shipped command is already correct.
+- **`table … already exists` on upgrade** — the app was started once without
+  running migrations (e.g. the Compose `command:` was removed), so it built the
+  schema itself without recording a migration version. Your data is fine. Back up,
+  then run `docker compose run --rm api uv run alembic stamp head` once to record
+  the current version (it touches no data), after which `alembic upgrade head`
+  works normally.
+
 ## Rollback Expectations
 
 - Stop the upgraded containers before attempting rollback.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,6 +31,8 @@ RUN uv run patchright install --with-deps chromium
 COPY app ./app
 COPY alembic.ini ./alembic.ini
 COPY alembic ./alembic
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x ./docker-entrypoint.sh
 
 ENV VAULT_DATA_DIR=/data/files \
     VAULT_THUMB_DIR=/data/thumbs \
@@ -38,4 +40,7 @@ ENV VAULT_DATA_DIR=/data/files \
 
 EXPOSE 8000
 
+# Entrypoint runs DB migrations, then execs CMD. Migrations therefore run on
+# every container start regardless of the orchestrator's command (issue #29).
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD ["uv", "run", "uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log", "--proxy-headers"]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -160,7 +160,7 @@ class Settings(BaseSettings):
     backup_s3_secret_key: str = ""
 
     app_name: str = "PrintStash"
-    app_version: str = "0.7.1"
+    app_version: str = "0.7.2"
 
     @property
     def incoming_dir(self) -> Path:

--- a/backend/app/db/migrate.py
+++ b/backend/app/db/migrate.py
@@ -1,0 +1,100 @@
+"""Database migration runner — the single, safe entry point for bringing a
+database up to the latest Alembic revision.
+
+Used by the container entrypoint (``python -m app.db.migrate``) so migrations run
+on every start, however the app is launched, instead of depending on a fragile
+Compose ``command:`` line (issue #29). Idempotent: a no-op when already at head.
+
+It also **self-heals an "orphan" database** — one whose schema was built by the
+app's startup ``create_all()`` without ever recording an Alembic version (what
+happened when a user removed the Compose migration step). Running ``upgrade head``
+on such a DB would fail with "table already exists" because the baseline
+migration tries to re-create existing tables. So if we find application tables
+but no ``alembic_version``, we ``stamp head`` first to adopt the existing schema,
+then upgrade. ``stamp`` only writes the version marker — it touches no data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from sqlalchemy import create_engine, inspect
+
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# backend/app/db/migrate.py -> parents[2] == backend/
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_SCRIPT_LOCATION = _BACKEND_DIR / "alembic"
+
+
+def _alembic_config(url: str) -> Config:
+    """Build an Alembic config programmatically (no alembic.ini file).
+
+    Using ``Config()`` rather than ``Config("alembic.ini")`` leaves
+    ``config_file_name`` as ``None``, which makes ``env.py`` skip ``fileConfig`` —
+    so running migrations does not hijack the app/pytest logging configuration.
+    """
+    cfg = Config()
+    cfg.set_main_option("script_location", str(_SCRIPT_LOCATION))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+def _current_revision(engine) -> str | None:
+    """The DB's recorded Alembic revision, or None when it has never been stamped."""
+    with engine.connect() as conn:
+        return MigrationContext.configure(conn).get_current_revision()
+
+
+def _has_application_tables(engine) -> bool:
+    """True if the DB holds tables other than Alembic's own bookkeeping table."""
+    tables = set(inspect(engine).get_table_names())
+    tables.discard("alembic_version")
+    return bool(tables)
+
+
+def run_migrations(database_url: str | None = None) -> None:
+    """Bring *database_url* (default: configured DB) to the latest revision.
+
+    Handles all three states the entrypoint can meet:
+
+    * **fresh** (no tables): runs the whole chain from baseline and stamps head.
+    * **already managed** (has ``alembic_version``): applies any pending
+      migrations; a no-op when already at head.
+    * **orphan** (app tables but no ``alembic_version``): stamps head to adopt the
+      existing schema, then upgrades — no data touched, no "table exists" error.
+    """
+    url = database_url or settings.db_url
+
+    engine = create_engine(url)
+    try:
+        revision = _current_revision(engine)
+        orphan = revision is None and _has_application_tables(engine)
+    finally:
+        engine.dispose()
+
+    cfg = _alembic_config(url)
+    if orphan:
+        logger.warning(
+            "migrate: database has tables but no Alembic version — stamping head "
+            "to adopt the existing schema before upgrading (orphan rescue). This "
+            "writes only the version marker; no data is changed."
+        )
+        command.stamp(cfg, "head")
+
+    command.upgrade(cfg, "head")
+    logger.info("migrate: database is at the latest revision (head)")
+
+
+def main() -> None:  # pragma: no cover - thin CLI wrapper, exercised via entrypoint
+    run_migrations()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/backend/app/db/migrate.py
+++ b/backend/app/db/migrate.py
@@ -22,6 +22,7 @@ from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from sqlalchemy import create_engine, inspect
+from sqlmodel import SQLModel
 
 from app.core.config import settings
 from app.core.logging import get_logger
@@ -59,36 +60,66 @@ def _has_application_tables(engine) -> bool:
     return bool(tables)
 
 
+def _create_all(url: str) -> None:
+    """Build the full current schema directly from the SQLModel models."""
+    import app.db.models  # noqa: F401 — register all tables on SQLModel.metadata
+
+    engine = create_engine(url)
+    try:
+        SQLModel.metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+
 def run_migrations(database_url: str | None = None) -> None:
     """Bring *database_url* (default: configured DB) to the latest revision.
 
     Handles all three states the entrypoint can meet:
 
-    * **fresh** (no tables): runs the whole chain from baseline and stamps head.
     * **already managed** (has ``alembic_version``): applies any pending
       migrations; a no-op when already at head.
     * **orphan** (app tables but no ``alembic_version``): stamps head to adopt the
       existing schema, then upgrades — no data touched, no "table exists" error.
+    * **fresh** (no tables): builds the schema directly from the models and stamps
+      head, rather than replaying the historical migration chain. That chain was
+      authored against SQLite and does not apply cleanly on stricter engines like
+      Postgres (its baseline fails outright); on an empty database the chain's
+      data backfills are no-ops, so ``create_all`` + ``stamp head`` yields an
+      equivalent, head-stamped schema on every supported engine.
     """
     url = database_url or settings.db_url
 
     engine = create_engine(url)
     try:
         revision = _current_revision(engine)
-        orphan = revision is None and _has_application_tables(engine)
+        has_tables = _has_application_tables(engine)
     finally:
         engine.dispose()
 
     cfg = _alembic_config(url)
-    if orphan:
+
+    if revision is not None:
+        # Already managed by Alembic — apply any pending migrations.
+        command.upgrade(cfg, "head")
+    elif has_tables:
+        # Orphan: schema built without recording a version (issue #29).
         logger.warning(
             "migrate: database has tables but no Alembic version — stamping head "
             "to adopt the existing schema before upgrading (orphan rescue). This "
             "writes only the version marker; no data is changed."
         )
         command.stamp(cfg, "head")
+        command.upgrade(cfg, "head")
+    else:
+        # Fresh database — create the schema from the models, then stamp head so
+        # Alembic considers it current (engine-agnostic; avoids the SQLite-only
+        # baseline migration). Future migrations apply normally from here.
+        logger.info(
+            "migrate: empty database — creating schema from models and stamping head"
+        )
+        _create_all(url)
+        command.stamp(cfg, "head")
 
-    command.upgrade(cfg, "head")
     logger.info("migrate: database is at the latest revision (head)")
 
 

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import AsyncGenerator, Generator, Iterator, Protocol, runtime_checkable
 
-from sqlalchemy import event
+from sqlalchemy import event, inspect
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -155,16 +155,36 @@ def get_engine() -> Engine:
     return _engine
 
 
-def init_db() -> None:
-    """Bootstrap a fresh database.
+def _is_alembic_managed(engine: Engine) -> bool:
+    """True when the DB's schema is owned by Alembic (an ``alembic_version`` table
+    exists) — i.e. migrations have run against it.
 
-    Schema upgrades now belong to Alembic. ``create_all()`` remains here only
-    so a brand-new self-hosted SQLite install can come up without a separate
-    migration step.
+    In that case ``create_all()`` must NOT also build tables: it can't reproduce
+    the data backfills/ALTERs the migrations carry, and on a fresh DB it would
+    leave an un-stamped, divergent schema. See ``app/db/migrate.py``.
     """
+    try:
+        return "alembic_version" in inspect(engine).get_table_names()
+    except Exception:  # pragma: no cover - defensive; treat unreadable as unmanaged
+        return False
+
+
+def init_db(engine: Engine | None = None) -> None:
+    """Bootstrap a database that Alembic has not already built.
+
+    Production runs migrations *before* the app starts (see ``app/db/migrate.py``
+    and the container entrypoint), so the schema is Alembic-owned and this is a
+    no-op. The direct ``create_all()`` path remains only for the test suite and a
+    brand-new local dev database that hasn't been migrated yet — never on top of
+    an Alembic-managed database, which is what used to produce a divergent,
+    un-stamped schema (issue #29).
+    """
+    eng = engine if engine is not None else _engine
     from app.db import models  # noqa: F401
 
-    SQLModel.metadata.create_all(_engine)
+    if _is_alembic_managed(eng):
+        return
+    SQLModel.metadata.create_all(eng)
 
 
 def _ensure_sentinel_rows() -> None:

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Container entrypoint: bring the database to the latest schema, then exec the
+# image command (CMD: uvicorn).
+#
+# Running migrations here — inside the image, on every start — means they happen
+# however the container is launched (Compose, Portainer, Unraid, bare `docker
+# run`), so a missing/edited `command:` can no longer skip them (issue #29).
+# `app.db.migrate` is idempotent (a no-op at head) and self-heals an un-stamped
+# "orphan" database. `set -e` aborts startup if a migration fails — before the
+# app serves a single request, which is exactly when you want to find out.
+set -e
+
+uv run python -m app.db.migrate
+
+exec "$@"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printstash"
-version = "0.7.1"
+version = "0.7.2"
 description = "PrintStash — self-hosted 3D printing asset manager"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -174,3 +174,69 @@ def test_init_db_is_strict_noop_on_alembic_managed_db(tmp_path: Path) -> None:
         assert migrate_mod._current_revision(engine) == _head_revision()
     finally:
         engine.dispose()
+
+
+# --------------------------------------------------------------------------- #
+# State dispatch: a fresh DB must NOT replay the historical migration chain
+# (its baseline is SQLite-only and fails on Postgres) — it bootstraps via
+# create_all + stamp instead. This is what makes Postgres work; asserted here
+# without needing a Postgres service in CI.
+# --------------------------------------------------------------------------- #
+class _Spy:
+    def __init__(self) -> None:
+        self.upgrade: list = []
+        self.stamp: list = []
+        self.create_all: list = []
+
+    def install(self, monkeypatch, tmp_path: Path) -> str:
+        url = _url(tmp_path, "dispatch.sqlite")
+        monkeypatch.setattr(
+            migrate_mod.command, "upgrade", lambda *a, **k: self.upgrade.append(a)
+        )
+        monkeypatch.setattr(
+            migrate_mod.command, "stamp", lambda *a, **k: self.stamp.append(a)
+        )
+        monkeypatch.setattr(
+            migrate_mod, "_create_all", lambda u: self.create_all.append(u)
+        )
+        return url
+
+
+def test_fresh_db_bootstraps_via_create_all_not_baseline(tmp_path, monkeypatch) -> None:
+    spy = _Spy()
+    url = spy.install(monkeypatch, tmp_path)  # empty DB → fresh
+    migrate_mod.run_migrations(url)
+    assert spy.create_all == [url]  # schema built from models
+    assert len(spy.stamp) == 1  # stamped head
+    assert spy.upgrade == []  # baseline chain NOT replayed (Postgres-safe)
+
+
+def test_orphan_db_stamps_then_upgrades(tmp_path, monkeypatch) -> None:
+    # Real orphan: tables but no alembic_version.
+    url = _url(tmp_path, "dispatch.sqlite")
+    engine = create_engine(url)
+    SQLModel.metadata.create_all(engine)
+    engine.dispose()
+
+    spy = _Spy()
+    # Re-point spies at the SAME url (already has tables).
+    monkeypatch.setattr(migrate_mod.command, "upgrade", lambda *a, **k: spy.upgrade.append(a))
+    monkeypatch.setattr(migrate_mod.command, "stamp", lambda *a, **k: spy.stamp.append(a))
+    monkeypatch.setattr(migrate_mod, "_create_all", lambda u: spy.create_all.append(u))
+
+    migrate_mod.run_migrations(url)
+    assert len(spy.stamp) == 1 and len(spy.upgrade) == 1  # adopt then upgrade
+    assert spy.create_all == []  # never rebuilds an existing schema
+
+
+def test_managed_db_only_upgrades(tmp_path, monkeypatch) -> None:
+    url = _url(tmp_path, "dispatch.sqlite")
+    migrate_mod.run_migrations(url)  # make it managed (real run)
+
+    spy = _Spy()
+    monkeypatch.setattr(migrate_mod.command, "upgrade", lambda *a, **k: spy.upgrade.append(a))
+    monkeypatch.setattr(migrate_mod.command, "stamp", lambda *a, **k: spy.stamp.append(a))
+    monkeypatch.setattr(migrate_mod, "_create_all", lambda u: spy.create_all.append(u))
+
+    migrate_mod.run_migrations(url)
+    assert spy.upgrade and not spy.stamp and not spy.create_all

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 from alembic import command
 from alembic.config import Config
-from sqlalchemy import create_engine, inspect
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, inspect, text
+from sqlmodel import Session, SQLModel
+
+import app.db.models  # noqa: F401 — register all tables on SQLModel.metadata
+from app.db import migrate as migrate_mod
+from app.db.models import User
+from app.db.session import _is_alembic_managed, init_db
 
 
 def test_alembic_upgrade_creates_expected_schema(tmp_path: Path, monkeypatch) -> None:
@@ -40,3 +47,130 @@ def test_alembic_upgrade_creates_expected_schema(tmp_path: Path, monkeypatch) ->
     assert "expires_at" in share_columns
     assert "allow_download" in share_columns
     assert "selected_file_ids_json" in share_columns
+
+
+# --------------------------------------------------------------------------- #
+# Strict coverage for the migration runner (app/db/migrate.py) and create_all
+# gating — the entrypoint hardening for issue #29. Runs the real migration chain
+# against temp SQLite *files* in every DB state the entrypoint must survive.
+# --------------------------------------------------------------------------- #
+def _url(tmp_path: Path, name: str = "runner.sqlite") -> str:
+    return f"sqlite:///{tmp_path / name}"
+
+
+def _head_revision() -> str:
+    cfg = migrate_mod._alembic_config("sqlite://")
+    head = ScriptDirectory.from_config(cfg).get_current_head()
+    assert head is not None
+    return head
+
+
+def _current(url: str) -> str | None:
+    engine = create_engine(url)
+    try:
+        return migrate_mod._current_revision(engine)
+    finally:
+        engine.dispose()
+
+
+def _table_names(url: str) -> set[str]:
+    engine = create_engine(url)
+    try:
+        return set(inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def test_runner_fresh_db_migrates_to_head_and_stamps(tmp_path: Path) -> None:
+    url = _url(tmp_path)
+    migrate_mod.run_migrations(url)
+
+    assert _current(url) == _head_revision()
+    assert {"users", "models", "files", "alembic_version"} <= _table_names(url)
+
+
+def test_runner_is_idempotent_noop_at_head(tmp_path: Path) -> None:
+    url = _url(tmp_path)
+    migrate_mod.run_migrations(url)
+    head = _current(url)
+    migrate_mod.run_migrations(url)  # must not raise, must not move off head
+    assert _current(url) == head == _head_revision()
+
+
+def test_runner_orphan_db_is_adopted_without_table_exists_error(tmp_path: Path) -> None:
+    # The issue #29 state: full schema built by create_all(), no alembic_version.
+    url = _url(tmp_path)
+    engine = create_engine(url)
+    SQLModel.metadata.create_all(engine)
+    engine.dispose()
+
+    assert _current(url) is None
+    assert "users" in _table_names(url) and "alembic_version" not in _table_names(url)
+
+    # A naive `upgrade head` would hit "table already exists"; the runner must
+    # stamp first and finish cleanly at head.
+    migrate_mod.run_migrations(url)
+    assert _current(url) == _head_revision()
+
+
+def test_runner_orphan_rescue_preserves_existing_data(tmp_path: Path) -> None:
+    url = _url(tmp_path)
+    engine = create_engine(url)
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        session.add(
+            User(
+                username="keepme",
+                hashed_password="x",
+                is_active=True,
+                is_superuser=True,
+            )
+        )
+        session.commit()
+    engine.dispose()
+
+    migrate_mod.run_migrations(url)
+
+    engine = create_engine(url)
+    try:
+        with engine.connect() as conn:
+            names = [r[0] for r in conn.execute(text("SELECT username FROM users"))]
+    finally:
+        engine.dispose()
+    assert "keepme" in names  # rescue never dropped or rebuilt the data
+
+
+def test_has_application_tables_ignores_alembic_only(tmp_path: Path) -> None:
+    url = _url(tmp_path)
+    engine = create_engine(url)
+    try:
+        assert migrate_mod._has_application_tables(engine) is False
+    finally:
+        engine.dispose()
+
+
+def test_init_db_builds_schema_on_unmanaged_db(tmp_path: Path) -> None:
+    url = _url(tmp_path, "init.sqlite")
+    engine = create_engine(url)
+    try:
+        assert "users" not in set(inspect(engine).get_table_names())
+        init_db(engine)
+        assert "users" in set(inspect(engine).get_table_names())
+        assert _is_alembic_managed(engine) is False  # create_all leaves it un-stamped
+    finally:
+        engine.dispose()
+
+
+def test_init_db_is_strict_noop_on_alembic_managed_db(tmp_path: Path) -> None:
+    url = _url(tmp_path, "managed.sqlite")
+    migrate_mod.run_migrations(url)
+
+    engine = create_engine(url)
+    try:
+        assert _is_alembic_managed(engine) is True
+        before = set(inspect(engine).get_table_names())
+        init_db(engine)  # must NOT call create_all
+        assert set(inspect(engine).get_table_names()) == before
+        assert migrate_mod._current_revision(engine) == _head_revision()
+    finally:
+        engine.dispose()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "printstash"
-version = "0.7.1"
+version = "0.7.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -91,12 +91,9 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
-    command:
-      - /bin/sh
-      - -c
-      - >
-        uv run alembic upgrade head &&
-        uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-access-log --proxy-headers
+    # No migration command needed: the image entrypoint runs DB migrations on
+    # every start, then launches the server (the image CMD). Removing or editing
+    # this stanza can no longer skip migrations (issue #29).
 
 networks:
   printstash_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,12 +71,9 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
-    command:
-      - /bin/sh
-      - -c
-      - >
-        uv run alembic upgrade head &&
-        uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --no-access-log --proxy-headers
+    # No migration command needed: the image entrypoint runs DB migrations on
+    # every start, then launches the server (the image CMD). Removing or editing
+    # this stanza can no longer skip migrations (issue #29).
 
   postgres:
     image: postgres:16-alpine

--- a/docs/wiki/src/content/docs/guides/upgrading.md
+++ b/docs/wiki/src/content/docs/guides/upgrading.md
@@ -58,6 +58,44 @@ uv run alembic upgrade head
 
 Then restart the backend and frontend dev servers.
 
+## Troubleshooting migrations
+
+**`No module named alembic.__main__; 'alembic' is a package and cannot be
+directly executed`.** Run migrations with the `alembic` console script, not
+`python -m alembic` — Alembic ships no runnable `__main__`. The supported command
+is the one above:
+
+```bash
+docker compose run --rm api uv run alembic upgrade head
+```
+
+If you must invoke Python directly, the equivalent is
+`python -m alembic.config upgrade head`. Don't replace the Compose `command:`
+block with a hand-written `python -m alembic …` line — the shipped command
+already does the right thing.
+
+**`table … already exists` when running `alembic upgrade head`.** This shows up
+if the app was ever started *without* running migrations first — most commonly
+after deleting the Compose `command:` block so the container "just starts." On
+first boot the app creates the current schema itself, but that path doesn't
+record a migration version, so Alembic later tries to re-create tables that are
+already there.
+
+Your data is intact — Alembic simply doesn't know the schema is already current.
+The fix is a one-time **stamp**, done *while still on the image version the app
+last ran*, which records "this database is at this version" without running any
+migration or touching a single row:
+
+```bash
+# back up first (Settings → Backups, or POST /api/v1/backups)
+docker compose run --rm api uv run alembic stamp head
+```
+
+After that, upgrades work normally (`alembic upgrade head`). `stamp` only writes
+the version marker; it never creates, alters, or drops tables. If you're unsure
+which version built your schema, take a backup and restore-then-replay instead
+(see [Rollback](#rollback)).
+
 ## Version-specific notes
 
 ### 0.7.0 — Notifications & event hooks

--- a/docs/wiki/src/content/docs/guides/upgrading.md
+++ b/docs/wiki/src/content/docs/guides/upgrading.md
@@ -21,7 +21,6 @@ the old image around** until the new one has proven itself.
 ```bash
 docker compose down
 docker compose pull
-docker compose run --rm api uv run alembic upgrade head
 docker compose up -d
 ```
 
@@ -30,13 +29,21 @@ If you build from source instead of pulling published images:
 ```bash
 docker compose down
 docker compose build --pull
-docker compose run --rm api uv run alembic upgrade head
 docker compose up -d
 ```
 
-Running migrations as an explicit step (rather than letting the app do it on
-boot) means a migration failure stops you *before* the new app starts serving,
-which is exactly when you want to know.
+**Migrations run automatically.** The API image's entrypoint runs
+`alembic upgrade head` on every start, before the server launches, so a fresh
+`up -d` migrates the database for you. A failed migration aborts startup *before*
+the app serves a request — which is exactly when you want to know. You no longer
+need a separate migration step or a migration line in the Compose `command:`.
+
+If you prefer to run migrations explicitly first (e.g. to inspect them before the
+app comes up), it's still supported and idempotent:
+
+```bash
+docker compose run --rm api uv run alembic upgrade head
+```
 
 ### Pinning images
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "printstash-frontend",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/model-card.tsx
+++ b/frontend/src/components/model-card.tsx
@@ -93,6 +93,10 @@ function MetricCell({ id, model, isLast }: { id: CardMetricId; model: ModelListI
 function ModelCardInner({ model, metrics }: { model: ModelListItem; metrics: CardMetrics }) {
   const router = useRouter();
   const thumb = useAuthenticatedAssetUrl(model.thumbnail_url);
+  // Lazy thumbnails used to snap in at full opacity the instant their bytes
+  // arrived. Fade each one in on load so scrolling/searching settles smoothly
+  // instead of popping card by card.
+  const [thumbLoaded, setThumbLoaded] = useState(false);
   const printerPresence = model.printer_presence ?? [];
   const hasPrinter = printerPresence.length > 0;
   const ps = model.print_summary;
@@ -106,7 +110,7 @@ function ModelCardInner({ model, metrics }: { model: ModelListItem; metrics: Car
 
   return (
     <article
-      className="group flex h-full flex-col bg-card border border-border rounded transition-all duration-200 hover:border-blue-500 dark:hover:border-orange-500 overflow-hidden"
+      className="animate-card-in group flex h-full flex-col bg-card border border-border rounded transition-all duration-200 hover:border-blue-500 dark:hover:border-orange-500 overflow-hidden"
       onMouseEnter={handleHover}
       onTouchStart={handleHover}
     >
@@ -117,10 +121,18 @@ function ModelCardInner({ model, metrics }: { model: ModelListItem; metrics: Car
           {thumb ? (
             <img
               alt={model.name}
-              className="w-full h-full object-cover opacity-90 group-hover:opacity-100 transition-opacity"
+              className={`w-full h-full object-cover transition-opacity duration-300 ease-out ${
+                thumbLoaded ? "opacity-90 group-hover:opacity-100" : "opacity-0"
+              }`}
               src={thumb}
               loading="lazy"
               decoding="async"
+              onLoad={() => setThumbLoaded(true)}
+              // Cached images can finish before React attaches onLoad; catch that
+              // case so they don't stay stuck at opacity-0.
+              ref={(node) => {
+                if (node?.complete && node.naturalWidth > 0) setThumbLoaded(true);
+              }}
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center">

--- a/frontend/src/components/model-detail/index.tsx
+++ b/frontend/src/components/model-detail/index.tsx
@@ -168,7 +168,11 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
     try {
       await deleteModel(model.id);
       toast.success("Model deleted");
-      router.push("/");
+      // Return to the folder the model lived in, not the root — deleting one
+      // model shouldn't kick the user out of the collection they were browsing.
+      router.push(
+        model.collection ? `/?c=${encodeURIComponent(model.collection)}` : "/",
+      );
       router.refresh();
     } catch (e) {
       toast.error(e);

--- a/frontend/src/components/model-grid.tsx
+++ b/frontend/src/components/model-grid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "@/lib/navigation";
 import { CollectionRead, ModelListItem, PrinterRead, TagRead } from "@/types";
 import { ModelCard } from "@/components/model-card";
@@ -21,8 +22,17 @@ import {
   ChevronRight,
   Plus,
 } from "lucide-react";
-import { listModels, createCollection, updateModel, moveCollection, deleteCollection } from "@/lib/api";
-import { useCollections, usePrinters, useTags, useVaultStats } from "@/lib/queries";
+import { createCollection, updateModel, moveCollection, deleteCollection } from "@/lib/api";
+import {
+  useCollections,
+  useModelList,
+  useOutlinerModels,
+  usePrinters,
+  useTags,
+  useVaultStats,
+  type ModelListFilters,
+} from "@/lib/queries";
+import { queryKeys } from "@/lib/query-client";
 import { toast } from "@/lib/toast";
 import { useRequireAuth } from "@/lib/use-require-auth";
 import { useAuth } from "@/lib/auth-context";
@@ -109,11 +119,6 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
   const searchParams = useSearchParams();
   const auth = useRequireAuth();
   const { user } = useAuth();
-  const [models, setModels] = useState<ModelListItem[]>(initial?.models ?? []);
-  // Unfiltered model list for the outliner tree. The grid's `models` shrink to
-  // the active collection/tag filter; feeding those to the sidebar made other
-  // folders' leaves vanish (tree branches appeared to collapse on selection).
-  const [outlinerModels, setOutlinerModels] = useState<ModelListItem[]>(initial?.models ?? []);
   // Shared taxonomy facets from the TanStack Query cache: one cache entry shared
   // with the detail/upload views, revalidated on focus, and refetched after any
   // collection/tag mutation (the api layer invalidates the query cache).
@@ -129,47 +134,28 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
   // and send-to dialog; gated so non-admins don't fetch a list they can't use.
   const printers =
     usePrinters({ enabled: !!user?.is_superuser }).data ?? initial?.printers ?? [];
-  const [selectedCollection, setSelectedCollection] = useState<string | null>(null);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedPrinterId, setSelectedPrinterId] = useState<number | null>(null);
   const [selectedPrinterPresence, setSelectedPrinterPresence] = useState<"any" | "none" | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [uploadOpen, setUploadOpen] = useState(false);
-  const [loading, setLoading] = useState(!initial);
-  const [refreshing, setRefreshing] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(initial ? initial.models.length === PAGE_SIZE : false);
   const facetsLoading = collectionsQuery.isLoading || tagsQuery.isLoading;
-  const [error, setError] = useState<string | null>(null);
-  const [reloadKey, setReloadKey] = useState(0);
   const [isCreatingCollection, setIsCreatingCollection] = useState(false);
   const [newCollectionName, setNewCollectionName] = useState("");
-  const hasLoadedModels = useRef(!!initial);
-  // The server already rendered the first page with the current search query;
-  // skip the redundant client fetch on hydration.
-  const skipFirstFetch = useRef(!!initial);
   const { open: filterDrawerOpen, openDrawer, closeDrawer } = useMobileFilterDrawer();
 
   // Collection selection lives in the URL (`?c=<path>`) so it resets when the
   // user navigates away (e.g. to Settings) and clicks "Vault" again — that link
-  // points at "/" with no param. Without this, Next's router cache kept the
-  // component mounted and the old folder stuck around.
-  const collectionParam = searchParams.get("c");
+  // points at "/" with no param. Deriving it straight from the param (instead of
+  // mirroring into state) means a folder switch just re-keys the model query;
+  // `keepPreviousData` holds the old cards on screen until the new page lands, so
+  // there's no manual clearing or loading flash.
+  const selectedCollection = searchParams.get("c") || null;
   useEffect(() => {
-    const next = collectionParam || null;
-    if (next !== selectedCollection) {
-      // Clear stale models immediately so old cards don't flash for the 200 ms
-      // debounce window before the new collection loads.
-      setModels([]);
-      setLoading(true);
-      hasLoadedModels.current = false;
-      setSelectedCollection(next);
-    }
     // Remember the folder we're in so the logo / post-delete nav can return
     // here instead of resetting to the root once the `?c=` param is dropped.
-    rememberLastCollection(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [collectionParam]);
+    rememberLastCollection(selectedCollection);
+  }, [selectedCollection]);
 
   function handleCollectionChange(path: string | null) {
     const params = new URLSearchParams(searchParams.toString());
@@ -190,6 +176,54 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
   }, [searchParams, router]);
 
   const query = searchParams.get("q") ?? "";
+  const searchQuery = query.trim() || undefined;
+  const canViewPrinters = !!user?.is_superuser;
+  const queryClient = useQueryClient();
+
+  // Filters shared by the grid + outliner queries; only the search query and
+  // pagination differ between them.
+  const baseFilters: ModelListFilters = {
+    tag: selectedTags.length ? selectedTags : undefined,
+    printer_id: canViewPrinters ? selectedPrinterId ?? undefined : undefined,
+    printer_presence:
+      canViewPrinters && selectedPrinterId === null
+        ? selectedPrinterPresence ?? undefined
+        : undefined,
+  };
+  // The paginated grid. `keepPreviousData` (in the hook) holds the current page
+  // on screen while a new search/folder loads, and results are cached per filter
+  // set so backspacing a query or re-entering a folder is instant.
+  const modelQuery = useModelList(
+    {
+      ...baseFilters,
+      collection: selectedCollection ?? undefined,
+      // A search spans the whole library; a folder view lists only its direct
+      // children so subfolders' models don't leak into the parent (#30).
+      direct: !searchQuery,
+      q: searchQuery,
+    },
+    PAGE_SIZE,
+  );
+  const outlinerQuery = useOutlinerModels(baseFilters, 500);
+
+  const models = useMemo(
+    () => modelQuery.data?.pages.flat() ?? [],
+    [modelQuery.data],
+  );
+  const outlinerModels = outlinerQuery.data ?? [];
+  // First load shows skeletons; a filter change keeps the previous page visible
+  // and just flags `refreshing` for the subtle "Updating…" hint.
+  const loading = modelQuery.isLoading;
+  const refreshing = modelQuery.isFetching && !modelQuery.isFetchingNextPage && !loading;
+  const loadingMore = modelQuery.isFetchingNextPage;
+  const hasMore = modelQuery.hasNextPage ?? false;
+  const error = modelQuery.error ? (modelQuery.error as Error).message : null;
+  function loadMore() {
+    if (hasMore && !loadingMore) modelQuery.fetchNextPage();
+  }
+  function refresh() {
+    queryClient.invalidateQueries({ queryKey: queryKeys.models });
+  }
 
   const sortedModels = useMemo(() => sortModels(models, "date-desc"), [models]);
   // "All Models" is a folder explorer: at the root the grid shows collection
@@ -206,10 +240,19 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
   const showLibraryTotal =
     !selectedCollection && !hasActiveFilters && totalLibraryCount !== null;
   const displayCount = showLibraryTotal ? totalLibraryCount : models.length;
-  const visibleCollections = useMemo(
-    () => childCollections(collections, selectedCollection),
-    [collections, selectedCollection],
-  );
+  // While searching, the grid is a global result list, not a folder view: show
+  // only collections whose name matches the query (anywhere in the tree), to
+  // mirror the matching models. Without a query we fall back to the normal
+  // folder explorer (immediate children of the selected collection).
+  const visibleCollections = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    if (needle) {
+      return collections
+        .filter((c) => c.name.toLowerCase().includes(needle))
+        .sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return childCollections(collections, selectedCollection);
+  }, [collections, selectedCollection, query]);
   const breadcrumbs = useMemo(
     () => collectionBreadcrumbs(collections, selectedCollection),
     [collections, selectedCollection],
@@ -232,93 +275,8 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
     user?.is_superuser || canWriteCollection(selectedCollectionRow)
       ? selectedCollection
       : null;
-  const canViewPrinters = !!user?.is_superuser;
-  // Collections + tags are fetched by useCollections()/useTags() above.
-
-  // The outliner tree mirrors the active tag/printer filters so the collections
-  // sidebar narrows to matching models instead of always listing everything.
-  useEffect(() => {
-    let alive = true;
-    listModels({
-      limit: 500,
-      tag: selectedTags.length ? selectedTags : undefined,
-      printer_id: canViewPrinters ? selectedPrinterId ?? undefined : undefined,
-      printer_presence:
-        canViewPrinters && selectedPrinterId === null
-          ? selectedPrinterPresence ?? undefined
-          : undefined,
-    })
-      .then((data) => { if (alive) setOutlinerModels(data); })
-      .catch(() => {});
-    return () => { alive = false; };
-  }, [reloadKey, selectedTags, selectedPrinterId, selectedPrinterPresence, canViewPrinters]);
-
-  useEffect(() => {
-    if (skipFirstFetch.current) {
-      skipFirstFetch.current = false;
-      return;
-    }
-    let alive = true;
-    const handle = setTimeout(async () => {
-      if (hasLoadedModels.current) setRefreshing(true);
-      else setLoading(true);
-      try {
-        const searchQuery = query.trim() || undefined;
-        const data = await listModels({
-          limit: PAGE_SIZE,
-          offset: 0,
-          collection: selectedCollection ?? undefined,
-          direct: !searchQuery,
-          tag: selectedTags.length ? selectedTags : undefined,
-          q: searchQuery,
-          printer_id: canViewPrinters ? selectedPrinterId ?? undefined : undefined,
-          printer_presence:
-            canViewPrinters && selectedPrinterId === null
-              ? selectedPrinterPresence ?? undefined
-              : undefined,
-        });
-        if (!alive) return;
-        setModels(data);
-        setHasMore(data.length === PAGE_SIZE);
-        setError(null);
-        hasLoadedModels.current = true;
-      } catch (e: any) {
-        if (alive) setError(e.message);
-      } finally {
-        if (alive) { setLoading(false); setRefreshing(false); }
-      }
-    }, 200);
-    return () => { alive = false; clearTimeout(handle); };
-  }, [selectedCollection, selectedTags, selectedPrinterId, selectedPrinterPresence, query, reloadKey, canViewPrinters]);
-
-  async function loadMore() {
-    if (loadingMore || !hasMore) return;
-    setLoadingMore(true);
-    try {
-      const searchQuery = query.trim() || undefined;
-      const data = await listModels({
-        limit: PAGE_SIZE,
-        offset: models.length,
-        collection: selectedCollection ?? undefined,
-        direct: !searchQuery,
-        tag: selectedTags.length ? selectedTags : undefined,
-        q: searchQuery,
-        printer_id: canViewPrinters ? selectedPrinterId ?? undefined : undefined,
-        printer_presence:
-          canViewPrinters && selectedPrinterId === null
-            ? selectedPrinterPresence ?? undefined
-            : undefined,
-      });
-      setModels((prev) => [...prev, ...data]);
-      setHasMore(data.length === PAGE_SIZE);
-    } catch (e: any) {
-      setError(e.message);
-    } finally {
-      setLoadingMore(false);
-    }
-  }
-
-  function refresh() { setReloadKey((k) => k + 1); }
+  // Collections + tags are fetched by useCollections()/useTags() above; the
+  // model grid + outliner come from useModelList()/useOutlinerModels() above.
 
   async function handleCreateCollection() {
     const name = newCollectionName.trim();
@@ -337,7 +295,6 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
       setIsCreatingCollection(false);
       toast.success(`Collection "${name}" created`);
     } catch (e: any) {
-      setError(e.message);
       toast.error(e);
     }
   }
@@ -615,7 +572,7 @@ function CollectionFolderCard({ collection, onSelect }: { collection: Collection
     <button
       type="button"
       onClick={() => onSelect(collection.path)}
-      className="group flex flex-col text-left bg-muted border border-border rounded-lg hover:border-orange-500 dark:hover:border-orange-500 hover:shadow-sm transition-all relative overflow-hidden"
+      className="animate-card-in group flex flex-col text-left bg-muted border border-border rounded-lg hover:border-orange-500 dark:hover:border-orange-500 hover:shadow-sm transition-all relative overflow-hidden"
     >
       <div className="flex-1 flex items-center justify-center bg-muted/60 dark:bg-[var(--surface-container-high)] min-h-[140px]">
         <Folder className="w-16 h-16 text-blue-600/30 dark:text-orange-500/25" />

--- a/frontend/src/components/model-grid.tsx
+++ b/frontend/src/components/model-grid.tsx
@@ -28,6 +28,7 @@ import { useRequireAuth } from "@/lib/use-require-auth";
 import { useAuth } from "@/lib/auth-context";
 import { Link } from "@/lib/navigation";
 import { timeAgo } from "@/lib/format";
+import { rememberLastCollection } from "@/lib/last-collection";
 import { useAuthenticatedAssetUrl } from "@/lib/use-authenticated-asset-url";
 
 type SortKey = "date-desc" | "date-asc" | "name-asc" | "name-desc";
@@ -164,6 +165,9 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
       hasLoadedModels.current = false;
       setSelectedCollection(next);
     }
+    // Remember the folder we're in so the logo / post-delete nav can return
+    // here instead of resetting to the root once the `?c=` param is dropped.
+    rememberLastCollection(next);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collectionParam]);
 

--- a/frontend/src/components/top-bar.tsx
+++ b/frontend/src/components/top-bar.tsx
@@ -19,6 +19,7 @@ import {
   XCircle,
 } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
+import { lastVaultHref } from "@/lib/last-collection";
 import { BrandMark } from "@/components/brand-mark";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
@@ -107,6 +108,14 @@ export function TopBar() {
   const [profileOpen, setProfileOpen] = useState(false);
   const tasksRef = useRef<HTMLDivElement>(null);
   const profileRef = useRef<HTMLDivElement>(null);
+  // The logo returns to the model browser, restoring the last folder the user
+  // was in rather than always resetting to "All Models". Recomputed whenever the
+  // route changes (e.g. arriving on Settings) so it reflects the remembered
+  // collection at click time.
+  const [homeHref, setHomeHref] = useState("/");
+  useEffect(() => {
+    setHomeHref(lastVaultHref());
+  }, [pathname]);
 
   useEffect(() => {
     setTasks(listTasks());
@@ -132,7 +141,7 @@ export function TopBar() {
   return (
     <header className="h-16 bg-background border-b border-border flex items-center justify-between px-4 z-40 relative">
       {/* Logo */}
-      <Link href="/" className="flex items-center space-x-2 hover:opacity-80 transition-opacity">
+      <Link href={homeHref} className="flex items-center space-x-2 hover:opacity-80 transition-opacity">
         <div className="w-8 h-8 bg-blue-600 dark:bg-orange-600 rounded flex items-center justify-center flex-shrink-0">
           <BrandMark className="h-6 w-6 text-white" />
         </div>

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -178,6 +178,20 @@
   }
 }
 
+/* Cards settle in with a small fade + rise instead of appearing abruptly. Runs
+   once per mounted card (stable React keys), so it plays for a new folder /
+   search result / next page — not on every keystroke re-render. */
+@keyframes card-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* Thin styled scrollbars */
 ::-webkit-scrollbar {
   width: 4px;
@@ -210,7 +224,18 @@
     animation: slide-in-left 0.2s ease-out;
   }
 
+  .animate-card-in {
+    animation: card-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
   .pb-safe {
     padding-bottom: env(safe-area-inset-bottom, 8px);
+  }
+}
+
+/* Respect reduced-motion: keep the cards, drop the movement. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-card-in {
+    animation: none;
   }
 }

--- a/frontend/src/lib/__tests__/last-collection.test.ts
+++ b/frontend/src/lib/__tests__/last-collection.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  LAST_COLLECTION_STORAGE_KEY,
+  lastVaultHref,
+  readLastCollection,
+  rememberLastCollection,
+} from "@/lib/last-collection";
+
+afterEach(() => {
+  window.localStorage.removeItem(LAST_COLLECTION_STORAGE_KEY);
+});
+
+describe("last collection persistence", () => {
+  it("returns null and the root href when nothing is stored", () => {
+    expect(readLastCollection()).toBeNull();
+    expect(lastVaultHref()).toBe("/");
+  });
+
+  it("remembers a collection path and builds a restoring href", () => {
+    rememberLastCollection("spoolers");
+    expect(readLastCollection()).toBe("spoolers");
+    expect(lastVaultHref()).toBe("/?c=spoolers");
+  });
+
+  it("encodes paths with nesting and spaces", () => {
+    rememberLastCollection("spoolers/old prints");
+    expect(lastVaultHref()).toBe("/?c=spoolers%2Fold%20prints");
+  });
+
+  it("clears the remembered collection at the root", () => {
+    rememberLastCollection("spoolers");
+    rememberLastCollection(null);
+    expect(readLastCollection()).toBeNull();
+    expect(lastVaultHref()).toBe("/");
+  });
+});

--- a/frontend/src/lib/asset-cache.ts
+++ b/frontend/src/lib/asset-cache.ts
@@ -1,0 +1,88 @@
+import { getAuthenticatedBlob } from "@/lib/api";
+
+/**
+ * Session cache for authenticated asset blobs (thumbnails).
+ *
+ * Thumbnails are protected, so they're fetched with a bearer header and turned
+ * into object URLs (`URL.createObjectURL`). The old per-component hook re-fetched
+ * the blob on every mount and revoked the object URL on unmount, so scrolling a
+ * card out and back, paginating, or re-entering a folder paid for the same image
+ * again (even if only a cheap 304) and recreated its object URL — which is a big
+ * part of why the grid felt slow and the thumbnails "popped".
+ *
+ * This module keeps one object URL per asset path for the page session:
+ *  - In-flight fetches are deduped, so N cards sharing a thumbnail trigger one
+ *    request.
+ *  - Resolved object URLs are reused synchronously (`peekCachedAssetUrl`), so a
+ *    re-mount shows the image immediately instead of flashing empty.
+ *  - An LRU cap bounds memory; evicted URLs are revoked.
+ *
+ * Trade-off: a thumbnail that changes server-side mid-session (re-upload reusing
+ * a file id) stays cached until reload or an explicit `invalidateCachedAsset`.
+ * Acceptable for previews; call `invalidateCachedAsset` after a known change.
+ */
+
+// Bounds memory: each entry holds a decoded image blob alive via its object URL.
+// A few hundred small previews is a handful of MB — plenty for deep scrolling
+// without unbounded growth.
+const CACHE_LIMIT = 400;
+
+// Insertion order doubles as LRU order: re-reading a key deletes + re-sets it to
+// move it to the most-recent end.
+const urlCache = new Map<string, string>();
+const inflight = new Map<string, Promise<string>>();
+
+/** Synchronously return a cached object URL, or null if not resolved yet. */
+export function peekCachedAssetUrl(path: string): string | null {
+  const url = urlCache.get(path);
+  if (url === undefined) return null;
+  // Touch for LRU.
+  urlCache.delete(path);
+  urlCache.set(path, url);
+  return url;
+}
+
+/** Fetch (or reuse) the object URL for an authenticated asset path. */
+export function getCachedAssetUrl(path: string): Promise<string> {
+  const cached = peekCachedAssetUrl(path);
+  if (cached) return Promise.resolve(cached);
+
+  const pending = inflight.get(path);
+  if (pending) return pending;
+
+  const promise = getAuthenticatedBlob(path)
+    .then((blob) => {
+      const url = URL.createObjectURL(blob);
+      urlCache.set(path, url);
+      inflight.delete(path);
+      evictIfNeeded();
+      return url;
+    })
+    .catch((err) => {
+      inflight.delete(path);
+      throw err;
+    });
+
+  inflight.set(path, promise);
+  return promise;
+}
+
+/** Drop a single asset from the cache (e.g. after it was re-uploaded). */
+export function invalidateCachedAsset(path: string): void {
+  const url = urlCache.get(path);
+  if (url !== undefined) {
+    URL.revokeObjectURL(url);
+    urlCache.delete(path);
+  }
+  inflight.delete(path);
+}
+
+function evictIfNeeded(): void {
+  while (urlCache.size > CACHE_LIMIT) {
+    const oldest = urlCache.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    const url = urlCache.get(oldest);
+    urlCache.delete(oldest);
+    if (url !== undefined) URL.revokeObjectURL(url);
+  }
+}

--- a/frontend/src/lib/changelog.ts
+++ b/frontend/src/lib/changelog.ts
@@ -21,6 +21,16 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.7.2",
+    date: "Jun 2026",
+    changes: [
+      "Database migrations now run automatically when the app starts — there's no separate migration step, and editing or removing the Compose command can no longer skip them",
+      "Fresh installs and existing databases both come up cleanly on SQLite and PostgreSQL; a database that was once started without migrations is detected and adopted safely, without changing any data",
+      "Deleting a model now returns you to the folder you were browsing instead of jumping back to All Models",
+      "The PrintStash logo now takes you back to the collection you were in, rather than always to All Models",
+    ],
+  },
+  {
     version: "0.7.1",
     date: "Jun 2026",
     changes: [

--- a/frontend/src/lib/last-collection.ts
+++ b/frontend/src/lib/last-collection.ts
@@ -1,0 +1,34 @@
+// Remembers the last vault collection (folder) the user was browsing so the
+// PrintStash logo and post-delete navigation return there instead of resetting
+// to "All Models". Collection selection lives in the URL as `?c=<path>`, but
+// that param is dropped when the user navigates to Settings, a model, etc. —
+// persisting it here lets us restore the context on the way back.
+export const LAST_COLLECTION_STORAGE_KEY = "printstash.last.collection";
+
+/** Persist the current collection path (or clear it at the root). Best-effort. */
+export function rememberLastCollection(path: string | null): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (path) window.localStorage.setItem(LAST_COLLECTION_STORAGE_KEY, path);
+    else window.localStorage.removeItem(LAST_COLLECTION_STORAGE_KEY);
+  } catch {
+    // Storage unavailable (private mode / disabled) — context restore is a
+    // nicety, not a requirement, so silently skip it.
+  }
+}
+
+/** Read the remembered collection path, or null if none/unavailable. */
+export function readLastCollection(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(LAST_COLLECTION_STORAGE_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Home URL that restores the last collection, e.g. `/?c=spoolers` (or `/`). */
+export function lastVaultHref(): string {
+  const path = readLastCollection();
+  return path ? `/?c=${encodeURIComponent(path)}` : "/";
+}

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1,4 +1,8 @@
-import { useQuery } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  useQuery,
+} from "@tanstack/react-query";
 
 import {
   getPrintStatistics,
@@ -6,6 +10,7 @@ import {
   getVaultStats,
   listCollections,
   listFilamentProfiles,
+  listModels,
   listPrinterProfiles,
   listPrinters,
   listTags,
@@ -15,6 +20,8 @@ import { queryKeys } from "@/lib/query-client";
 import type {
   CollectionRead,
   FilamentProfileRead,
+  ListModelsParams,
+  ModelListItem,
   PrinterProfileRead,
   PrinterRead,
   PrintStatisticsRead,
@@ -99,5 +106,46 @@ export function useVaultConfig() {
   return useQuery<VaultConfigRead>({
     queryKey: queryKeys.vaultConfig,
     queryFn: () => getVaultConfig(),
+  });
+}
+
+/** Filters that key the model-list query (everything but pagination). */
+export type ModelListFilters = Omit<ListModelsParams, "limit" | "offset">;
+
+/**
+ * Paginated model grid, cached and keyed by its filters.
+ *
+ * Replaces the old hand-rolled `useEffect` + debounce + manual loading/`hasMore`
+ * bookkeeping. Two wins for search responsiveness:
+ *  - `placeholderData: keepPreviousData` keeps the current results on screen
+ *    while the next query loads, so typing/clearing a search no longer blanks
+ *    the grid (the "clunky" flash).
+ *  - Results are cached per filter set, so backspacing to a query you just ran
+ *    (or revisiting a folder) is instant instead of a fresh round-trip.
+ *
+ * Mutations invalidate `["models"]` via `invalidateQueriesForPath`, which by
+ * prefix-matching also busts every keyed list here.
+ */
+export function useModelList(filters: ModelListFilters, pageSize: number) {
+  return useInfiniteQuery<ModelListItem[]>({
+    queryKey: [...queryKeys.models, "list", filters],
+    queryFn: ({ pageParam }) =>
+      listModels({ ...filters, limit: pageSize, offset: pageParam as number }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === pageSize ? allPages.length * pageSize : undefined,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * Flat, unpaginated model list that feeds the outliner tree. Mirrors the active
+ * tag/printer filters but ignores the search query and pagination, so the tree
+ * keeps showing every matching leaf.
+ */
+export function useOutlinerModels(filters: ModelListFilters, limit: number) {
+  return useQuery<ModelListItem[]>({
+    queryKey: [...queryKeys.models, "outliner", filters, limit],
+    queryFn: () => listModels({ ...filters, limit }),
   });
 }

--- a/frontend/src/lib/use-authenticated-asset-url.ts
+++ b/frontend/src/lib/use-authenticated-asset-url.ts
@@ -2,30 +2,40 @@
 
 import { useEffect, useState } from "react";
 
-import { getAuthenticatedBlob } from "@/lib/api";
+import { getCachedAssetUrl, peekCachedAssetUrl } from "@/lib/asset-cache";
 
 export function useAuthenticatedAssetUrl(path: string | null | undefined): string | null {
-  const [url, setUrl] = useState<string | null>(null);
+  // Seed from the session cache so a thumbnail that's already been fetched shows
+  // instantly on re-mount (re-scroll, pagination, folder revisit) instead of
+  // flashing empty and fading in again.
+  const [url, setUrl] = useState<string | null>(() =>
+    path ? peekCachedAssetUrl(path) : null,
+  );
 
   useEffect(() => {
     let alive = true;
-    let objectUrl: string | null = null;
+    if (!path) {
+      setUrl(null);
+      return;
+    }
+    const cached = peekCachedAssetUrl(path);
+    if (cached) {
+      setUrl(cached);
+      return;
+    }
     setUrl(null);
-    if (!path) return;
-
-    getAuthenticatedBlob(path)
-      .then((blob) => {
-        if (!alive) return;
-        objectUrl = URL.createObjectURL(blob);
-        setUrl(objectUrl);
+    getCachedAssetUrl(path)
+      .then((resolved) => {
+        if (alive) setUrl(resolved);
       })
       .catch(() => {
         if (alive) setUrl(null);
       });
 
+    // Object URLs are owned by the cache (shared across components and reused
+    // across mounts), so we no longer revoke on unmount — the cache evicts.
     return () => {
       alive = false;
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [path]);
 

--- a/unraid/README.md
+++ b/unraid/README.md
@@ -37,7 +37,8 @@ From the `printstash-api` template:
   or point them wherever you keep app data.
 
 The template already:
-- runs database migrations on every start (`alembic upgrade head`), and
+- relies on the API image, which runs database migrations on every start
+  (`alembic upgrade head`) from its entrypoint — no command override needed, and
 - gives the container the network alias **`api`** so the frontend can reach it.
 
 > Install the API **before** the frontend — the frontend expects `api` to
@@ -154,6 +155,6 @@ Checklist before submitting on the CA submit page:
    (`curl -I <raw-url>` → `200`): the two `templates/*.xml`, `icon.svg`, and the
    `<ReadMe>`/`<Icon>` targets.
 
-Nice-to-have: provide a square **PNG** icon (CA prefers PNG over SVG), and
-consider baking `alembic upgrade head` into the API image entrypoint so the
-default command works without the Post Arguments override.
+Nice-to-have: provide a square **PNG** icon (CA prefers PNG over SVG). Migrations
+are now baked into the API image entrypoint (they run on every start, before the
+server), so the default command works without any Post Arguments override.


### PR DESCRIPTION
Release branch for **0.7.2**.

## 1. Automatic, engine-agnostic DB migrations (#29) — main feature
Migrations no longer depend on a fragile Compose `command:`, and now work on **both SQLite and PostgreSQL**.

- **Image entrypoint** (`docker-entrypoint.sh` + Dockerfile `ENTRYPOINT`) runs `python -m app.db.migrate` on every start, then execs the server. Runs however the container is launched; `set -e` fails startup *before* serving. Compose migration command removed.
- **`app/db/migrate.py`** dispatches by DB state:
  - **managed** (has `alembic_version`) → `upgrade head`
  - **orphan** (tables, no version — the #29 state) → `stamp head` + `upgrade` (adopts existing schema, no "table already exists", no data touched)
  - **fresh** (empty) → `create_all` from the models + `stamp head`, **skipping the SQLite-only baseline migration that fails on a fresh Postgres**
- **`init_db()`** skips `create_all` when the DB is Alembic-managed, so production never builds a divergent/un-stamped schema. Tests build schema via `create_all` directly, so they're unaffected.

### Validation (real engines, all states)
| State | SQLite | Postgres 16 |
|---|---|---|
| Fresh | ✅ | ✅ (was broken at baseline — now works) |
| Orphan | ✅ data preserved | ✅ data preserved |
| Managed / re-run | ✅ | ✅ |

Strict tests in `tests/test_migrations.py` (real migration chain against temp SQLite for every state + data preservation + dispatch logic proving a fresh DB never replays the baseline = the Postgres guarantee, no PG service needed in CI). Also verified against the maintainer's real running SQLite DB. **Full backend suite: 748 passed, 1 skipped; ruff clean.**

## 2. Collection navigation fixes (#30, web)
- Deleting a model returns to its collection (`/?c=<path>`), not All Models.
- The logo restores the last-browsed collection (localStorage) instead of hard-linking to `/`.

## 3. Migration troubleshooting docs (#29)
Upgrade guide + `UPGRADE.md` + Unraid notes: correct command is `uv run alembic upgrade head` (never `python -m alembic`), a data-safe `alembic stamp head` repair for orphan DBs, and a note that migrations are now automatic.

## 4. Main search + model grid UX (#34, web)
The top search bar listed **every folder** regardless of the query (the count updated but the matches were buried), so it looked broken.

- **Search scope:** searching now shows only collections **and** models whose names match the query, across the whole tree; no query falls back to the normal folder explorer.
- **Performance:** the grid moved off a hand-rolled `useEffect` + debounce onto a **TanStack `useInfiniteQuery`** with `keepPreviousData` — results stay on screen while a new search/folder loads and are cached per filter set, instead of refetching (and blanking) on every keystroke.
- **Thumbnail cache:** previews were re-fetched as auth blobs on every mount and revoked on unmount. They're now cached as **shared object URLs for the session** (LRU-bounded, in-flight deduped), so re-scrolling/revisiting a folder is instant.
- **Card load:** thumbnails fade in on load and cards animate in with a subtle fade+rise (respects `prefers-reduced-motion`) instead of popping in.

Frontend: typecheck clean, 144 tests pass; verified live against a 138-model library (thumbnail fade 0→0.9 over 300ms, cache reuse on folder revisit, search scoping).


## Release
Version bumped to **0.7.2** across `config.py`, `pyproject.toml`, `package.json`, `uv.lock`; changelogs updated (root `CHANGELOG.md` + in-app `changelog.ts`).

---
**Not in scope (pre-existing, tracked separately):** `alembic check` shows model↔migration drift. Its one practical consequence (fresh Postgres failing) is fixed here; full reconciliation is left for a later, careful pass.
