### PR TITLE
0.8.1

### DIFF
--- a/backend/app/api/v1/printers.py
+++ b/backend/app/api/v1/printers.py
@@ -37,6 +37,7 @@ from app.db.models import (
 )
 from app.db.session import get_session
 from app.schemas.printers import (
+    HomeAxes,
     MoonrakerConfigRead,
     PrinterCapabilities,
     PrinterCreate,
@@ -45,6 +46,7 @@ from app.schemas.printers import (
     PrinterUpdate,
     PrintJobRead,
     SendToPrinter,
+    SetTemperature,
     StartPrinterFile,
 )
 from app.services.printer_hub import (
@@ -789,6 +791,79 @@ async def cancel_printer(
     printer_id: int, session: Session = Depends(get_session)
 ) -> dict:
     return await _printer_control(printer_id, session, "cancel")
+
+
+def _require_gcode_provider(session: Session, printer_id: int):
+    p = get_or_404(session, Printer, printer_id, "printer_not_found")
+    if p.deleted_at is not None:
+        raise HTTPException(status_code=404, detail="printer_not_found")
+    provider = get_provider_client(p)
+    if not provider.capabilities.can_send_gcode:
+        raise HTTPException(
+            status_code=409, detail="operation_not_supported_for_provider"
+        )
+    return provider
+
+
+async def _run_gcode(provider, script: str) -> dict:
+    try:
+        await provider.run_gcode(script)
+    except ProviderError as exc:
+        raise HTTPException(status_code=502, detail=exc.code)
+    except Exception:
+        logger.error("printer gcode failed script=%s", script)
+        raise HTTPException(status_code=502, detail="provider_error")
+    return {"ok": True}
+
+
+@router.post(
+    "/{printer_id}/temperature",
+    dependencies=[Depends(require_superuser)],
+    summary="Set a heater target temperature",
+)
+async def set_printer_temperature(
+    printer_id: int,
+    payload: SetTemperature,
+    session: Session = Depends(get_session),
+) -> dict:
+    provider = _require_gcode_provider(session, printer_id)
+    code = "M104" if payload.heater == "extruder" else "M140"
+    return await _run_gcode(provider, f"{code} S{payload.target:g}")
+
+
+@router.post(
+    "/{printer_id}/home",
+    dependencies=[Depends(require_superuser)],
+    summary="Home the toolhead (all axes, or a subset)",
+)
+async def home_printer(
+    printer_id: int,
+    payload: HomeAxes,
+    session: Session = Depends(get_session),
+) -> dict:
+    provider = _require_gcode_provider(session, printer_id)
+    script = "G28" if not payload.axes else "G28 " + " ".join(payload.axes.upper())
+    return await _run_gcode(provider, script)
+
+
+@router.post(
+    "/{printer_id}/emergency_stop",
+    dependencies=[Depends(require_superuser)],
+    summary="Immediately halt the printer (Klipper emergency stop)",
+)
+async def emergency_stop_printer(
+    printer_id: int,
+    session: Session = Depends(get_session),
+) -> dict:
+    provider = _require_gcode_provider(session, printer_id)
+    try:
+        await provider.emergency_stop()
+    except ProviderError as exc:
+        raise HTTPException(status_code=502, detail=exc.code)
+    except Exception:
+        logger.error("printer emergency_stop failed printer=%s", printer_id)
+        raise HTTPException(status_code=502, detail="provider_error")
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/schemas/printers.py
+++ b/backend/app/schemas/printers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -30,6 +30,7 @@ class PrinterCapabilities(BaseModel):
     can_live_status: bool
     can_upload: bool
     can_list_files: bool = False
+    can_send_gcode: bool = False
     support_level: str = "stable"
     support_notes: list[str] = Field(default_factory=list)
     unsupported_actions: list[str] = Field(default_factory=list)
@@ -134,6 +135,34 @@ class StartPrinterFile(BaseModel):
         cleaned = validate_remote_filename_value(value)
         if not cleaned:
             raise ValueError("remote_filename_invalid")
+        return cleaned
+
+
+class SetTemperature(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    heater: Literal["extruder", "bed"]
+    # Sanity caps only — Klipper enforces each heater's real ``max_temp`` and
+    # rejects out-of-range targets. This just stops obvious typos.
+    target: float = Field(ge=0, le=500)
+
+
+class HomeAxes(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Empty/None homes all axes (G28). Otherwise a subset like "xy".
+    axes: Optional[str] = Field(default=None, max_length=3)
+
+    @field_validator("axes")
+    @classmethod
+    def validate_axes(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        cleaned = value.strip().lower()
+        if not cleaned:
+            return None
+        if any(c not in "xyz" for c in cleaned) or len(set(cleaned)) != len(cleaned):
+            raise ValueError("axes_invalid")
         return cleaned
 
 

--- a/backend/app/services/mesh_render.py
+++ b/backend/app/services/mesh_render.py
@@ -222,58 +222,69 @@ def render_mesh_thumbnail(
         def _normalise(v: "np.ndarray") -> "np.ndarray":
             return v / np.linalg.norm(v)
 
+        # Model albedo: the blue-grey surface colour, baked into the light terms
+        # below (not the rasteriser's per-pixel multiply, which is now pure white —
+        # see `base_color`). Folding albedo into shading lets the specular and rim
+        # add *white* highlights on top of the tinted body, so curved surfaces get
+        # a bright sheen that reads on the dark card instead of clipping at a dim
+        # blue-grey ceiling. Slightly lighter + less saturated than the old base so
+        # the model pops against a near-black background.
+        albedo = np.array([0.70, 0.75, 0.84])
+
         # Key light: main illumination, upper-left and well in front of the
-        # camera so the lit side reads as one clean gradient.
+        # camera so the lit side reads as one clean gradient. Strength >1 so the
+        # directly-lit side drives toward white — the gradient has real range now.
         key_dir = _normalise(np.array([-0.5, 0.65, 1.0]))
         key_color = np.array([1.00, 0.98, 0.95])  # warm white
-        key_str = 0.85
+        key_str = 1.05
 
         # Fill light: opposite side, soft and cool. Kept gentle so it only lifts
         # the shadow side and never forms a second highlight — competing
         # directional highlights are what made smooth surfaces look muddy/blotchy.
         fill_dir = _normalise(np.array([0.55, -0.25, 0.55]))
         fill_color = np.array([0.55, 0.62, 0.78])  # cool blue-grey
-        fill_str = 0.26
+        fill_str = 0.30
 
         # Rim: a view-based Fresnel edge light (brightens the silhouette where the
-        # surface turns away from the camera). Derived from the view normal's Z in
-        # the shading pass — a real edge light, not a third directional lamp aimed
-        # across the front, which previously smeared bright patches into the form.
+        # surface turns away from the camera). Additive white, so it lifts the
+        # silhouette off the dark card rather than darkening into it.
         rim_color = np.array([0.85, 0.92, 1.00])  # near-white, slightly cool
-        rim_str = 0.18
+        rim_str = 0.22
         rim_power = 3.0
 
-        # Ambient: blue-grey floor. Lifted a touch so curved faces turned away
-        # from the key don't crush into a muddy near-black blotch (the headphone
-        # arm), while still dark enough to read as 3D form rather than a wash.
-        ambient_color = np.array([0.14, 0.155, 0.185])
+        # Ambient: blue-grey floor tied to the albedo so shadowed faces stay a
+        # dark version of the body colour (never crushed to muddy near-black, never
+        # a flat grey wash). Lifted enough that curved faces turned away from the
+        # key still read as form against the dark card.
+        ambient_str = 0.30
 
-        # Blinn-Phong specular off the key light — a subtle sheen that picks out
-        # ridges, like the 3D viewer. Kept gentle: a strong spec sparkles facet to
-        # facet on tessellated curves. Camera is on +Z in view-space, so the
-        # half-vector is between key_dir and (0,0,1).
+        # Blinn-Phong specular off the key light — an additive *white* sheen that
+        # picks out ridges, like the 3D viewer. Kept gentle: a strong spec sparkles
+        # facet to facet on tessellated curves. Camera is on +Z in view-space, so
+        # the half-vector is between key_dir and (0,0,1).
         half = _normalise(key_dir + np.array([0.0, 0.0, 1.0]))
-        spec_str = 0.16
+        spec_str = 0.22
         spec_power = 32.0
 
         def _shade(n: "np.ndarray") -> "np.ndarray":
             # Per-fragment (Phong) shading from a view-space unit normal of any
-            # leading shape (..., 3). Same lamp rig as before, but evaluated after
-            # the normal is interpolated across the triangle in the rasteriser —
-            # lighting *colour* per vertex (Gouraud) made triangle edges and the
-            # many-triangle "poles" show up as banding and radial fan streaks;
-            # shading per pixel removes them.
+            # leading shape (..., 3), returning absolute linear colour in [0, 1]
+            # (the rasteriser scales by white). Diffuse terms are tinted by the
+            # albedo; rim and specular add white on top so highlights brighten the
+            # body toward white instead of clipping at the albedo. Evaluated per
+            # pixel after the normal is interpolated across the triangle — per-
+            # vertex (Gouraud) colour made triangle edges and many-triangle "poles"
+            # show as banding and radial fan streaks; per-pixel shading removes them.
             diff_k = np.clip(n @ key_dir, 0.0, 1.0)[..., None]
             diff_f = np.clip(n @ fill_dir, 0.0, 1.0)[..., None]
             fres = (1.0 - np.clip(n[..., 2:3], 0.0, 1.0)) ** rim_power
             spec = np.clip(n @ half, 0.0, 1.0)[..., None] ** spec_power
-            rgb = (
-                ambient_color
+            diffuse = (
+                ambient_str
                 + key_str * diff_k * key_color
                 + fill_str * diff_f * fill_color
-                + rim_str * fres * rim_color
-                + spec_str * spec
-            )
+            ) * albedo
+            rgb = diffuse + rim_str * fres * rim_color + spec_str * spec
             return np.clip(rgb, 0.0, 1.0)
 
         # ------------------------------------------------------------------
@@ -281,9 +292,10 @@ def render_mesh_thumbnail(
         #    a time into the shared image/z-buffer. The z-buffer makes chunk order
         #    irrelevant, so the result is identical to a single-pass render.
         # ------------------------------------------------------------------
-        # Model colour: a mid blue-grey. Darker than before so the lit gradient
-        # has room to breathe instead of clipping to a pale wash.
-        base_color = np.array([150, 168, 192], dtype=np.float32)
+        # The albedo now lives in `_shade` (so highlights can add white on top),
+        # so the rasteriser multiply is pure white — it just scales the absolute
+        # [0, 1] colour `_shade` returns up to 8-bit.
+        base_color = np.array([255, 255, 255], dtype=np.float32)
 
         # Transparent background — floats cleanly on any card colour.
         img = np.zeros((ss_height, ss_width, 3), dtype=np.uint8)
@@ -360,7 +372,7 @@ def render_mesh_thumbnail(
             logger.warning(
                 "mesh_render: no visible triangles for %s — using silhouette", name
             )
-            flat_color = np.clip(ambient_color + 0.4, 0.0, 1.0)
+            flat_color = albedo * 0.6
 
             def _flat_shade(n: "np.ndarray", _c=flat_color) -> "np.ndarray":
                 return np.broadcast_to(_c, n.shape)

--- a/backend/app/services/moonraker.py
+++ b/backend/app/services/moonraker.py
@@ -144,6 +144,14 @@ class MoonrakerClient:
     async def cancel_print(self) -> Dict[str, Any]:
         return await self._request("POST", "/printer/print/cancel")
 
+    async def run_gcode(self, script: str) -> Dict[str, Any]:
+        return await self._request(
+            "POST", "/printer/gcode/script", params={"script": script}
+        )
+
+    async def emergency_stop(self) -> Dict[str, Any]:
+        return await self._request("POST", "/printer/emergency_stop")
+
     async def get_print_history(self, limit: int = 50) -> list[Dict[str, Any]]:
         data = await self._request(
             "GET", "/server/history/list", params={"limit": limit}

--- a/backend/app/services/printer_provider.py
+++ b/backend/app/services/printer_provider.py
@@ -35,6 +35,7 @@ class ProviderCapabilities:
     can_live_status: bool
     can_upload: bool
     can_list_files: bool = False
+    can_send_gcode: bool = False
     support_level: str = "stable"
     support_notes: tuple[str, ...] = ()
     unsupported_actions: tuple[str, ...] = ()
@@ -65,6 +66,10 @@ class PrinterProviderClient(Protocol):
 
     async def cancel(self) -> dict[str, Any]: ...
 
+    async def run_gcode(self, script: str) -> dict[str, Any]: ...
+
+    async def emergency_stop(self) -> dict[str, Any]: ...
+
     async def subscribe_status(
         self,
         on_status: Callable[[dict[str, Any]], Awaitable[None]],
@@ -82,6 +87,7 @@ class MoonrakerProvider:
         can_live_status=True,
         can_upload=True,
         can_list_files=True,
+        can_send_gcode=True,
         support_level="stable",
     )
 
@@ -153,6 +159,18 @@ class MoonrakerProvider:
     async def cancel(self) -> dict[str, Any]:
         try:
             return await self.client.cancel_print()
+        except MoonrakerError as exc:
+            raise ProviderError(str(exc), code="provider_transport_error") from exc
+
+    async def run_gcode(self, script: str) -> dict[str, Any]:
+        try:
+            return await self.client.run_gcode(script)
+        except MoonrakerError as exc:
+            raise ProviderError(str(exc), code="provider_transport_error") from exc
+
+    async def emergency_stop(self) -> dict[str, Any]:
+        try:
+            return await self.client.emergency_stop()
         except MoonrakerError as exc:
             raise ProviderError(str(exc), code="provider_transport_error") from exc
 
@@ -324,6 +342,18 @@ class BambuLanProvider:
             {"print": {"sequence_id": "0", "command": "stop"}}
         )
 
+    async def run_gcode(self, script: str) -> dict[str, Any]:
+        raise ProviderError(
+            "operation_not_supported_for_provider",
+            code="operation_not_supported_for_provider",
+        )
+
+    async def emergency_stop(self) -> dict[str, Any]:
+        raise ProviderError(
+            "operation_not_supported_for_provider",
+            code="operation_not_supported_for_provider",
+        )
+
     async def subscribe_status(
         self,
         on_status: Callable[[dict[str, Any]], Awaitable[None]],
@@ -369,6 +399,7 @@ def provider_diagnostic_summary(provider: PrinterProvider) -> dict[str, object]:
             "can_live_status": caps.can_live_status,
             "can_upload": caps.can_upload,
             "can_list_files": caps.can_list_files,
+            "can_send_gcode": caps.can_send_gcode,
         },
         "unsupported_actions": list(caps.unsupported_actions),
         "notes": list(caps.support_notes),

--- a/backend/tests/test_printers_api.py
+++ b/backend/tests/test_printers_api.py
@@ -19,6 +19,7 @@ from app.db.models import (
     PrintJobState,
     Printer,
     PrinterFile,
+    PrinterProvider,
     PrinterStatus,
     User,
 )
@@ -245,6 +246,89 @@ class TestPrinterControl:
             resp = client.post(f"/api/v1/printers/{p.id}/cancel", headers=auth_headers)
             assert resp.status_code == 200
             assert resp.json() == {"ok": True}
+
+    def test_set_temperature_builds_gcode(
+        self, client: TestClient, auth_headers, db_session: Session
+    ):
+        p = Printer(name="Ender 3", moonraker_url="http://10.0.0.1:7125")
+        db_session.add(p)
+        db_session.commit()
+        db_session.refresh(p)
+
+        with patch(
+            "app.services.printer_provider.MoonrakerProvider.run_gcode",
+            new_callable=AsyncMock,
+        ) as mock_gcode:
+            mock_gcode.return_value = {"result": "ok"}
+            resp = client.post(
+                f"/api/v1/printers/{p.id}/temperature",
+                json={"heater": "bed", "target": 60},
+                headers=auth_headers,
+            )
+            assert resp.status_code == 200
+            mock_gcode.assert_called_once_with("M140 S60")
+
+    def test_home_subset_axes_builds_gcode(
+        self, client: TestClient, auth_headers, db_session: Session
+    ):
+        p = Printer(name="Ender 3", moonraker_url="http://10.0.0.1:7125")
+        db_session.add(p)
+        db_session.commit()
+        db_session.refresh(p)
+
+        with patch(
+            "app.services.printer_provider.MoonrakerProvider.run_gcode",
+            new_callable=AsyncMock,
+        ) as mock_gcode:
+            mock_gcode.return_value = {"result": "ok"}
+            resp = client.post(
+                f"/api/v1/printers/{p.id}/home",
+                json={"axes": "xy"},
+                headers=auth_headers,
+            )
+            assert resp.status_code == 200
+            mock_gcode.assert_called_once_with("G28 X Y")
+
+    def test_emergency_stop_calls_provider(
+        self, client: TestClient, auth_headers, db_session: Session
+    ):
+        p = Printer(name="Ender 3", moonraker_url="http://10.0.0.1:7125")
+        db_session.add(p)
+        db_session.commit()
+        db_session.refresh(p)
+
+        with patch(
+            "app.services.printer_provider.MoonrakerProvider.emergency_stop",
+            new_callable=AsyncMock,
+        ) as mock_estop:
+            mock_estop.return_value = {"result": "ok"}
+            resp = client.post(
+                f"/api/v1/printers/{p.id}/emergency_stop", headers=auth_headers
+            )
+            assert resp.status_code == 200
+            mock_estop.assert_called_once()
+
+    def test_set_temperature_rejected_for_bambu(
+        self, client: TestClient, auth_headers, db_session: Session
+    ):
+        p = Printer(
+            name="Bambu",
+            provider=PrinterProvider.BAMBU_LAN,
+            moonraker_url="",
+            bambu_host="192.168.1.50",
+            bambu_serial="SN123",
+            bambu_access_code="access",
+        )
+        db_session.add(p)
+        db_session.commit()
+        db_session.refresh(p)
+
+        resp = client.post(
+            f"/api/v1/printers/{p.id}/temperature",
+            json={"heater": "extruder", "target": 200},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 409
 
 
 class TestBambuPrinter:

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -47,7 +47,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         children
       ) : (
         <MobileFilterProvider>
-          <div className="flex flex-col h-screen overflow-hidden">
+          <div className="flex flex-col h-dvh overflow-hidden">
             <TopBar />
             <AuthBanner />
             <div className="flex flex-1 min-h-0 overflow-hidden">

--- a/frontend/src/components/model-detail/index.tsx
+++ b/frontend/src/components/model-detail/index.tsx
@@ -488,7 +488,7 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
 
       {/* Two-Column Layout. On mobile the panels stack and the whole area
           scrolls; on desktop each pane keeps its own fixed height. */}
-      <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-y-auto md:overflow-hidden">
+      <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-y-auto md:overflow-hidden pb-24 md:pb-0">
         {/* Left: 3D Model Preview */}
         <div className="flex-1 min-h-[250px] md:min-h-0 bg-[var(--surface-container-low)] relative border-b md:border-b-0 md:border-r border-[var(--outline-variant)] flex items-center justify-center m-2 md:m-4 rounded overflow-hidden"
           style={{ boxShadow: "inset 0 0 0 1px var(--surface-variant)" }}>

--- a/frontend/src/components/model-detail/index.tsx
+++ b/frontend/src/components/model-detail/index.tsx
@@ -486,8 +486,9 @@ export function ModelDetail({ model: initialModel }: { model: ModelRead }) {
         </div>
       </header>
 
-      {/* Two-Column Layout */}
-      <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-hidden md:overflow-hidden">
+      {/* Two-Column Layout. On mobile the panels stack and the whole area
+          scrolls; on desktop each pane keeps its own fixed height. */}
+      <div className="flex-1 flex flex-col md:flex-row min-h-0 overflow-y-auto md:overflow-hidden">
         {/* Left: 3D Model Preview */}
         <div className="flex-1 min-h-[250px] md:min-h-0 bg-[var(--surface-container-low)] relative border-b md:border-b-0 md:border-r border-[var(--outline-variant)] flex items-center justify-center m-2 md:m-4 rounded overflow-hidden"
           style={{ boxShadow: "inset 0 0 0 1px var(--surface-variant)" }}>

--- a/frontend/src/components/model-grid.tsx
+++ b/frontend/src/components/model-grid.tsx
@@ -449,7 +449,7 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
         loading={facetsLoading}
       />
 
-      <main className="flex-1 overflow-y-auto bg-background flex flex-col">
+      <main className="flex-1 overflow-y-auto bg-background flex flex-col pb-24 md:pb-0">
         {/* Breadcrumb */}
         <nav className="px-4 sm:px-6 py-3 bg-background border-b border-border flex items-center space-x-2 text-sm tracking-tight">
           {selectedCollection && breadcrumbs.length > 0 ? (

--- a/frontend/src/components/printer-detail.tsx
+++ b/frontend/src/components/printer-detail.tsx
@@ -14,14 +14,17 @@ import {
 import {
   cancelPrinter,
   deletePrinterFile,
+  emergencyStopPrinter,
   getMoonrakerConfig,
   getPrinterDiagnostics,
   getPrinter,
+  homePrinter,
   listPrinterFiles,
   listPrinterJobs,
   openPrinterWS,
   pausePrinter,
   resumePrinter,
+  setPrinterTemperature,
   startPrinterFile,
   syncPrinterFiles,
 } from "@/lib/api";
@@ -35,8 +38,10 @@ import {
   FileText,
   Info,
   Loader2,
+  Home,
   Pause,
   Play,
+  Power,
   Square,
   RefreshCcw,
   Settings,
@@ -46,6 +51,12 @@ import {
   WifiOff,
   XCircle,
 } from "lucide-react";
+
+const PREHEAT_PRESETS: { name: string; hotend: number; bed: number }[] = [
+  { name: "PLA", hotend: 200, bed: 60 },
+  { name: "PETG", hotend: 240, bed: 80 },
+  { name: "ABS", hotend: 245, bed: 100 },
+];
 
 const STATUS_COLORS: Record<PrinterStatus, string> = {
   ready: "bg-emerald-500",
@@ -115,6 +126,9 @@ export function PrinterDetailPage({
   const [wsConnected, setWsConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState<"pause" | "resume" | "cancel" | null>(null);
+  const [machineBusy, setMachineBusy] = useState<string | null>(null);
+  const [hotendTarget, setHotendTarget] = useState("");
+  const [bedTarget, setBedTarget] = useState("");
   const [activeTab, setActiveTab] = useState<"status" | "files" | "jobs" | "config" | "diagnostics">("status");
   const [startingFileId, setStartingFileId] = useState<number | null>(null);
   const [deletingFileId, setDeletingFileId] = useState<number | null>(null);
@@ -229,6 +243,72 @@ export function PrinterDetailPage({
     } finally {
       setBusy(null);
     }
+  }
+
+  async function machineAction(
+    key: string,
+    fn: () => Promise<unknown>,
+    successMsg: string,
+  ) {
+    if (!auth.isAuthenticated) { auth.showAuthRequiredToast(); return; }
+    setMachineBusy(key);
+    try {
+      await fn();
+      toast.success(successMsg);
+    } catch (e) {
+      toast.error(e);
+    } finally {
+      setMachineBusy(null);
+    }
+  }
+
+  function applyTemp(heater: "extruder" | "bed", raw: string, clear: () => void) {
+    const t = Number(raw);
+    if (!Number.isFinite(t) || t < 0 || t > 500) {
+      toast.error("Enter a temperature between 0 and 500.");
+      return;
+    }
+    void machineAction(
+      `set-${heater}`,
+      () => setPrinterTemperature(printerId, heater, t).then(clear),
+      `${heater === "extruder" ? "Hotend" : "Bed"} set to ${t}°C`,
+    );
+  }
+
+  function preheat(p: (typeof PREHEAT_PRESETS)[number]) {
+    void machineAction(
+      `preheat-${p.name}`,
+      async () => {
+        await setPrinterTemperature(printerId, "extruder", p.hotend);
+        await setPrinterTemperature(printerId, "bed", p.bed);
+      },
+      `Preheating for ${p.name}`,
+    );
+  }
+
+  function cooldown() {
+    void machineAction(
+      "cooldown",
+      async () => {
+        await setPrinterTemperature(printerId, "extruder", 0);
+        await setPrinterTemperature(printerId, "bed", 0);
+      },
+      "Cooling down",
+    );
+  }
+
+  function emergencyStop() {
+    if (
+      !window.confirm(
+        "Emergency stop halts the printer immediately and requires a firmware restart. Continue?",
+      )
+    )
+      return;
+    void machineAction(
+      "estop",
+      () => emergencyStopPrinter(printerId),
+      "Emergency stop sent",
+    );
   }
 
   async function syncFiles() {
@@ -490,6 +570,96 @@ export function PrinterDetailPage({
           <div className="p-6 space-y-5">
             <TempRow label="Hotend" cur={ext.temperature} tgt={ext.target} />
             <TempRow label="Bed" cur={bed.temperature} tgt={bed.target} />
+
+            {printer.capabilities.can_send_gcode && (
+              <div className="border-t border-border pt-4 space-y-4">
+                <div className="space-y-2">
+                  <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+                    Preheat
+                  </span>
+                  <div className="flex flex-wrap gap-2">
+                    {PREHEAT_PRESETS.map((p) => (
+                      <button
+                        key={p.name}
+                        onClick={() => preheat(p)}
+                        disabled={!auth.isAuthenticated || machineBusy !== null}
+                        title={`Hotend ${p.hotend}°C · Bed ${p.bed}°C`}
+                        className={BTN_SECONDARY}
+                      >
+                        {machineBusy === `preheat-${p.name}` && (
+                          <Loader2 className="h-3 w-3 animate-spin" />
+                        )}
+                        {p.name}
+                      </button>
+                    ))}
+                    <button
+                      onClick={cooldown}
+                      disabled={!auth.isAuthenticated || machineBusy !== null}
+                      className={BTN_SECONDARY}
+                    >
+                      {machineBusy === "cooldown" && (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      )}
+                      Cooldown
+                    </button>
+                  </div>
+                </div>
+
+                <SetTempInput
+                  label="Hotend target"
+                  value={hotendTarget}
+                  onChange={setHotendTarget}
+                  onApply={() =>
+                    applyTemp("extruder", hotendTarget, () => setHotendTarget(""))
+                  }
+                  busy={machineBusy === "set-extruder"}
+                  disabled={!auth.isAuthenticated || machineBusy !== null}
+                />
+                <SetTempInput
+                  label="Bed target"
+                  value={bedTarget}
+                  onChange={setBedTarget}
+                  onApply={() =>
+                    applyTemp("bed", bedTarget, () => setBedTarget(""))
+                  }
+                  busy={machineBusy === "set-bed"}
+                  disabled={!auth.isAuthenticated || machineBusy !== null}
+                />
+
+                <div className="border-t border-border pt-4 flex flex-wrap gap-2">
+                  <button
+                    onClick={() =>
+                      void machineAction(
+                        "home",
+                        () => homePrinter(printerId),
+                        "Homing all axes",
+                      )
+                    }
+                    disabled={!auth.isAuthenticated || machineBusy !== null}
+                    className={BTN_SECONDARY}
+                  >
+                    {machineBusy === "home" ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Home className="h-3.5 w-3.5" />
+                    )}
+                    Home all
+                  </button>
+                  <button
+                    onClick={emergencyStop}
+                    disabled={!auth.isAuthenticated || machineBusy !== null}
+                    className={BTN_DANGER}
+                  >
+                    {machineBusy === "estop" ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Power className="h-3.5 w-3.5" />
+                    )}
+                    E-stop
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         </section>
       </div>
@@ -1063,6 +1233,52 @@ function ControlButton({
       )}
       {label}
     </button>
+  );
+}
+
+function SetTempInput({
+  label,
+  value,
+  onChange,
+  onApply,
+  busy,
+  disabled,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  onApply: () => void;
+  busy?: boolean;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-end gap-2">
+      <label className="flex-1 space-y-1">
+        <span className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+        <input
+          type="number"
+          min={0}
+          max={500}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !disabled) onApply();
+          }}
+          placeholder="°C"
+          className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 font-mono text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-blue-600 dark:focus:ring-orange-500"
+        />
+      </label>
+      <button
+        onClick={onApply}
+        disabled={disabled || value === ""}
+        className={BTN_SECONDARY}
+      >
+        {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+        Set
+      </button>
+    </div>
   );
 }
 

--- a/frontend/src/lib/api/printers.ts
+++ b/frontend/src/lib/api/printers.ts
@@ -113,6 +113,25 @@ export function cancelPrinter(id: number): Promise<void> {
   return printerControl(id, "cancel");
 }
 
+export function setPrinterTemperature(
+  id: number,
+  heater: "extruder" | "bed",
+  target: number,
+): Promise<void> {
+  return sendJson(`/api/v1/printers/${id}/temperature`, "POST", {
+    heater,
+    target,
+  });
+}
+
+export function homePrinter(id: number, axes?: string): Promise<void> {
+  return sendJson(`/api/v1/printers/${id}/home`, "POST", { axes: axes ?? null });
+}
+
+export function emergencyStopPrinter(id: number): Promise<void> {
+  return sendAction(`/api/v1/printers/${id}/emergency_stop`, "POST");
+}
+
 export function getPrinterStatus(id: number): Promise<PrinterStatusResponse> {
   // One-shot live snapshot — always fetch fresh.
   return getJson<PrinterStatusResponse>(`/api/v1/printers/${id}/status`, {

--- a/frontend/src/pages/document-detail.tsx
+++ b/frontend/src/pages/document-detail.tsx
@@ -248,7 +248,7 @@ export default function DocumentDetailPage() {
           )}
         </div>
 
-        <div className="flex-1 min-h-0 overflow-auto">
+        <div className="flex-1 min-h-0 overflow-auto pb-24 md:pb-0">
         {/* Markdown: edit or preview */}
         {isMarkdown &&
           (mode === "edit" ? (

--- a/frontend/src/pages/printer-detail.tsx
+++ b/frontend/src/pages/printer-detail.tsx
@@ -8,7 +8,7 @@ export default function PrinterDetailRoute() {
   const printerId = Number(id);
   if (!id || Number.isNaN(printerId)) return <NotFound />;
   return (
-    <div className="h-full overflow-y-auto p-6">
+    <div className="h-full overflow-y-auto p-6 pb-24 md:pb-6">
       <PrinterDetailPage printerId={printerId} initialPrinter={undefined} />
     </div>
   );

--- a/frontend/src/types/printers.ts
+++ b/frontend/src/types/printers.ts
@@ -45,6 +45,7 @@ export interface PrinterCapabilities {
   can_live_status: boolean;
   can_upload: boolean;
   can_list_files: boolean;
+  can_send_gcode: boolean;
   support_level: "stable" | "beta" | string;
   support_notes: string[];
   unsupported_actions: string[];
@@ -69,6 +70,7 @@ export interface PrinterDiagnostics {
     can_cancel: boolean;
     can_live_status: boolean;
     can_list_files: boolean;
+    can_send_gcode: boolean;
   };
   unsupported_actions: string[];
   notes: string[];


### PR DESCRIPTION
Release branch for 0.8.1.

## Printer controls (this change)
Adds gcode-backed printer controls to the status tab, behind a new `can_send_gcode` capability (Moonraker only; hidden for Bambu LAN).

- Provider: `run_gcode` + `emergency_stop` passthrough on the Moonraker client/provider; Bambu reports the action unsupported.
- Endpoints: `POST /{id}/temperature` (`M104`/`M140`), `POST /{id}/home` (`G28 [axes]`), `POST /{id}/emergency_stop`.
- UI: editable hotend/bed targets, PLA/PETG/ABS preheat + cooldown presets, "Home all", and a confirm-guarded "E-stop".
- Tests: 4 new API tests (gcode-string building, axis subset, e-stop call, Bambu 409).

## Also on this branch
- fix(thumbnails): brighter, higher-contrast mesh lighting on dark theme
- fix(mobile): use dvh so pages scroll fully under the browser chrome

## Verification
- Backend: 838 passed, 1 skipped
- Frontend: production build clean, `tsc` + eslint clean
- Not yet smoke-tested against real printer hardware

No schema/migration changes — capabilities are computed, not stored.