### PR TITLE
0.8.3 — fix: repair blob census in GC and backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.8.3
+
+**Upgrade immediately if you use Documents.**
+
+### Fixed
+
+- **Hourly cleanup could delete document files.** The background job that
+  removes unreferenced files only recognised model files as "in use", so
+  uploaded documents (PDFs and other binaries) were treated as leftovers and
+  deleted. Only local storage was affected; S3/R2 installs were not. Documents
+  deleted by an earlier version cannot be recovered by upgrading — restore them
+  from a backup taken before the loss, if you have one.
+- **Backups omitted document files.** For the same reason, document blobs were
+  never written into the backup archive, so restoring a backup silently lost
+  them. New backups include them.
+- **S3/R2 existence checks hid errors.** A credentials or permissions failure
+  was reported as "this file does not exist" instead of raising. Combined with
+  the cleanup job, a transient auth error could have been read as "every file
+  is unreferenced".
+
 ## 0.8.2
 
 ### Added

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -164,7 +164,7 @@ class Settings(BaseSettings):
     backup_s3_secret_key: str = ""
 
     app_name: str = "PrintStash"
-    app_version: str = "0.8.2"
+    app_version: str = "0.8.3"
 
     @property
     def incoming_dir(self) -> Path:

--- a/backend/app/services/backup.py
+++ b/backend/app/services/backup.py
@@ -22,9 +22,9 @@ from pathlib import Path
 from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.time import utcnow
-from app.db.models import File as FileModel
 from app.db.session import get_engine, get_session_factory
 from app.services.storage_backend import get_backend
+from app.services.storage_utils import all_owned_blob_keys
 
 logger = get_logger(__name__)
 
@@ -121,11 +121,8 @@ def _find_blobs() -> list[tuple[str, int]]:
     key is gone), and surfacing the size lets ``create_backup`` build the
     manifest *before* streaming the file bodies.
     """
-    from sqlmodel import select
-
     with get_session_factory().session() as session:
-        rows = session.exec(select(FileModel.path)).all()
-    keys = list(dict.fromkeys(rows))
+        keys = sorted(all_owned_blob_keys(session))
     backend = get_backend()
     out: list[tuple[str, int]] = []
     for key in keys:

--- a/backend/app/services/storage_backend.py
+++ b/backend/app/services/storage_backend.py
@@ -404,8 +404,17 @@ class S3StorageBackend(StorageBackend):
         try:
             self._client.head_object(Bucket=self._bucket, Key=key)
             return True
-        except botocore.exceptions.ClientError:
-            return False
+        except botocore.exceptions.ClientError as exc:
+            # Only a genuine "not there" is False. Credential, permission and
+            # network errors must raise: swallowing them tells the orphan-blob
+            # GC that every blob is missing, and it deletes the bucket.
+            if exc.response.get("Error", {}).get("Code") in (
+                "404",
+                "NoSuchKey",
+                "NotFound",
+            ):
+                return False
+            raise
 
     def write_stream(self, src: BinaryIO, key: str) -> int:
         from boto3.s3.transfer import TransferConfig

--- a/backend/app/services/storage_utils.py
+++ b/backend/app/services/storage_utils.py
@@ -1,0 +1,40 @@
+"""The single source of truth for "which blobs does the database still own?".
+
+Both the orphan-blob GC (``services.trash``) and the backup manifest
+(``services.backup``) have to answer this question, and they must answer it
+identically: a key the GC believes is orphaned gets deleted, and a key the
+backup misses is silently absent from the archive. They used to census
+``File.path`` alone, which made every Document blob look unowned.
+"""
+
+from __future__ import annotations
+
+from sqlmodel import Session, select
+
+from app.db.models import Document, File
+from app.services.storage_backend import get_backend
+
+
+def all_owned_blob_keys(session: Session) -> set[str]:
+    """Every storage key a DB row lays claim to, across all owning tables.
+
+    Trashed rows are included on purpose: their bytes must survive until the
+    row is hard-deleted, otherwise restoring from trash yields an empty file.
+
+    Derived artefacts (thumbnails, the STL cache) and readme/body images are
+    absent because neither sweeper walks their prefixes — they live under
+    ``thumb_dir`` locally and outside ``vault-data/files/`` on S3. Widening a
+    walker to cover them means teaching this function to enumerate them first.
+    """
+    backend = get_backend()
+
+    keys: set[str] = set(session.exec(select(File.path)).all())
+
+    documents = session.exec(
+        select(Document.id, Document.filename).where(Document.filename.is_not(None))  # type: ignore[union-attr]
+    ).all()
+    keys.update(
+        backend.document_file_key(doc_id, filename) for doc_id, filename in documents
+    )
+
+    return keys

--- a/backend/app/services/trash.py
+++ b/backend/app/services/trash.py
@@ -28,6 +28,7 @@ from app.db.models import (
 from app.db.scopes import trashed
 from app.db.session import get_session_factory
 from app.services.storage_backend import get_backend
+from app.services.storage_utils import all_owned_blob_keys
 
 logger = get_logger(__name__)
 
@@ -128,14 +129,14 @@ def hard_delete_expired_models(session: Session, retention_days: int) -> list[in
 
 def _cleanup_orphan_blobs(session: Session) -> int:
     backend = get_backend()
-    file_paths = set(session.exec(select(File.path)).all())
+    owned = all_owned_blob_keys(session)
     removed = 0
     if settings.storage_backend == "s3":
         walker = backend.walk_keys("vault-data/files/")
     else:
         walker = backend.walk_keys(str(settings.data_dir))
     for key in walker:
-        if key not in file_paths:
+        if key not in owned:
             backend.delete(key)
             removed += 1
     return removed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printstash"
-version = "0.8.2"
+version = "0.8.3"
 description = "PrintStash — self-hosted 3D printing asset manager"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_backup_restore.py
+++ b/backend/tests/test_backup_restore.py
@@ -24,7 +24,7 @@ from sqlmodel import Session, SQLModel, create_engine, select
 import app.services.backup as backup
 import app.services.storage_backend as storage_backend
 from app.core.config import _overlay
-from app.db.models import File, FileType, Model, User
+from app.db.models import Document, DocumentKind, File, FileType, Model, User
 from app.db.session import SQLiteSessionFactory, override_session_factory
 from app.services.auth import create_access_token, hash_password
 from app.services.storage_backend import get_backend
@@ -115,6 +115,22 @@ def _seed_model_with_blob(
         session.add(f)
         session.commit()
         return model.id, key
+
+
+def _seed_document_with_blob(env: BackupEnv, *, name: str, content: bytes) -> str:
+    """Create a binary Document row and write its blob. Returns the storage key."""
+    with env.new_session() as session:
+        doc = Document(name=name, kind=DocumentKind.PDF)
+        session.add(doc)
+        session.commit()
+        session.refresh(doc)
+        key = get_backend().document_file_key(doc.id, name)
+        get_backend().write_bytes(content, key)
+        doc.filename = name
+        doc.size_bytes = len(content)
+        session.add(doc)
+        session.commit()
+        return key
 
 
 def _read_model_names(env: BackupEnv) -> list[str]:
@@ -258,6 +274,20 @@ def test_restore_recovers_blob_bytes(backup_env: BackupEnv):
     # The blob the database references must be back, byte-for-byte.
     assert Path(key).exists(), "restored blob is missing at its storage key"
     assert Path(key).read_bytes() == content
+
+
+def test_backup_includes_document_blobs(backup_env: BackupEnv):
+    """Documents are vault-owned bytes: a backup that omits them is a lie."""
+    content = b"%PDF-1.4 assembly manual\n"
+    key = _seed_document_with_blob(backup_env, name="manual.pdf", content=content)
+    meta = backup.create_backup()
+
+    Path(key).unlink()
+    result = backup.restore_backup(meta.id)
+
+    assert Path(key).exists(), "document blob was never in the archive"
+    assert Path(key).read_bytes() == content
+    assert result["restored_files"] == 1
 
 
 def test_download_then_restore_endpoint_round_trip(

--- a/backend/tests/test_gc.py
+++ b/backend/tests/test_gc.py
@@ -1,0 +1,147 @@
+"""Orphan-blob GC must delete only blobs no live DB row claims.
+
+Regression pack for the census bug: the sweep used to compare every key under
+``data_dir`` against ``File.path`` alone, so a Document's PDF looked like an
+orphan and was deleted on the next hourly cycle.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session
+
+from app.core.config import _overlay
+from app.core.time import utcnow
+from app.db.models import Document, DocumentKind, File, FileType, Model
+from app.services.storage_backend import get_backend
+from app.services.trash import _cleanup_orphan_blobs
+
+
+@pytest.fixture
+def storage(tmp_path: Path):
+    _overlay["storage_backend"] = "local"
+    _overlay["data_dir"] = tmp_path / "files"
+    _overlay["thumb_dir"] = tmp_path / "thumbs"
+    (tmp_path / "files").mkdir()
+    (tmp_path / "thumbs").mkdir()
+    yield get_backend()
+    for key in ("storage_backend", "data_dir", "thumb_dir"):
+        _overlay.pop(key, None)
+
+
+def _write(key: str, data: bytes = b"x") -> str:
+    p = Path(key)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(data)
+    return key
+
+
+def _model_with_file(session: Session, storage, slug: str) -> File:
+    model = Model(name=slug, slug=slug, hash=f"hash-{slug}")
+    session.add(model)
+    session.commit()
+    session.refresh(model)
+    key = _write(storage.blob_key(slug, 1, f"{slug}.stl"))
+    f = File(
+        model_id=model.id,
+        path=key,
+        original_filename=f"{slug}.stl",
+        file_type=FileType.STL,
+        version=1,
+        size_bytes=1,
+        sha256=f"sha-{slug}",
+    )
+    session.add(f)
+    session.commit()
+    session.refresh(f)
+    return f
+
+
+def _binary_document(session: Session, storage, name: str = "manual.pdf") -> Document:
+    doc = Document(name=name, kind=DocumentKind.PDF)
+    session.add(doc)
+    session.commit()
+    session.refresh(doc)
+    doc.filename = name
+    doc.size_bytes = 1
+    session.add(doc)
+    session.commit()
+    _write(storage.document_file_key(doc.id, name))
+    return doc
+
+
+def test_gc_preserves_document_blobs(db_session: Session, storage) -> None:
+    doc = _binary_document(db_session, storage)
+    key = storage.document_file_key(doc.id, doc.filename)
+
+    _cleanup_orphan_blobs(db_session)
+
+    assert Path(key).exists(), "GC deleted a live document's blob"
+
+
+def test_gc_preserves_model_blobs(db_session: Session, storage) -> None:
+    f = _model_with_file(db_session, storage, "widget")
+
+    _cleanup_orphan_blobs(db_session)
+
+    assert Path(f.path).exists()
+
+
+def test_gc_preserves_trashed_model_blobs(db_session: Session, storage) -> None:
+    """A trashed model's bytes must survive until hard delete — restore needs them."""
+    f = _model_with_file(db_session, storage, "trashed")
+    f.deleted_at = utcnow()
+    db_session.add(f)
+    db_session.commit()
+
+    _cleanup_orphan_blobs(db_session)
+
+    assert Path(f.path).exists()
+
+
+def test_gc_preserves_document_blobs_when_models_exist(
+    db_session: Session, storage
+) -> None:
+    """The two censuses must union, not shadow each other."""
+    f = _model_with_file(db_session, storage, "widget")
+    doc = _binary_document(db_session, storage)
+
+    _cleanup_orphan_blobs(db_session)
+
+    assert Path(f.path).exists()
+    assert Path(storage.document_file_key(doc.id, doc.filename)).exists()
+
+
+def test_gc_deletes_actual_orphans(db_session: Session, storage) -> None:
+    orphan_blob = _write(storage.blob_key("gone", 1, "gone.stl"))
+    orphan_doc = _write(storage.document_file_key(999, "gone.pdf"))
+
+    removed = _cleanup_orphan_blobs(db_session)
+
+    assert not Path(orphan_blob).exists()
+    assert not Path(orphan_doc).exists()
+    assert removed == 2
+
+
+def test_gc_deletes_blob_of_hard_deleted_document(
+    db_session: Session, storage
+) -> None:
+    doc = _binary_document(db_session, storage)
+    key = storage.document_file_key(doc.id, doc.filename)
+    db_session.delete(doc)
+    db_session.commit()
+
+    _cleanup_orphan_blobs(db_session)
+
+    assert not Path(key).exists()
+
+
+def test_gc_ignores_markdown_documents(db_session: Session, storage) -> None:
+    """Markdown docs own no blob — they must not contribute a bogus key."""
+    doc = Document(name="notes", kind=DocumentKind.MARKDOWN, body="# hi")
+    db_session.add(doc)
+    db_session.commit()
+
+    assert _cleanup_orphan_blobs(db_session) == 0

--- a/backend/tests/test_storage_seam.py
+++ b/backend/tests/test_storage_seam.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from sqlmodel import Session, select
 
 from app.db.models import Model
 from app.db.scopes import live, trashed
-from app.services.storage_backend import LocalStorageBackend, StorageBackend
+from app.services.storage_backend import (
+    LocalStorageBackend,
+    S3StorageBackend,
+    StorageBackend,
+)
 from app.services.trash import restore_model, soft_delete_model
 
 
@@ -101,3 +106,42 @@ def test_live_and_trashed_scopes(db_session: Session) -> None:
 
     restore_model(db_session, m)
     assert m in db_session.exec(select(Model).where(live(Model))).all()
+
+
+# ---------------------------------------------------------------------------
+# S3 exists(): only a genuine miss is False
+# ---------------------------------------------------------------------------
+
+
+def _s3_backend_raising(error_code: str) -> S3StorageBackend:
+    """An S3 backend whose head_object always fails with *error_code*.
+
+    Built without __init__ so no boto3 client or bucket config is needed.
+    """
+    import botocore.exceptions
+
+    class _Client:
+        def head_object(self, **_kwargs):
+            raise botocore.exceptions.ClientError(
+                {"Error": {"Code": error_code, "Message": error_code}}, "HeadObject"
+            )
+
+    backend = object.__new__(S3StorageBackend)
+    backend._client = _Client()  # type: ignore[attr-defined]
+    backend._bucket = "test-bucket"  # type: ignore[attr-defined]
+    return backend
+
+
+@pytest.mark.parametrize("code", ["404", "NoSuchKey", "NotFound"])
+def test_s3_exists_false_on_missing_key(code: str) -> None:
+    assert _s3_backend_raising(code).exists("some/key") is False
+
+
+@pytest.mark.parametrize("code", ["403", "AccessDenied", "InvalidAccessKeyId"])
+def test_s3_exists_raises_on_auth_error(code: str) -> None:
+    """A credential failure must never read as 'the blob is gone' — that is how
+    the orphan-blob GC talks itself into deleting the whole bucket."""
+    import botocore.exceptions
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        _s3_backend_raising(code).exists("some/key")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "printstash"
-version = "0.8.2"
+version = "0.8.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## The bug

The orphan-blob GC (`services/trash.py::_cleanup_orphan_blobs`) and the backup
manifest (`services/backup.py::_find_blobs`) both answered *"which blobs does the
database still own?"* by selecting `File.path` alone.

Document blobs are keyed by `document_file_key(id, filename)` and own no `path`
column, so both sweepers classified them as unowned:

- **Data loss.** On local storage the GC walker descends all of `data_dir`, which
  contains `documents/`. The hourly cleanup deleted every uploaded document.
- **Silent incomplete backups.** Document blobs were never written into the
  archive, so a restore dropped them too.
- S3/R2 installs were unaffected — their walker is scoped to `vault-data/files/`.

Separately, S3 `exists()` swallowed *every* `ClientError`, so a credentials or
permissions failure reported the key as absent. Combined with the GC, a transient
auth error reads as "every blob is orphaned".

## The fix

- New `services/storage_utils.py` with `all_owned_blob_keys(session)` — the single
  census both sweepers now share, so they can no longer disagree. Trashed rows are
  included on purpose: their bytes must survive until hard delete.
- `S3StorageBackend.exists()` returns `False` only on a genuine miss (`404` /
  `NoSuchKey` / `NotFound`) and re-raises everything else.

## Tests

All fail without the fix:

- `tests/test_gc.py` — documents survive a GC cycle, trashed models keep their
  bytes, genuine orphans (including a hard-deleted document's blob) are still
  collected, markdown docs contribute no bogus key.
- `tests/test_backup_restore.py::test_backup_includes_document_blobs` — a document
  round-trips through backup → restore.
- `tests/test_storage_seam.py` — `exists()` is `False` on a miss, raises on auth error.

## Verification

- `uv run pytest tests -v` → 852 passed, 1 skipped
- `uv run ruff check app/ tests/` → clean

Note: `test_notifications.py::test_run_dispatcher_loop_survives_tick_error` is a
pre-existing wall-clock flake (`sleep(0.1)` expecting ≥2 ticks at a 0.01s interval)
and can fail under load on `main` too. Untouched here.

Upgrade note in the changelog is explicit that documents already deleted by an
earlier version are not recoverable by upgrading.