### PR TITLE
0.8.4: integrity, security, and performance hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,11 +41,12 @@
 # POSTGRES_PASSWORD=printstash
 
 # --- Auth ---
-# IMPORTANT: change this before first start. The default is a placeholder,
-# not a safe value — anyone who knows it can mint valid tokens.
-# Generate strong random values, e.g.:  openssl rand -hex 32
-
-# JWT secret for user login tokens. Change this to a long random string.
+# JWT secret for user login tokens.
+#
+# Leave it at the placeholder and the app generates a random secret on first
+# start and stores it in its database — the placeholder is public, so it is
+# never used to sign anything. Set it explicitly (openssl rand -hex 32) when you
+# want to manage the secret yourself, e.g. to share it across replicas.
 VAULT_JWT_SECRET=changeme_jwt_secret_please_change
 # VAULT_ACCESS_TOKEN_EXPIRE_MINUTES=60
 # VAULT_REMEMBER_ME_DAYS=2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## 0.8.4
+
+**Behavior changes on upgrade — read before installing.**
+
+### Security
+
+- **JWT secret can no longer boot with the shipped default.** The app now
+  generates and persists a real secret on first boot; if a `VAULT_JWT_SECRET`
+  was left at the placeholder value, existing sessions are invalidated once on
+  the upgrade boot. Set your own with `openssl rand -hex 32` if you manage it
+  explicitly.
+- **SQLite foreign keys are now enforced.** The upgrade repairs any orphaned
+  rows first (clears a dangling attribution, or drops a row whose required
+  parent no longer exists) so enforcement doesn't turn a later delete into a
+  crash.
+- **Outbound fetches are pinned to the address the SSRF guard validated**,
+  closing a DNS-rebind gap between validation and connection.
+
+### Fixed
+
+- **Printer history re-import could duplicate every past job.** Comparing
+  imported filenames case-sensitively (and, in one path, against only the
+  first character of the stored name) meant a printer that changed filename
+  casing between polls — or any poll at all — could re-import its whole
+  history. Comparison is now a real case-insensitive match on both sides.
+- **Backup restore could race the background jobs.** Restoring while GC, an
+  external library scan, or a live print sync were in flight could leave the
+  database mid-swap under them. Restore now waits briefly for in-flight
+  ingestion to finish and refuses with a 409 if it doesn't; GC and printer sync
+  skip their tick while a restore is in progress.
+
+### Performance
+
+- **Collection permission checks and model-list role resolution** now run as
+  a single SQL query instead of a per-row Python scan.
+- **Print-job ingestion is atomic** — a failed thumbnail no longer leaves a
+  half-built model behind.
+- **The printer WebSocket fan-out no longer blocks on a slow client.** One
+  stalled browser tab used to stall the update for every other subscriber to
+  that printer; sends now run concurrently with a timeout, and a slow or dead
+  socket is dropped instead of blocking the rest.
+- **The dashboard's storage-usage figure is cached for 60 seconds** instead of
+  walking the filesystem on every load.
+- **Print statistics no longer re-hydrate every completed job on every
+  dashboard load.** Cost and effective filament grams are now resolved once,
+  when a print completes, and summed directly.
+  **Behavior change:** a print's cost is frozen at completion time — editing a
+  filament profile's price afterwards no longer revises the cost of prints
+  that already finished.
+
 ## 0.8.3
 
 **Upgrade immediately if you use Documents.**

--- a/backend/alembic/versions/175be54ef975_print_job_cost_denormalized.py
+++ b/backend/alembic/versions/175be54ef975_print_job_cost_denormalized.py
@@ -1,0 +1,160 @@
+"""denormalise per-job filament cost onto print_jobs
+
+Revision ID: 175be54ef975
+Revises: b2d8f6a1c94e
+Create Date: 2026-07-09 15:00:00
+
+``print_statistics`` used to hydrate every completed PrintJob + Metadata +
+Model + Collection row and re-match a filament profile per row on every
+dashboard load. This adds ``print_jobs.cost`` and
+``print_jobs.filament_g_effective``, backfilled here, so the aggregate can be
+a plain ``SUM()``.
+
+The backfill replays the cost resolution that
+``app.services.model_views.filament_cost_for_job`` performs (spool-linked
+profile first, then a fuzzy metadata match, then the slicer's own estimate)
+frozen as of this migration — a migration must stay stable even if that
+service logic changes later, so this does not import it.
+
+Behavior change (call out in the changelog): going forward, a completed
+print's cost is fixed at completion time. Editing a filament profile's price
+no longer changes the cost of print jobs that already finished.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "175be54ef975"
+down_revision = "b2d8f6a1c94e"
+branch_labels = None
+depends_on = None
+
+
+def _normalise(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip().lower()
+    return stripped or None
+
+
+def _matching_profile(profiles: list[dict], material_type, material_brand):
+    candidates = [_normalise(material_brand), _normalise(material_type)]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        for profile in profiles:
+            if _normalise(profile["name"]) == candidate:
+                return profile
+
+    norm_type = _normalise(material_type)
+    norm_brand = _normalise(material_brand)
+    if norm_type is None:
+        return None
+    for profile in profiles:
+        if _normalise(profile["material_type"]) != norm_type:
+            continue
+        if norm_brand is not None:
+            if _normalise(profile["material_brand"]) == norm_brand:
+                return profile
+        elif profile["material_brand"] is None:
+            return profile
+    return None
+
+
+def _cost_for_grams(profiles, material_type, material_brand, grams):
+    if grams is None:
+        return None
+    profile = _matching_profile(profiles, material_type, material_brand)
+    if profile is None or profile["cost_per_kg"] is None:
+        return None
+    return round(grams * profile["cost_per_kg"] / 1000, 4)
+
+
+def _resolve(job, md, profiles):
+    """Return (grams_effective, cost) for one print_jobs row, frozen logic."""
+    spool_filament_id = job["spool_filament_id"]
+    measured_grams = job["filament_used_g"]
+
+    if measured_grams is not None:
+        grams = measured_grams
+    elif md is not None:
+        grams = md["filament_weight_g"]
+    else:
+        grams = None
+
+    material_type = md["material_type"] if md is not None else None
+    material_brand = md["material_brand"] if md is not None else None
+
+    cost = None
+    if grams is not None and spool_filament_id is not None:
+        for profile in profiles:
+            if (
+                profile["spoolman_filament_id"] == spool_filament_id
+                and profile["cost_per_kg"] is not None
+            ):
+                cost = round(grams * profile["cost_per_kg"] / 1000, 4)
+                break
+    if cost is None:
+        cost = _cost_for_grams(profiles, material_type, material_brand, grams)
+    if cost is None and measured_grams is None and md is not None:
+        # Slicer's own cost estimate, used when no profile matches at all.
+        cost = md["filament_cost"]
+
+    return grams, cost
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("print_jobs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("cost", sa.Float(), nullable=True))
+        batch_op.add_column(
+            sa.Column("filament_g_effective", sa.Float(), nullable=True)
+        )
+
+    conn = op.get_bind()
+
+    profiles = [
+        dict(row._mapping)
+        for row in conn.execute(
+            sa.text(
+                "SELECT id, name, material_type, material_brand, cost_per_kg, "
+                "spoolman_filament_id FROM filament_profiles"
+            )
+        )
+    ]
+    metadata_by_file = {
+        row._mapping["file_id"]: dict(row._mapping)
+        for row in conn.execute(
+            sa.text(
+                "SELECT file_id, material_type, material_brand, filament_weight_g, "
+                "filament_cost FROM metadata"
+            )
+        )
+    }
+    jobs = [
+        dict(row._mapping)
+        for row in conn.execute(
+            sa.text(
+                "SELECT id, file_id, filament_used_g, spool_filament_id FROM print_jobs"
+            )
+        )
+    ]
+
+    update_stmt = sa.text(
+        "UPDATE print_jobs SET filament_g_effective = :grams, cost = :cost "
+        "WHERE id = :id"
+    )
+    for job in jobs:
+        md = metadata_by_file.get(job["file_id"])
+        grams, cost = _resolve(job, md, profiles)
+        if grams is None and cost is None:
+            continue
+        conn.execute(update_stmt, {"grams": grams, "cost": cost, "id": job["id"]})
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("print_jobs", schema=None) as batch_op:
+        batch_op.drop_column("filament_g_effective")
+        batch_op.drop_column("cost")

--- a/backend/alembic/versions/a1c7e4f9b23d_system_config_jwt_secret.py
+++ b/backend/alembic/versions/a1c7e4f9b23d_system_config_jwt_secret.py
@@ -1,0 +1,33 @@
+"""system_config: persist a generated JWT secret
+
+Revision ID: a1c7e4f9b23d
+Revises: f6b3d0a8c2e9
+Create Date: 2026-07-09 13:00:00
+
+Installs that never set VAULT_JWT_SECRET were signing tokens with the secret
+published in .env.example and the compose defaults. On boot the app now
+generates one and stores it here, so the replacement survives restarts. The
+column stays NULL when the operator supplies the secret via the environment.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "a1c7e4f9b23d"
+down_revision = "f6b3d0a8c2e9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "system_config",
+        sa.Column("jwt_secret", sa.String(length=128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("system_config", "jwt_secret")

--- a/backend/alembic/versions/b2d8f6a1c94e_repair_orphan_fk_rows.py
+++ b/backend/alembic/versions/b2d8f6a1c94e_repair_orphan_fk_rows.py
@@ -1,0 +1,90 @@
+"""repair orphan rows before SQLite foreign keys are enforced
+
+Revision ID: b2d8f6a1c94e
+Revises: a1c7e4f9b23d
+Create Date: 2026-07-09 13:30:00
+
+SQLite only enforces foreign keys when ``PRAGMA foreign_keys=ON``, which this
+release turns on for the first time. Until now nothing stopped a row from
+outliving its parent — the hourly GC hard-deletes trashed users while
+``models.created_by`` still points at them, for instance.
+
+Existing orphans are tolerated by SQLite until something touches the row, so
+they surface later as a mystery IntegrityError on an unrelated write. Repair
+them here instead, driven by ``PRAGMA foreign_key_check`` so we fix exactly
+what is actually broken:
+
+  * dangling nullable reference  -> set NULL (loses an audit-trail name at worst)
+  * dangling required reference  -> delete the row (it cannot be loaded anyway)
+
+Postgres enforced these constraints all along, so it has nothing to repair.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "b2d8f6a1c94e"
+down_revision = "a1c7e4f9b23d"
+branch_labels = None
+depends_on = None
+
+
+def _fk_column(conn, table: str, fk_id: int) -> tuple[str, bool]:
+    """Return ``(column_name, nullable)`` for foreign key *fk_id* of *table*."""
+    for row in conn.exec_driver_sql(f'PRAGMA foreign_key_list("{table}")'):
+        if row[0] == fk_id:
+            column = row[3]
+            break
+    else:
+        raise RuntimeError(f"foreign key {fk_id} not found on {table}")
+
+    for row in conn.exec_driver_sql(f'PRAGMA table_info("{table}")'):
+        if row[1] == column:
+            return column, not bool(row[3])
+    raise RuntimeError(f"column {column} not found on {table}")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "sqlite":
+        return
+
+    # foreign_key_check yields (table, rowid, parent_table, fk_id) per orphan.
+    orphans = list(conn.exec_driver_sql("PRAGMA foreign_key_check"))
+    if not orphans:
+        return
+
+    nulled = 0
+    deleted = 0
+    for table, rowid, _parent, fk_id in orphans:
+        if rowid is None:  # WITHOUT ROWID table — nothing we can address
+            continue
+        column, nullable = _fk_column(conn, table, fk_id)
+        if nullable:
+            conn.exec_driver_sql(
+                f'UPDATE "{table}" SET "{column}" = NULL WHERE rowid = ?', (rowid,)
+            )
+            nulled += 1
+        else:
+            conn.exec_driver_sql(f'DELETE FROM "{table}" WHERE rowid = ?', (rowid,))
+            deleted += 1
+
+    print(
+        f"repaired foreign key orphans: {nulled} reference(s) cleared, "
+        f"{deleted} unloadable row(s) removed"
+    )
+
+    remaining = list(conn.exec_driver_sql("PRAGMA foreign_key_check"))
+    if remaining:
+        raise RuntimeError(
+            f"{len(remaining)} foreign key violation(s) remain after repair; "
+            "refusing to enable enforcement on a dirty database"
+        )
+
+
+def downgrade() -> None:
+    # Deleted rows and cleared references are not recoverable, and enforcement
+    # simply stops when the pragma is off again.
+    pass

--- a/backend/app/api/v1/backup.py
+++ b/backend/app/api/v1/backup.py
@@ -131,6 +131,8 @@ def restore_backup(backup_id: str) -> dict:
         result = backup.restore_backup(backup_id)
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="backup_not_found")
+    except backup.RestoreConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
     except Exception as exc:
         logger.exception("restore %s failed", backup_id)
         raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/app/api/v1/models.py
+++ b/backend/app/api/v1/models.py
@@ -65,11 +65,9 @@ from app.schemas.models import (
     TrashedModelRead,
     VaultStatsRead,
 )
-from app.services import filament as filament_svc
-from app.services import model_views, print_results, rbac, storage, taxonomy
+from app.services import job_import, model_views, print_results, rbac, storage, taxonomy
 from app.services.ingestion import add_gcode_revision_to_model
-from app.services.moonraker import MoonrakerClient, MoonrakerError
-from app.services.runtime_config import auto_mark_known_good_enabled
+from app.services.moonraker import MoonrakerError
 from app.services.trash import (
     hard_delete_expired_models,
     hard_delete_model,
@@ -507,6 +505,10 @@ def create_manual_print_job(
         finished_at=payload.finished_at,
         error=payload.error,
     )
+    if state == PrintJobState.COMPLETED:
+        job.filament_g_effective, job.cost = print_results.resolve_completion_cost(
+            session, job
+        )
     session.add(job)
     session.commit()
     session.refresh(job)
@@ -553,104 +555,18 @@ async def import_print_jobs_from_printer(
     if not printer.moonraker_url:
         raise HTTPException(status_code=400, detail={"code": "printer_no_url"})
 
-    gcode_files = session.exec(
-        select(File)
-        .where(File.model_id == model_id)
-        .where(live(File))
-        .where(File.file_type == FileType.GCODE)
-        .order_by(File.version.asc())  # type: ignore[attr-defined]
-    ).all()
-    filenames_to_file = {f.original_filename.lower(): f for f in gcode_files}
-
-    client = MoonrakerClient(printer.moonraker_url, printer.api_key)
     try:
-        history = await client.get_print_history(limit=100)
+        return await job_import.import_print_jobs_from_printer(
+            session,
+            model_id=model_id,
+            printer_id=printer_id,
+            moonraker_url=printer.moonraker_url,
+            moonraker_api_key=printer.api_key,
+        )
     except MoonrakerError as exc:
         raise HTTPException(
             status_code=502, detail={"code": "printer_unreachable", "detail": str(exc)}
         )
-
-    existing_remote = {
-        row[0]
-        for row in session.exec(
-            select(PrintJob.remote_filename)
-            .where(PrintJob.printer_id == printer_id)
-            .where(PrintJob.model_id == model_id)
-            .where(live(PrintJob))
-        ).all()
-    }
-
-    results: List[ImportedPrintJobRead] = []
-    for entry in history:
-        fname = entry.get("filename", "")
-        matched = filenames_to_file.get(fname.lower())
-        already_imported = fname in existing_remote
-
-        if matched and not already_imported:
-            raw_status = entry.get("status", "completed")
-            state_map = {
-                "completed": PrintJobState.COMPLETED,
-                "cancelled": PrintJobState.CANCELLED,
-                "error": PrintJobState.FAILED,
-            }
-            state = state_map.get(raw_status, PrintJobState.COMPLETED)
-            start_ts = entry.get("start_time")
-            end_ts = entry.get("end_time")
-
-            from datetime import timezone
-            from datetime import datetime as _dt
-
-            def _ts(t: float | None):
-                return _dt.fromtimestamp(t, tz=timezone.utc) if t else None
-
-            duration = entry.get("print_duration")
-            used_mm = entry.get("filament_used")
-            material = print_results.material_type_for_file(session, matched.id)
-            job = PrintJob(
-                printer_id=printer_id,
-                file_id=matched.id,
-                model_id=model_id,
-                remote_filename=fname,
-                state=state,
-                source="printer_history",
-                started_at=_ts(start_ts),
-                finished_at=_ts(end_ts),
-                actual_duration_s=int(duration) if duration else None,
-                filament_used_mm=float(used_mm) if used_mm else None,
-                filament_used_g=filament_svc.mm_to_grams(used_mm, material)
-                if used_mm
-                else None,
-            )
-            session.add(job)
-            session.commit()
-
-            if state == PrintJobState.COMPLETED and auto_mark_known_good_enabled(
-                session
-            ):
-                print_results.mark_known_good_if_eligible(session, matched.id)
-
-            results.append(
-                ImportedPrintJobRead(
-                    filename=fname,
-                    status=raw_status,
-                    print_duration=entry.get("print_duration"),
-                    start_time=start_ts,
-                    end_time=end_ts,
-                    matched_file_id=matched.id,
-                    imported=True,
-                )
-            )
-        elif matched and already_imported:
-            results.append(
-                ImportedPrintJobRead(
-                    filename=fname,
-                    status=entry.get("status", ""),
-                    matched_file_id=matched.id,
-                    imported=False,
-                )
-            )
-
-    return results
 
 
 def _dedupe_ids(ids: List[int]) -> List[int]:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -169,7 +169,7 @@ class Settings(BaseSettings):
     backup_s3_secret_key: str = ""
 
     app_name: str = "PrintStash"
-    app_version: str = "0.8.3"
+    app_version: str = "0.8.4"
 
     @property
     def incoming_dir(self) -> Path:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -21,6 +21,11 @@ from sqlalchemy.engine.url import make_url
 _overlay: dict[str, Any] = {}
 _overlay_lock = asyncio.Lock()
 
+# The secret shipped in .env.example and the compose defaults. Public knowledge,
+# therefore never usable: ``runtime_config.ensure_jwt_secret`` replaces it with a
+# generated one on first boot.
+DEFAULT_JWT_SECRET = "changeme_jwt_secret_please_change"
+
 
 class Settings(BaseSettings):
     """Frozen env-only settings. Never mutated after import.
@@ -54,7 +59,7 @@ class Settings(BaseSettings):
 
     db_url: str = "sqlite:////data/db/printstash.sqlite"
 
-    jwt_secret: str = "changeme_jwt_secret_please_change"
+    jwt_secret: str = DEFAULT_JWT_SECRET
     jwt_algorithm: str = "HS256"
     access_token_expire_minutes: int = 60
     # "Remember me" login lifetime. Kept short because the access token is a

--- a/backend/app/core/url_safety.py
+++ b/backend/app/core/url_safety.py
@@ -3,13 +3,33 @@
 Used anywhere the server makes an outbound request to a user-supplied URL
 (URL/zip imports, notification webhooks). Centralised so the security-critical
 IP predicate has a single source of truth.
+
+Validating a hostname and then handing the *hostname* to an HTTP client leaves a
+DNS-rebinding window: the client resolves again, and the attacker's second
+answer can be 127.0.0.1. Callers therefore resolve once via
+:func:`resolve_public_target` and fetch through :func:`pinned_transport`, which
+dials the address that was actually validated. The URL keeps its hostname, so
+TLS SNI and certificate verification stay honest.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import socket
+from dataclasses import dataclass
+from typing import Iterable
 from urllib.parse import urlsplit
+
+import httpx
+from httpcore import AnyIOBackend, AsyncNetworkStream
+
+
+class UnsafeUrlError(Exception):
+    """The URL is not safe to fetch server-side. ``reason`` is a stable code."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 def is_public_ip(ip_str: str) -> bool:
@@ -28,25 +48,90 @@ def is_public_ip(ip_str: str) -> bool:
     )
 
 
-def is_public_url(url: str) -> bool:
-    """True if ``url`` is HTTP(S) and every resolved address is public.
+@dataclass(frozen=True)
+class PinnedTarget:
+    """A URL whose every resolved address was public, plus the one we will dial."""
 
-    Non-raising variant for callers that want a boolean gate. Returns ``False``
-    for non-HTTP schemes, a missing host, DNS failure, or any address that
-    resolves to a non-public range (defends against SSRF + DNS-rebind to a
-    private host).
+    url: str
+    host: str
+    port: int
+    ip: str
+
+
+def resolve_public_target(url: str) -> PinnedTarget:
+    """Resolve *url* once and require every answer to be a public address.
+
+    Raises :class:`UnsafeUrlError`. Every returned address is checked, not only
+    the one we dial: a host answering with both a public and a private address
+    is an attack, not a fallback.
     """
     parts = urlsplit(url)
     if parts.scheme not in ("http", "https"):
-        return False
+        raise UnsafeUrlError("url_scheme_not_allowed")
     host = parts.hostname
     if not host:
-        return False
+        raise UnsafeUrlError("url_host_missing")
+    port = parts.port or (443 if parts.scheme == "https" else 80)
+
     try:
-        infos = socket.getaddrinfo(host, parts.port or None, proto=socket.IPPROTO_TCP)
-    except socket.gaierror:
-        return False
-    addrs = {info[4][0] for info in infos}
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UnsafeUrlError("url_dns_resolution_failed") from exc
+
+    addrs = [info[4][0] for info in infos]
     if not addrs:
+        raise UnsafeUrlError("url_dns_resolution_failed")
+    for addr in addrs:
+        if not is_public_ip(addr):
+            raise UnsafeUrlError("url_target_not_public")
+
+    return PinnedTarget(url=url, host=host, port=port, ip=addrs[0])
+
+
+def is_public_url(url: str) -> bool:
+    """Boolean gate for callers that only need to reject, not to fetch."""
+    try:
+        resolve_public_target(url)
+    except UnsafeUrlError:
         return False
-    return all(is_public_ip(addr) for addr in addrs)
+    return True
+
+
+class _PinnedBackend(AnyIOBackend):
+    """Network backend that dials *ip* whatever hostname it is handed.
+
+    Only the TCP peer is substituted. The request URL still carries the real
+    hostname, so Host, SNI and certificate hostname verification are unchanged.
+    Rewriting the URL to the bare IP instead would quietly drop the certificate
+    hostname check.
+    """
+
+    def __init__(self, ip: str) -> None:
+        self._ip = ip
+
+    async def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Iterable[object] | None = None,
+    ) -> AsyncNetworkStream:
+        return await super().connect_tcp(
+            self._ip,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,  # type: ignore[arg-type]
+        )
+
+
+def pinned_transport(target: PinnedTarget) -> httpx.AsyncHTTPTransport:
+    """An httpx transport that connects only to *target*'s validated address.
+
+    ponytail: reaches into ``transport._pool`` because httpx exposes no public
+    hook for the network backend. Pinned by a test that asserts the dialled peer.
+    """
+    transport = httpx.AsyncHTTPTransport(retries=0)
+    transport._pool._network_backend = _PinnedBackend(target.ip)  # type: ignore[attr-defined]
+    return transport

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -493,6 +493,11 @@ class SystemConfig(SQLModel, table=True):
     # Storage backend: "local" or "s3"
     storage_backend: Optional[str] = Field(default=None, max_length=64)
 
+    # Generated on first boot when no VAULT_JWT_SECRET is supplied, so an install
+    # never signs tokens with the public default. Stays None when the operator
+    # sets the env var — theirs wins and we don't copy it into the DB.
+    jwt_secret: Optional[str] = Field(default=None, max_length=128)
+
     # S3 / R2 settings
     s3_bucket: Optional[str] = Field(default=None, max_length=256)
     s3_endpoint_url: Optional[str] = Field(default=None, max_length=512)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -680,6 +680,13 @@ class PrintJob(SQLModel, table=True):
     filament_used_g: Optional[float] = None
     actual_duration_s: Optional[int] = None
 
+    # Resolved once at completion (`filament_cost_for_job`) and frozen from
+    # then on — editing a filament profile's price afterwards does not
+    # change historical cost. Populated by every write path that marks a job
+    # COMPLETED; backfilled for pre-existing rows by migration 175be54ef975.
+    cost: Optional[float] = None
+    filament_g_effective: Optional[float] = None
+
     # Spoolman spool this print consumed, selected when starting/logging the
     # job. A soft reference (Spoolman owns the spool table) — not an FK. The
     # cached label keeps history readable if the spool is later renamed/archived

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -37,6 +37,7 @@ def _set_sqlite_pragmas(dbapi_conn, _record) -> None:
     cursor.execute("PRAGMA synchronous=NORMAL")
     cursor.execute("PRAGMA busy_timeout=5000")
     cursor.execute("PRAGMA temp_store=MEMORY")
+    cursor.execute("PRAGMA foreign_keys=ON")
     cursor.close()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,7 @@ from app.services.audit import (
     install_audit_listeners,
     set_audit_context,
 )
+from app.services.backup import restore_in_progress
 from app.services.trash import gc_soft_deleted
 from app.services.library_watcher import LibraryWatcher
 from app.services.notifications import run_dispatcher_loop
@@ -133,6 +134,8 @@ async def _external_scan_loop() -> None:
     """
     while True:
         await asyncio.sleep(60)
+        if restore_in_progress():
+            continue
         try:
             await asyncio.to_thread(_run_due_external_scans)
         except Exception:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -34,7 +34,7 @@ from app.services.trash import gc_soft_deleted
 from app.services.library_watcher import LibraryWatcher
 from app.services.notifications import run_dispatcher_loop
 from app.services.printer_hub import PrinterHub
-from app.services.runtime_config import apply_overlay, is_configured
+from app.services.runtime_config import apply_overlay, ensure_jwt_secret, is_configured
 from app.services.storage_backend import init_backend
 
 logger = get_logger(__name__)
@@ -55,6 +55,8 @@ async def lifespan(app: FastAPI):
     init_db()
     with get_session_factory().scoped_session() as session:
         apply_overlay(session)
+        # Must run after apply_overlay: that call clears the overlay dict.
+        ensure_jwt_secret(session)
         configured = is_configured(session)
         # Clear any NAS scans stranded RUNNING by a previous unclean shutdown,
         # otherwise the scheduler would skip them forever.

--- a/backend/app/services/backup.py
+++ b/backend/app/services/backup.py
@@ -14,6 +14,8 @@ import gzip
 import io
 import json
 import tarfile
+import threading
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
@@ -23,10 +25,25 @@ from app.core.config import settings
 from app.core.logging import get_logger
 from app.core.time import utcnow
 from app.db.session import get_engine, get_session_factory
+from app.services.jobs import registry
 from app.services.storage_backend import get_backend
 from app.services.storage_utils import all_owned_blob_keys
 
 logger = get_logger(__name__)
+
+# ponytail: process-wide gate, single-process/single-worker only. A
+# multi-worker deployment needs a DB-backed lock instead of this in-memory
+# Event — not built here.
+_restore_gate = threading.Event()
+_RESTORE_GRACE_PERIOD_S = 2.0
+
+
+class RestoreConflictError(Exception):
+    """Raised when a restore is refused because ingestion work is in flight."""
+
+
+def restore_in_progress() -> bool:
+    return _restore_gate.is_set()
 
 MANIFEST_VERSION = "1"
 _BACKUP_S3_PREFIX = "printstash-backups/"
@@ -500,34 +517,52 @@ def restore_backup(backup_id: str) -> dict:
 
     Downloads from S3 if the backup is only in cloud storage.
     WARNING: This replaces the current database and all files.
+
+    Sets a process-wide gate so background loops (GC, external scans, printer
+    sync) skip their tick instead of racing the DB file swap. Refuses with
+    ``RestoreConflictError`` if ingestion work is still running after a short
+    grace period, rather than restoring underneath it.
     """
     meta = get_backup(backup_id)
     if meta is None:
         raise FileNotFoundError(f"backup {backup_id} not found")
 
-    archive_path = _download_backup_to_local(meta)
-    restored_files = 0
+    _restore_gate.set()
+    try:
+        time.sleep(_RESTORE_GRACE_PERIOD_S)
+        running = registry.snapshot_counts()["running"]
+        if running:
+            raise RestoreConflictError(
+                f"{running} ingestion job(s) still running; retry once they finish"
+            )
 
-    # Seekable read so the manifest (written last) can be consulted before the
-    # file members are written, regardless of their order in the archive.
-    with tarfile.open(archive_path, mode="r:gz") as tar:
-        arc_to_key = _restore_key_map(tar)
+        archive_path = _download_backup_to_local(meta)
+        restored_files = 0
 
-        db_member = tar.extractfile("db.sqlite3") if _has_member(tar, "db.sqlite3") else None
-        if db_member is not None:
-            _restore_database(db_member.read())
+        # Seekable read so the manifest (written last) can be consulted before the
+        # file members are written, regardless of their order in the archive.
+        with tarfile.open(archive_path, mode="r:gz") as tar:
+            arc_to_key = _restore_key_map(tar)
 
-        for member in tar.getmembers():
-            if not member.name.startswith("files/") or member.name == "files/":
-                continue
-            f = tar.extractfile(member)
-            if f is None:
-                continue
-            # Prefer the exact key the manifest recorded; fall back to the legacy
-            # arcname transform for archives created before the map existed.
-            key = arc_to_key.get(member.name, member.name[len("files/") :])
-            get_backend().write_bytes(f.read(), key)
-            restored_files += 1
+            db_member = (
+                tar.extractfile("db.sqlite3") if _has_member(tar, "db.sqlite3") else None
+            )
+            if db_member is not None:
+                _restore_database(db_member.read())
+
+            for member in tar.getmembers():
+                if not member.name.startswith("files/") or member.name == "files/":
+                    continue
+                f = tar.extractfile(member)
+                if f is None:
+                    continue
+                # Prefer the exact key the manifest recorded; fall back to the legacy
+                # arcname transform for archives created before the map existed.
+                key = arc_to_key.get(member.name, member.name[len("files/") :])
+                get_backend().write_bytes(f.read(), key)
+                restored_files += 1
+    finally:
+        _restore_gate.clear()
 
     logger.info("backup %s restored: %d files", backup_id, restored_files)
 

--- a/backend/app/services/importer.py
+++ b/backend/app/services/importer.py
@@ -16,20 +16,25 @@ count + per-entry + total uncompressed size caps).
 
 from __future__ import annotations
 
-import socket
 import threading
 import time
 import uuid
 import zipfile
+
+import httpx
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Optional
-from urllib.parse import unquote, urlparse, urlsplit
+from urllib.parse import unquote, urlparse
 
 from app.core.config import settings
-from app.core.http_client import get_http_client
 from app.core.logging import get_logger
-from app.core.url_safety import is_public_ip as _is_public_ip
+from app.core.url_safety import (
+    PinnedTarget,
+    UnsafeUrlError,
+    pinned_transport,
+    resolve_public_target,
+)
 from app.db.models import SUFFIX_TO_FILE_TYPE
 from app.db.session import SessionFactory
 from app.services import storage
@@ -53,27 +58,22 @@ class ImportError_(Exception):
 # ---------------------------------------------------------------------------
 
 
+def _resolve_or_raise(url: str) -> PinnedTarget:
+    """Resolve *url* once, or raise the importer's error type."""
+    try:
+        return resolve_public_target(url)
+    except UnsafeUrlError as exc:
+        raise ImportError_(exc.reason) from exc
+
+
 def validate_public_url(url: str) -> None:
     """Reject non-HTTP(S) schemes and hosts that resolve to non-public IPs.
 
-    Raises ``ImportError_`` if the URL is unsafe to fetch server-side.
+    Raises ``ImportError_`` if the URL is unsafe to fetch server-side. Callers
+    that go on to *fetch* the URL must use the address this resolution returned
+    (see ``download_to_staging``); re-resolving reopens a DNS-rebind window.
     """
-    parts = urlsplit(url)
-    if parts.scheme not in ("http", "https"):
-        raise ImportError_("url_scheme_not_allowed")
-    host = parts.hostname
-    if not host:
-        raise ImportError_("url_host_missing")
-    try:
-        infos = socket.getaddrinfo(host, parts.port or None, proto=socket.IPPROTO_TCP)
-    except socket.gaierror as exc:
-        raise ImportError_("url_dns_resolution_failed") from exc
-    addrs = {info[4][0] for info in infos}
-    if not addrs:
-        raise ImportError_("url_dns_resolution_failed")
-    for addr in addrs:
-        if not _is_public_ip(addr):
-            raise ImportError_("url_target_not_public")
+    _resolve_or_raise(url)
 
 
 def _filename_from_url(url: str, fallback: str = "download") -> str:
@@ -91,37 +91,43 @@ async def download_to_staging(url: str) -> tuple[Path, str]:
 
     Returns ``(staged_path, original_filename)``. Enforces ``max_upload_bytes``.
     """
-    client = get_http_client()
     current = url
     for _ in range(settings.url_import_max_redirects + 1):
-        validate_public_url(current)
-        async with client.stream(
-            "GET", current, follow_redirects=False, timeout=60.0
-        ) as resp:
-            if resp.is_redirect:
-                location = resp.headers.get("location")
-                if not location:
-                    raise ImportError_("url_redirect_without_location")
-                current = str(resp.url.join(location))
-                continue
-            resp.raise_for_status()
-            original_filename = _content_disposition_name(resp) or _filename_from_url(
-                current
-            )
-            suffix = Path(original_filename).suffix.lower() or ".bin"
-            staged = settings.incoming_dir / f"{uuid.uuid4().hex}{suffix}"
-            staged.parent.mkdir(parents=True, exist_ok=True)
-            written = 0
-            limit = settings.max_upload_bytes
-            with staged.open("wb") as out:
-                async for chunk in resp.aiter_bytes(1024 * 1024):
-                    written += len(chunk)
-                    if written > limit:
-                        out.close()
-                        staged.unlink(missing_ok=True)
-                        raise ImportError_("download_too_large")
-                    out.write(chunk)
-            return staged, original_filename
+        # Resolve once and dial exactly that address: validating the hostname and
+        # then letting httpx resolve it again would let a hostile DNS server
+        # answer 127.0.0.1 the second time. Each redirect hop is a fresh URL, so
+        # each gets its own validation and its own pinned connection.
+        target = _resolve_or_raise(current)
+        async with httpx.AsyncClient(
+            transport=pinned_transport(target), timeout=60.0
+        ) as client:
+            async with client.stream(
+                "GET", current, follow_redirects=False
+            ) as resp:
+                if resp.is_redirect:
+                    location = resp.headers.get("location")
+                    if not location:
+                        raise ImportError_("url_redirect_without_location")
+                    current = str(resp.url.join(location))
+                    continue
+                resp.raise_for_status()
+                original_filename = _content_disposition_name(
+                    resp
+                ) or _filename_from_url(current)
+                suffix = Path(original_filename).suffix.lower() or ".bin"
+                staged = settings.incoming_dir / f"{uuid.uuid4().hex}{suffix}"
+                staged.parent.mkdir(parents=True, exist_ok=True)
+                written = 0
+                limit = settings.max_upload_bytes
+                with staged.open("wb") as out:
+                    async for chunk in resp.aiter_bytes(1024 * 1024):
+                        written += len(chunk)
+                        if written > limit:
+                            out.close()
+                            staged.unlink(missing_ok=True)
+                            raise ImportError_("download_too_large")
+                        out.write(chunk)
+                return staged, original_filename
     raise ImportError_("url_too_many_redirects")
 
 

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session, select
 
 from app.core.logging import get_logger
@@ -128,9 +129,21 @@ def resolve_or_create_model(
             name=model_name, slug=slug, hash=dedup_hash, source_url=source_url
         )
         session.add(model)
-        session.commit()
-        session.refresh(model)
-        return model, True
+        try:
+            session.commit()
+        except IntegrityError:
+            # Another upload of the same bytes won the race between the SELECT
+            # above and this INSERT (Model.hash is unique). Dedup onto theirs
+            # rather than failing the second uploader's request.
+            session.rollback()
+            existing = session.exec(
+                select(Model).where(Model.hash == dedup_hash)
+            ).first()
+            if existing is None:
+                raise
+        else:
+            session.refresh(model)
+            return model, True
 
     if actor is not None:
         rbac.require_model_collection_role(
@@ -239,25 +252,34 @@ def persist_artifact(
         external_library_id=external_library_id,
         source_mtime=source_mtime,
     )
-    session.add(file_row)
-    session.commit()
-    session.refresh(file_row)
-    assert file_row.id is not None
+    # One transaction for the whole artifact: a File row committed before its
+    # Metadata is a model that renders with no print time, filament or cost and
+    # no error to explain it. flush() allocates the id the thumbnail key needs
+    # without ending the transaction.
+    try:
+        session.add(file_row)
+        session.flush()
+        assert file_row.id is not None
 
-    if thumb_bytes:
-        thumb_key = backend.thumbnail_key(file_row.id)
-        backend.write_bytes(thumbnail.to_webp(thumb_bytes), thumb_key)
-        if overwrite_thumbnail or not model.thumbnail_path:
-            model.thumbnail_path = thumb_key
-            model.thumbnail_file_id = file_row.id
-            session.add(model)
+        if thumb_bytes:
+            thumb_key = backend.thumbnail_key(file_row.id)
+            backend.write_bytes(thumbnail.to_webp(thumb_bytes), thumb_key)
+            if overwrite_thumbnail or not model.thumbnail_path:
+                model.thumbnail_path = thumb_key
+                model.thumbnail_file_id = file_row.id
+                session.add(model)
 
-    # The parser may carry detection-only keys (e.g. printer_preset_name)
-    # that have no Metadata column.
-    md_fields = {k: v for k, v in meta.items() if k in Metadata.model_fields}
-    md = Metadata(file_id=file_row.id, **md_fields)
-    session.add(md)
-    session.commit()
+        # The parser may carry detection-only keys (e.g. printer_preset_name)
+        # that have no Metadata column.
+        md_fields = {k: v for k, v in meta.items() if k in Metadata.model_fields}
+        session.add(Metadata(file_id=file_row.id, **md_fields))
+        session.commit()
+    except Exception:
+        session.rollback()
+        # The blob was already moved into place. Leaving it is safe: no row
+        # claims it, so the orphan sweep collects it (see storage_utils).
+        raise
+
     session.refresh(file_row)
     return file_row
 

--- a/backend/app/services/job_import.py
+++ b/backend/app/services/job_import.py
@@ -1,0 +1,140 @@
+"""Import completed print history from a printer's own record (Moonraker).
+
+Kept separate from ``print_results`` (which owns post-completion side effects
+for jobs already tracked in the vault) — this module owns turning a printer's
+history feed into new ``PrintJob`` rows.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+from sqlmodel import Session, select
+
+from app.db.models import File, FileType, PrintJob, PrintJobState
+from app.db.scopes import live
+from app.schemas.models import ImportedPrintJobRead
+from app.services import filament as filament_svc
+from app.services import print_results
+from app.services.moonraker import MoonrakerClient, MoonrakerError
+from app.services.runtime_config import auto_mark_known_good_enabled
+
+_STATE_MAP = {
+    "completed": PrintJobState.COMPLETED,
+    "cancelled": PrintJobState.CANCELLED,
+    "error": PrintJobState.FAILED,
+}
+
+
+def _ts(t: float | None) -> datetime | None:
+    return datetime.fromtimestamp(t, tz=timezone.utc) if t else None
+
+
+async def import_print_jobs_from_printer(
+    session: Session,
+    *,
+    model_id: int,
+    printer_id: int,
+    moonraker_url: str,
+    moonraker_api_key: str | None,
+) -> List[ImportedPrintJobRead]:
+    """Fetch a printer's print history and import entries matching this model's G-code files.
+
+    Dedup compares filenames case-insensitively on both sides — printers
+    (notably Moonraker after a firmware update) can report a filename with
+    different casing across polls than what was originally uploaded, and a
+    case-sensitive comparison would re-import the entire history.
+    """
+    gcode_files = session.exec(
+        select(File)
+        .where(File.model_id == model_id)
+        .where(live(File))
+        .where(File.file_type == FileType.GCODE)
+        .order_by(File.version.asc())  # type: ignore[attr-defined]
+    ).all()
+    filenames_to_file = {f.original_filename.lower(): f for f in gcode_files}
+
+    client = MoonrakerClient(moonraker_url, moonraker_api_key)
+    try:
+        history = await client.get_print_history(limit=100)
+    except MoonrakerError as exc:
+        raise MoonrakerError(str(exc)) from exc
+
+    existing_remote = {
+        row.lower()
+        for row in session.exec(
+            select(PrintJob.remote_filename)
+            .where(PrintJob.printer_id == printer_id)
+            .where(PrintJob.model_id == model_id)
+            .where(live(PrintJob))
+        ).all()
+    }
+
+    results: List[ImportedPrintJobRead] = []
+    newly_completed_file_ids: set[int] = set()
+    for entry in history:
+        fname = entry.get("filename", "")
+        matched = filenames_to_file.get(fname.lower())
+        already_imported = fname.lower() in existing_remote
+
+        if matched and not already_imported:
+            raw_status = entry.get("status", "completed")
+            state = _STATE_MAP.get(raw_status, PrintJobState.COMPLETED)
+            start_ts = entry.get("start_time")
+            end_ts = entry.get("end_time")
+            duration = entry.get("print_duration")
+            used_mm = entry.get("filament_used")
+            material = print_results.material_type_for_file(session, matched.id)
+            job = PrintJob(
+                printer_id=printer_id,
+                file_id=matched.id,
+                model_id=model_id,
+                remote_filename=fname,
+                state=state,
+                source="printer_history",
+                started_at=_ts(start_ts),
+                finished_at=_ts(end_ts),
+                actual_duration_s=int(duration) if duration else None,
+                filament_used_mm=float(used_mm) if used_mm else None,
+                filament_used_g=filament_svc.mm_to_grams(used_mm, material)
+                if used_mm
+                else None,
+            )
+            if state == PrintJobState.COMPLETED:
+                job.filament_g_effective, job.cost = (
+                    print_results.resolve_completion_cost(session, job)
+                )
+                newly_completed_file_ids.add(matched.id)
+
+            session.add(job)
+            existing_remote.add(fname.lower())
+
+            results.append(
+                ImportedPrintJobRead(
+                    filename=fname,
+                    status=raw_status,
+                    print_duration=entry.get("print_duration"),
+                    start_time=start_ts,
+                    end_time=end_ts,
+                    matched_file_id=matched.id,
+                    imported=True,
+                )
+            )
+        elif matched and already_imported:
+            results.append(
+                ImportedPrintJobRead(
+                    filename=fname,
+                    status=entry.get("status", ""),
+                    matched_file_id=matched.id,
+                    imported=False,
+                )
+            )
+
+    session.commit()
+
+    if newly_completed_file_ids and auto_mark_known_good_enabled(session):
+        for file_id in newly_completed_file_ids:
+            print_results.mark_known_good_if_eligible(session, file_id)
+
+    return results

--- a/backend/app/services/model_views.py
+++ b/backend/app/services/model_views.py
@@ -512,6 +512,11 @@ def list_items(
                 slicer_name=md.slicer_name,
             )
 
+    # One resolution for the whole page: per-row lookups cost two queries each.
+    roles = rbac.effective_roles_for_collections(
+        session, user, (m.collection_id for m in rows)
+    )
+
     out: List[ModelListItem] = []
     for m in rows:
         assert m.id is not None
@@ -524,7 +529,7 @@ def list_items(
                 collection=collection_name_for(m),
                 collection_id=m.collection_id,
                 source_url=m.source_url,
-                effective_role=_effective_model_role(session, user, m),
+                effective_role=roles.get(m.collection_id),
                 tags=sorted(t.name for t in m.tags),
                 thumbnail_url=thumb_url(m),
                 file_count=int(file_counts.get(m.id, 0)),

--- a/backend/app/services/model_views.py
+++ b/backend/app/services/model_views.py
@@ -10,6 +10,8 @@ per facet) — N+1 regressions are bugs in this module, testable without HTTP.
 
 from __future__ import annotations
 
+from time import monotonic
+
 from collections import defaultdict
 from datetime import datetime, timedelta
 import csv
@@ -842,6 +844,29 @@ def list_trashed(
 # ---------------------------------------------------------------------------
 
 
+# ``backend.usage()`` walks the whole storage tree (or lists the bucket). The
+# dashboard calls it on every load, where a slightly stale total is fine.
+_USAGE_TTL_S = 60.0
+_usage_cache: dict[tuple[str, str], tuple[float, dict]] = {}
+
+
+def _cached_storage_usage() -> dict:
+    """Storage usage, recomputed at most once per minute per configured backend.
+
+    Keyed on the effective backend + data dir so a runtime reconfiguration (and
+    each test's tmp_path) gets its own entry. Failures are not cached: a
+    transient S3 error should not pin an error state for a minute.
+    """
+    key = (str(settings.storage_backend), str(settings.data_dir))
+    now = monotonic()
+    hit = _usage_cache.get(key)
+    if hit is not None and now - hit[0] < _USAGE_TTL_S:
+        return hit[1]
+    usage = get_backend().usage()
+    _usage_cache[key] = (now, usage)
+    return usage
+
+
 def vault_stats(session: Session, user: User) -> VaultStatsRead:
     live_model_ids = select(Model.id).where(
         live(Model),
@@ -884,7 +909,7 @@ def vault_stats(session: Session, user: User) -> VaultStatsRead:
     ).one()
 
     try:
-        storage_usage = StorageUsageRead(**get_backend().usage())
+        storage_usage = StorageUsageRead(**_cached_storage_usage())
     except Exception as exc:
         storage_usage = StorageUsageRead(
             backend=settings.storage_backend,

--- a/backend/app/services/model_views.py
+++ b/backend/app/services/model_views.py
@@ -940,44 +940,15 @@ _STATS_PERIODS: dict[str, Optional[int]] = {
 }
 
 
-def _effective_print_metrics(
-    profiles: list[FilamentProfile],
-    md: Metadata | None,
-    job: PrintJob,
-) -> tuple[Optional[float], Optional[float], Optional[int]]:
-    """Filament grams, cost and duration for a completed print.
-
-    Prefers the values the printer actually measured; falls back to the slicer
-    estimate from :class:`Metadata` when the printer reported nothing (Bambu
-    does not report live consumption, and manual logs often omit it). Without
-    this fallback the cost/filament totals read as "—" for whole fleets.
-    """
-    if job.filament_used_g is not None:
-        grams: Optional[float] = job.filament_used_g
-        cost = filament_cost_for_grams(profiles, md, grams)
-    elif md is not None:
-        grams = md.filament_weight_g
-        cost = filament_cost_for_grams(profiles, md, grams)
-        if cost is None:
-            cost = md.filament_cost
-    else:
-        grams = None
-        cost = None
-
-    duration = job.actual_duration_s
-    if duration is None and md is not None:
-        duration = md.estimated_time_s
-
-    return grams, cost, duration
-
-
 def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
     """Aggregate *completed* print jobs over a preset time window.
 
-    Counts cost, filament and duration totals plus the collections and
-    filaments with the most prints. Per-print cost reuses the same
-    profile-matching helper that drives the model detail view, so the numbers
-    here are consistent with what users see per model.
+    Reads the cost and effective filament grams that were resolved and
+    frozen once, at completion time (see
+    ``print_results.resolve_completion_cost``), rather than re-hydrating
+    every job row and re-matching a filament profile on every dashboard
+    load. A profile's price edited after a print completed does not change
+    that print's historical cost.
     """
     if period not in _STATS_PERIODS:
         period = "30d"
@@ -992,7 +963,19 @@ def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
     anchor = func.coalesce(PrintJob.finished_at, PrintJob.created_at)
 
     query = (
-        select(PrintJob, Metadata, Model, Collection)
+        select(
+            PrintJob.cost,
+            PrintJob.filament_g_effective,
+            PrintJob.actual_duration_s,
+            PrintJob.finished_at,
+            PrintJob.created_at,
+            Model.collection_id,
+            Collection.name,
+            Collection.path,
+            Metadata.material_type,
+            Metadata.material_brand,
+            Metadata.estimated_time_s,
+        )
         .join(File, File.id == PrintJob.file_id)
         .outerjoin(Metadata, Metadata.file_id == File.id)
         .join(Model, Model.id == PrintJob.model_id)
@@ -1006,7 +989,6 @@ def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
         query = query.where(anchor >= start_at)  # type: ignore[operator]
 
     rows = session.exec(query).all()
-    profiles = _load_filament_profiles(session)
 
     total_cost = 0.0
     has_cost = False
@@ -1022,8 +1004,21 @@ def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
     filament_acc: dict[tuple, dict] = {}
     time_acc: dict[str, dict] = {}
 
-    for job, md, model, collection in rows:
-        grams, cost, duration = _effective_print_metrics(profiles, md, job)
+    for (
+        cost,
+        grams,
+        duration,
+        finished_at,
+        created_at,
+        cid,
+        cname,
+        cpath,
+        mtype,
+        mbrand,
+        estimated_time_s,
+    ) in rows:
+        if duration is None:
+            duration = estimated_time_s
         if cost is not None:
             total_cost += cost
             has_cost = True
@@ -1036,12 +1031,11 @@ def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
             total_duration_s += duration
 
         # Top collections (Uncategorized bucket when the model has no collection).
-        cid = collection.id if collection is not None else None
         c = collection_acc.setdefault(
             cid,
             {
-                "name": collection.name if collection is not None else "Uncategorized",
-                "path": collection.path if collection is not None else None,
+                "name": cname if cid is not None else "Uncategorized",
+                "path": cpath if cid is not None else None,
                 "print_count": 0,
                 "total_cost": 0.0,
                 "has_cost": False,
@@ -1053,8 +1047,6 @@ def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
             c["has_cost"] = True
 
         # Top filaments grouped by (material_type, material_brand).
-        mtype = md.material_type if md is not None else None
-        mbrand = md.material_brand if md is not None else None
         f = filament_acc.setdefault(
             (mtype, mbrand),
             {
@@ -1076,7 +1068,7 @@ def print_statistics(session: Session, period: str) -> PrintStatisticsRead:
             f["has_cost"] = True
 
         # Cost-over-time buckets keyed by day (≤90d) or month (longer/all).
-        when = ensure_utc(job.finished_at or job.created_at)
+        when = ensure_utc(finished_at or created_at)
         key = when.strftime("%Y-%m") if bucket_monthly else when.strftime("%Y-%m-%d")
         b = time_acc.setdefault(
             key,

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+
+import httpx
 from datetime import datetime, timedelta, timezone
 from email.utils import parsedate_to_datetime
 from typing import Any, Dict, List, Optional
@@ -31,10 +33,14 @@ from urllib.parse import urlsplit
 from sqlalchemy import or_
 from sqlmodel import Session, select
 
-from app.core.http_client import get_http_client
 from app.core.logging import get_logger
 from app.core.time import utcnow
-from app.core.url_safety import is_public_url
+from app.core.url_safety import (
+    PinnedTarget,
+    UnsafeUrlError,
+    pinned_transport,
+    resolve_public_target,
+)
 from app.db.session import get_session_factory
 from app.db.models import (
     Model,
@@ -81,6 +87,17 @@ _MAX_RETRY_AFTER_SECONDS = 3600
 _CIRCUIT_BREAKER_THRESHOLD = 10
 # Delivered/failed rows older than this are pruned by the GC loop.
 _DELIVERY_RETENTION_DAYS = 30
+
+
+def _client_for(target: PinnedTarget) -> httpx.AsyncClient:
+    """HTTP client bound to the address the SSRF guard validated.
+
+    A seam: the dispatcher's only network egress, so tests replace this rather
+    than the guard itself.
+    """
+    return httpx.AsyncClient(
+        transport=pinned_transport(target), timeout=_REQUEST_TIMEOUT_S
+    )
 
 
 def next_retry_delay(attempts: int) -> Optional[int]:
@@ -397,7 +414,11 @@ async def _send_one(item: Dict[str, Any]) -> None:
 
     # SSRF guard: never POST to a user-supplied URL that resolves to a private/
     # loopback/link-local host. DNS resolution blocks, so run it in a thread.
-    if not await asyncio.to_thread(is_public_url, req.url):
+    # We keep the resolved address and dial it directly below, so a hostile DNS
+    # server cannot answer differently between this check and the connection.
+    try:
+        target = await asyncio.to_thread(resolve_public_target, req.url)
+    except UnsafeUrlError:
         host = urlsplit(req.url).hostname or req.url
         await asyncio.to_thread(
             _record_result,
@@ -416,15 +437,14 @@ async def _send_one(item: Dict[str, Any]) -> None:
     headers.setdefault("X-PrintStash-Delivery-Id", str(delivery_id))
 
     try:
-        client = get_http_client()
-        resp = await client.request(
-            req.method,
-            req.url,
-            headers=headers,
-            json=req.json,
-            content=req.data.encode("utf-8") if req.data is not None else None,
-            timeout=_REQUEST_TIMEOUT_S,
-        )
+        async with _client_for(target) as client:
+            resp = await client.request(
+                req.method,
+                req.url,
+                headers=headers,
+                json=req.json,
+                content=req.data.encode("utf-8") if req.data is not None else None,
+            )
         if 200 <= resp.status_code < 300:
             await asyncio.to_thread(
                 _record_result, delivery_id, channel_id, success=True, error=None
@@ -790,21 +810,22 @@ async def send_test(channel_id: int) -> Dict[str, Any]:
         await asyncio.to_thread(_record_channel_test, channel_id, False, str(exc))
         return {"ok": False, "error": str(exc)}
     # Same SSRF guard as live delivery — the Test button must not be an escape.
-    if not await asyncio.to_thread(is_public_url, req.url):
+    try:
+        target = await asyncio.to_thread(resolve_public_target, req.url)
+    except UnsafeUrlError:
         host = urlsplit(req.url).hostname or req.url
         err = f"blocked: {host} is not a public host"
         await asyncio.to_thread(_record_channel_test, channel_id, False, err)
         return {"ok": False, "error": err}
     try:
-        client = get_http_client()
-        resp = await client.request(
-            req.method,
-            req.url,
-            headers=req.headers or None,
-            json=req.json,
-            content=req.data.encode("utf-8") if req.data is not None else None,
-            timeout=_REQUEST_TIMEOUT_S,
-        )
+        async with _client_for(target) as client:
+            resp = await client.request(
+                req.method,
+                req.url,
+                headers=req.headers or None,
+                json=req.json,
+                content=req.data.encode("utf-8") if req.data is not None else None,
+            )
         if 200 <= resp.status_code < 300:
             await asyncio.to_thread(_record_channel_test, channel_id, True, None)
             return {"ok": True, "error": None}

--- a/backend/app/services/print_results.py
+++ b/backend/app/services/print_results.py
@@ -27,6 +27,36 @@ def material_type_for_file(session: Session, file_id: int) -> str | None:
     return meta.material_type if meta else None
 
 
+def resolve_completion_cost(
+    session: Session, job: PrintJob
+) -> tuple[float | None, float | None]:
+    """Effective filament grams and frozen cost for a job reaching COMPLETED.
+
+    Called once, at the moment a job is marked completed, from every path
+    that can do that (live printer sync, manual log, history import) so
+    ``print_statistics`` can sum a persisted column instead of re-deriving
+    cost per row on every dashboard load. The result is frozen — a later
+    change to a filament profile's price does not revise it.
+    """
+    from app.services import model_views
+
+    md = session.exec(
+        select(Metadata).where(Metadata.file_id == job.file_id)
+    ).first()
+    if job.filament_used_g is not None:
+        grams = job.filament_used_g
+    elif md is not None:
+        grams = md.filament_weight_g
+    else:
+        grams = None
+
+    profiles = model_views._load_filament_profiles(session)
+    cost = model_views.filament_cost_for_job(profiles, md, grams, job.spool_filament_id)
+    if cost is None and job.filament_used_g is None and md is not None:
+        cost = md.filament_cost
+    return grams, cost
+
+
 def linked_profile_for_spool(
     session: Session, spool_filament_id: int | None
 ) -> FilamentProfile | None:

--- a/backend/app/services/printer_hub.py
+++ b/backend/app/services/printer_hub.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 from fastapi import Request, WebSocket
 from sqlmodel import Session, select
@@ -27,10 +27,12 @@ from app.db.models import (
     PrinterStatus,
 )
 from app.db.session import get_session_factory
+from app.services.backup import restore_in_progress
 from app.services import filament as filament_svc
 from app.services import notifications
 from app.services import print_results
 from app.services.printer_provider import ProviderError, get_provider_client
+from app.services.realtime import InProcessBus, RealtimeBus
 from app.services.runtime_config import auto_mark_known_good_enabled
 from app.db.scopes import live
 
@@ -99,20 +101,23 @@ _STATUS_WRITE_INTERVAL_S = 30.0
 
 
 class PrinterHub:
-    def __init__(self) -> None:
+    def __init__(self, bus: RealtimeBus | None = None) -> None:
         self.snapshots: Dict[int, Dict[str, Any]] = {}
-        self.subscribers: Dict[int, Set[WebSocket]] = {}
+        self.bus: RealtimeBus = bus if bus is not None else InProcessBus()
         self.tasks: Dict[int, asyncio.Task] = {}
         self.stop_events: Dict[int, asyncio.Event] = {}
         self._lock = asyncio.Lock()
         # printer_id -> (status, error, monotonic time of last DB write)
         self._last_status_write: Dict[int, tuple[PrinterStatus, str | None, float]] = {}
 
+    @staticmethod
+    def _channel(printer_id: int) -> str:
+        return f"printer:{printer_id}"
+
     # -- WS subscriber registry --
 
     async def attach(self, printer_id: int, ws: WebSocket) -> None:
-        async with self._lock:
-            self.subscribers.setdefault(printer_id, set()).add(ws)
+        await self.bus.subscribe(self._channel(printer_id), ws)
         snap = self.snapshots.get(printer_id)
         if snap is not None:
             try:
@@ -123,24 +128,10 @@ class PrinterHub:
                 pass
 
     async def detach(self, printer_id: int, ws: WebSocket) -> None:
-        async with self._lock:
-            subs = self.subscribers.get(printer_id)
-            if subs and ws in subs:
-                subs.remove(ws)
+        await self.bus.unsubscribe(self._channel(printer_id), ws)
 
     async def _broadcast(self, printer_id: int, payload: Dict[str, Any]) -> None:
-        async with self._lock:
-            subs = list(self.subscribers.get(printer_id, ()))
-        dead: list[WebSocket] = []
-        for ws in subs:
-            try:
-                await ws.send_json(payload)
-            except Exception:
-                dead.append(ws)
-        if dead:
-            async with self._lock:
-                for ws in dead:
-                    self.subscribers.get(printer_id, set()).discard(ws)
+        await self.bus.publish(self._channel(printer_id), payload)
 
     # -- printer lifecycle --
 
@@ -344,6 +335,8 @@ class PrinterHub:
         """
         if not filename:
             return
+        if restore_in_progress():
+            return
         try:
             await asyncio.to_thread(
                 self._sync_active_job_db,
@@ -482,6 +475,11 @@ class PrinterHub:
                         ),
                         density_g_cm3=linked.density_g_cm3 if linked else None,
                     )
+                if new_state == PrintJobState.COMPLETED:
+                    (
+                        job.filament_g_effective,
+                        job.cost,
+                    ) = print_results.resolve_completion_cost(session, job)
             if changed:
                 job.updated_at = utcnow()
                 if new_state == PrintJobState.FAILED:

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from fastapi import HTTPException, status
+from sqlalchemy import or_
 from sqlmodel import Session, select
 
 from app.db.models import Collection, CollectionPermission, CollectionRole, User
@@ -66,33 +67,58 @@ def require_collection_role(
     )
 
 
+def _like_prefix(path: str) -> str:
+    """Build the descendant-matching LIKE pattern for *path*.
+
+    ``slugify`` cannot currently emit ``%`` or ``_``, so the escaping is belt
+    and braces — but this is an access-control boundary, and an unescaped ``_``
+    is a single-character wildcard that would widen a grant to sibling trees.
+    """
+    escaped = path.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return escaped + "/%"
+
+
 def accessible_collection_ids(
     session: Session,
     user: User,
     minimum: CollectionRole = CollectionRole.VIEW,
 ) -> set[int]:
-    collections = list(session.exec(select(Collection).where(live(Collection))).all())
-    if user.is_superuser:
-        return {int(c.id) for c in collections if c.id is not None}
+    """Ids of every live collection *user* can reach at *minimum* or above.
 
-    grants = session.exec(
-        select(CollectionPermission, Collection)
-        .join(Collection, Collection.id == CollectionPermission.collection_id)
-        .where(CollectionPermission.user_id == user.id, live(Collection))
+    A grant cascades to descendants, which the materialised ``path`` turns into
+    a prefix test. Grant filtering and cascade both run in SQL; the previous
+    version compared every live collection against every grant in Python, on
+    every permission check.
+    """
+    if user.is_superuser:
+        rows = session.exec(select(Collection.id).where(live(Collection))).all()
+        return {int(cid) for cid in rows if cid is not None}
+
+    granted_paths = session.exec(
+        select(Collection.path)
+        .join(CollectionPermission, Collection.id == CollectionPermission.collection_id)  # type: ignore[arg-type]
+        .where(
+            CollectionPermission.user_id == user.id,
+            CollectionPermission.role.in_(  # type: ignore[union-attr]
+                [role for role in CollectionRole if role_allows(role, minimum)]
+            ),
+            live(Collection),
+        )
     ).all()
-    out: set[int] = set()
-    for collection in collections:
-        if collection.id is None:
-            continue
-        for permission, granted_collection in grants:
-            inherited = (
-                collection.path == granted_collection.path
-                or collection.path.startswith(granted_collection.path + "/")
+    if not granted_paths:
+        return set()
+
+    reachable = or_(
+        *[
+            or_(
+                Collection.path == path,
+                Collection.path.like(_like_prefix(path), escape="\\"),  # type: ignore[union-attr]
             )
-            if inherited and role_allows(permission.role, minimum):
-                out.add(collection.id)
-                break
-    return out
+            for path in granted_paths
+        ]
+    )
+    rows = session.exec(select(Collection.id).where(live(Collection), reachable)).all()
+    return {int(cid) for cid in rows if cid is not None}
 
 
 def require_model_collection_role(

--- a/backend/app/services/rbac.py
+++ b/backend/app/services/rbac.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Iterable
+
 from fastapi import HTTPException, status
 from sqlalchemy import or_
 from sqlmodel import Session, select
@@ -119,6 +121,55 @@ def accessible_collection_ids(
     )
     rows = session.exec(select(Collection.id).where(live(Collection), reachable)).all()
     return {int(cid) for cid in rows if cid is not None}
+
+
+def effective_roles_for_collections(
+    session: Session,
+    user: User,
+    collection_ids: Iterable[int | None],
+) -> dict[int | None, CollectionRole | None]:
+    """Resolve the effective role for many collections at once.
+
+    Two queries regardless of how many ids are asked for. ``effective_collection_role``
+    costs two queries *per call*, so resolving a page of rows one at a time turns
+    a listing into an N+1. ``None`` maps to ``None`` (the root, which only
+    superusers reach).
+    """
+    ids = {cid for cid in collection_ids if cid is not None}
+    out: dict[int | None, CollectionRole | None] = {None: None}
+
+    if user.is_superuser:
+        out.update({cid: CollectionRole.ADMIN for cid in ids})
+        out[None] = CollectionRole.ADMIN
+        return out
+
+    out.update({cid: None for cid in ids})
+    if not ids:
+        return out
+
+    paths = session.exec(
+        select(Collection.id, Collection.path).where(
+            Collection.id.in_(ids),  # type: ignore[union-attr]
+            live(Collection),
+        )
+    ).all()
+
+    grants = session.exec(
+        select(Collection.path, CollectionPermission.role)
+        .join(CollectionPermission, Collection.id == CollectionPermission.collection_id)  # type: ignore[arg-type]
+        .where(CollectionPermission.user_id == user.id, live(Collection))
+    ).all()
+    if not grants:
+        return out
+
+    for cid, path in paths:
+        best: CollectionRole | None = None
+        for granted_path, role in grants:
+            inherited = path == granted_path or path.startswith(granted_path + "/")
+            if inherited and ROLE_ORDER[role] > ROLE_ORDER.get(best, 0):
+                best = role
+        out[int(cid)] = best
+    return out
 
 
 def require_model_collection_role(

--- a/backend/app/services/realtime.py
+++ b/backend/app/services/realtime.py
@@ -1,0 +1,67 @@
+"""Non-blocking pub/sub seam for WebSocket fan-out.
+
+``InProcessBus`` is the only adapter today — Stage 4/cloud can swap in a
+Redis-backed bus at the construction site with no change to callers, since
+they only depend on the ``RealtimeBus`` protocol.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Protocol, Set
+
+from fastapi import WebSocket
+
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SEND_TIMEOUT_S = 2.0
+
+
+class RealtimeBus(Protocol):
+    async def publish(self, channel: str, payload: Dict[str, Any]) -> None: ...
+
+    async def subscribe(self, channel: str, ws: WebSocket) -> None: ...
+
+    async def unsubscribe(self, channel: str, ws: WebSocket) -> None: ...
+
+
+class InProcessBus:
+    """Single-process fan-out. Subscriber sends run concurrently so one slow
+    or dead socket can't delay delivery to the rest of a channel."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, Set[WebSocket]] = {}
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, channel: str, ws: WebSocket) -> None:
+        async with self._lock:
+            self._subscribers.setdefault(channel, set()).add(ws)
+
+    async def unsubscribe(self, channel: str, ws: WebSocket) -> None:
+        async with self._lock:
+            subs = self._subscribers.get(channel)
+            if subs and ws in subs:
+                subs.remove(ws)
+
+    async def publish(self, channel: str, payload: Dict[str, Any]) -> None:
+        async with self._lock:
+            subs = list(self._subscribers.get(channel, ()))
+        if not subs:
+            return
+
+        async def _send(ws: WebSocket) -> WebSocket | None:
+            try:
+                async with asyncio.timeout(_SEND_TIMEOUT_S):
+                    await ws.send_json(payload)
+                return None
+            except Exception:
+                return ws
+
+        results = await asyncio.gather(*(_send(ws) for ws in subs))
+        dead = [r for r in results if r is not None]
+        if dead:
+            async with self._lock:
+                for ws in dead:
+                    self._subscribers.get(channel, set()).discard(ws)

--- a/backend/app/services/runtime_config.py
+++ b/backend/app/services/runtime_config.py
@@ -8,12 +8,13 @@ value without code changes. See ADR-0002.
 
 from __future__ import annotations
 
+import secrets
 from pathlib import Path
 from typing import Any, Optional
 
 from sqlmodel import Session, select
 
-from app.core.config import _overlay, ensure_dirs, settings
+from app.core.config import DEFAULT_JWT_SECRET, _overlay, ensure_dirs, settings
 from app.core.logging import get_logger
 from app.core.time import utcnow
 from app.db.models import SystemConfig, User
@@ -92,6 +93,37 @@ def apply_overlay(session: Session) -> None:
     # the importer's existing cookie path picks it up (see makerworld_auth).
     if config.makerworld_token:
         _overlay["makerworld_cookie"] = f"token={config.makerworld_token}"
+
+
+def ensure_jwt_secret(session: Session) -> None:
+    """Guarantee this install does not sign tokens with the published default.
+
+    Env wins and is never copied into the DB. Otherwise the persisted secret is
+    applied, or a fresh one is generated and stored so it survives restarts —
+    regenerating on every boot would log everyone out on every restart.
+
+    Refusing to boot instead would brick every existing install, since the
+    compose files default ``VAULT_JWT_SECRET`` to the shipped value.
+    """
+    if settings.jwt_secret != DEFAULT_JWT_SECRET:
+        return
+
+    config = get_or_create(session)
+    if config.jwt_secret:
+        _overlay["jwt_secret"] = config.jwt_secret
+        return
+
+    generated = secrets.token_hex(32)
+    config.jwt_secret = generated
+    config.updated_at = utcnow()
+    session.add(config)
+    session.commit()
+    _overlay["jwt_secret"] = generated
+    logger.warning(
+        "no VAULT_JWT_SECRET set — generated one and stored it in the database. "
+        "Existing login sessions are now invalid. Set VAULT_JWT_SECRET "
+        "(openssl rand -hex 32) to manage it yourself."
+    )
 
 
 def update_storage(

--- a/backend/app/services/trash.py
+++ b/backend/app/services/trash.py
@@ -144,7 +144,17 @@ def _cleanup_orphan_blobs(session: Session) -> int:
 
 def gc_soft_deleted(retention_days: int | None = None) -> dict[str, int]:
     """Hourly GC: purge expired trash rows across all soft-deletable tables,
-    then sweep orphaned blobs."""
+    then sweep orphaned blobs.
+
+    No-ops while a backup restore is in progress — restore replaces the DB
+    file and disposes the engine, so a GC pass racing it would run queries
+    against a database that no longer matches its connection.
+    """
+    from app.services.backup import restore_in_progress
+
+    if restore_in_progress():
+        logger.info("gc skipped: backup restore in progress")
+        return {"rows": 0, "orphan_blobs": 0}
     effective_retention = (
         int(settings.trash_retention_days) if retention_days is None else retention_days
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printstash"
-version = "0.8.3"
+version = "0.8.4"
 description = "PrintStash — self-hosted 3D printing asset manager"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,11 +8,16 @@ from typing import Iterator
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import event
 from sqlalchemy.pool import StaticPool
 from sqlmodel import Session, SQLModel, create_engine, select
 
 from app.core.config import _overlay
-from app.db.session import SQLiteSessionFactory, override_session_factory
+from app.db.session import (
+    SQLiteSessionFactory,
+    _set_sqlite_pragmas,
+    override_session_factory,
+)
 from app.services.printer_hub import PrinterHub
 
 TEST_DATA_DIR = Path(__file__).parent / "fixtures"
@@ -24,6 +29,10 @@ _test_engine = create_engine(
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,
 )
+
+# Same per-connection pragmas the app installs (notably foreign_keys=ON), so a
+# delete path that violates a constraint fails here rather than in production.
+event.listen(_test_engine, "connect", _set_sqlite_pragmas)
 
 _test_factory = SQLiteSessionFactory(_test_engine)
 
@@ -63,13 +72,21 @@ _TRUNCATE_TABLES_ORDER = [
 
 
 def _truncate_all() -> None:
-    """Truncate all tables between tests (respect FK order)."""
+    """Truncate all tables between tests.
+
+    FK enforcement is off for the wipe: this is a teardown, not a delete path,
+    and the listed order doesn't satisfy every constraint (metadata references
+    files, which go first). Leaving it on made the DELETEs fail silently and
+    leak rows into the next test.
+    """
     with _test_engine.begin() as conn:
+        conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
         for table in _TRUNCATE_TABLES_ORDER:
             try:
                 conn.exec_driver_sql(f"DELETE FROM {table}")
             except Exception:
                 pass
+        conn.exec_driver_sql("PRAGMA foreign_keys=ON")
     # Re-create sentinel rows.
     _ensure_test_sentinels()
 

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -32,7 +32,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from app.core.config import _overlay
 from app.db.session import SQLiteSessionFactory, override_session_factory
 from app.services import notification_renderers as renderers
-from app.services import notifications as notifications_service
+from app.core import url_safety
 
 from .fakes.provider_targets import build_provider_app
 from .fakes.recorder import Recorder
@@ -106,7 +106,9 @@ def fakes(monkeypatch: pytest.MonkeyPatch) -> Iterator[Fakes]:
     # Point the Telegram renderer at the fake Bot API (host is otherwise fixed).
     monkeypatch.setattr(renderers, "TELEGRAM_API_BASE", server.base_url)
     # Allow loopback targets — real providers are public, the fake is on 127.0.0.1.
-    monkeypatch.setattr(notifications_service, "is_public_url", lambda _url: True)
+    # Only the IP classification is relaxed: resolution and the pinned transport
+    # still run for real, so the dispatcher's egress path is the shipped one.
+    monkeypatch.setattr(url_safety, "is_public_ip", lambda _ip: True)
 
     try:
         yield Fakes(recorder=recorder, base_url=server.base_url)

--- a/backend/tests/test_backup_restore.py
+++ b/backend/tests/test_backup_restore.py
@@ -73,6 +73,9 @@ def backup_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Back
     # Reset cached singletons so they pick up our overlay.
     monkeypatch.setattr(storage_backend, "_backend", None, raising=False)
     monkeypatch.setattr(backup, "_backup_s3", None, raising=False)
+    # Real restores wait a grace period for in-flight jobs to finish; tests
+    # don't need to pay that wall-clock cost.
+    monkeypatch.setattr(backup, "_RESTORE_GRACE_PERIOD_S", 0)
 
     try:
         yield BackupEnv(
@@ -334,6 +337,71 @@ def test_download_then_restore_endpoint_round_trip(
 def test_restore_unknown_backup_raises(backup_env: BackupEnv):
     with pytest.raises(FileNotFoundError):
         backup.restore_backup("does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# Restore gate (item 11: quiesce background loops during restore)
+# ---------------------------------------------------------------------------
+
+
+def test_restore_rejected_while_job_running(backup_env: BackupEnv):
+    from app.services.jobs import registry
+
+    _seed_model_with_blob(backup_env, name="Widget", content=b"x")
+    meta = backup.create_backup()
+    db_bytes_before = backup_env.db_file.read_bytes()
+
+    job_id = registry.create()
+    registry.update(job_id, state="running")
+    try:
+        with pytest.raises(backup.RestoreConflictError):
+            backup.restore_backup(meta.id)
+    finally:
+        registry.update(job_id, state="completed")
+
+    assert backup_env.db_file.read_bytes() == db_bytes_before
+    assert not backup.restore_in_progress()
+
+
+def test_gc_skips_during_restore(backup_env: BackupEnv):
+    from app.services import trash
+
+    # A trashed row past retention would normally be purged.
+    with backup_env.new_session() as session:
+        from app.core.time import utcnow
+        from datetime import timedelta
+
+        from app.db.models import Tag
+
+        session.add(Tag(name="stale", slug="stale", deleted_at=utcnow() - timedelta(days=999)))
+        session.commit()
+
+    backup._restore_gate.set()
+    try:
+        result = trash.gc_soft_deleted()
+    finally:
+        backup._restore_gate.clear()
+
+    assert result == {"rows": 0, "orphan_blobs": 0}
+    with backup_env.new_session() as session:
+        assert session.exec(select(Tag)).first() is not None
+
+
+def test_gate_is_cleared_when_restore_raises(
+    backup_env: BackupEnv, monkeypatch: pytest.MonkeyPatch
+):
+    _seed_model_with_blob(backup_env, name="Widget", content=b"x")
+    meta = backup.create_backup()
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated failure mid-restore")
+
+    monkeypatch.setattr(backup, "_download_backup_to_local", _boom)
+
+    with pytest.raises(RuntimeError):
+        backup.restore_backup(meta.id)
+
+    assert not backup.restore_in_progress()
 
 
 def test_delete_backup_removes_archive(backup_env: BackupEnv):

--- a/backend/tests/test_collection_rbac.py
+++ b/backend/tests/test_collection_rbac.py
@@ -339,3 +339,44 @@ def test_deleting_a_child_does_not_block_deleting_the_parent(
     # After the child is trashed, the parent deletes cleanly.
     assert client.delete(f"/api/v1/collections/{child['id']}", headers=h).status_code == 204
     assert client.delete(f"/api/v1/collections/{parent['id']}", headers=h).status_code == 204
+
+
+def test_role_revocation_takes_effect_immediately(
+    client: TestClient,
+    db_session: Session,
+) -> None:
+    """Revoking a grant must lock the user out on the very next request.
+
+    Access is resolved per request, so nothing may cache a stale grant — a
+    revoked collaborator who can still read is the whole point of the feature.
+    """
+    user = _user(db_session, "revoked")
+    collection = taxonomy.resolve_or_create_collection(db_session, "Secrets")
+    assert collection is not None
+    child = taxonomy.resolve_or_create_collection(db_session, "Secrets/Inner")
+    assert child is not None
+    _grant(db_session, user, collection.id, CollectionRole.VIEW)
+    model = _model(db_session, "Inner Model", child.id)
+
+    before = client.get(f"/api/v1/models/{model.id}", headers=_headers(user))
+    assert before.status_code == 200
+
+    permission = db_session.exec(
+        select(CollectionPermission).where(
+            CollectionPermission.user_id == user.id,
+            CollectionPermission.collection_id == collection.id,
+        )
+    ).one()
+    db_session.delete(permission)
+    db_session.commit()
+
+    after = client.get(f"/api/v1/models/{model.id}", headers=_headers(user))
+    # 404, not 403: the model is filtered out before the role check, so a revoked
+    # user cannot even confirm it exists.
+    assert after.status_code == 404, "revoked user still reads an inherited model"
+
+    listed = client.get("/api/v1/models", headers=_headers(user))
+    assert listed.status_code == 200
+    body = listed.json()
+    rows = body["items"] if isinstance(body, dict) else body
+    assert all(row["id"] != model.id for row in rows)

--- a/backend/tests/test_ingestion_atomicity.py
+++ b/backend/tests/test_ingestion_atomicity.py
@@ -1,0 +1,174 @@
+"""``persist_artifact`` writes one artifact, or nothing at all.
+
+It used to commit the File row before writing the thumbnail and the Metadata
+row. A failure in between (a corrupt image, a full disk) left a committed File
+with no metadata — a model that renders but has no print time, filament or cost,
+and no error anywhere to explain it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session, select
+
+from app.core.config import _overlay
+from app.db.models import File, FileType, Metadata, Model
+from app.services import ingestion, thumbnail
+from app.services.storage_backend import get_backend
+
+
+@pytest.fixture
+def storage(tmp_path: Path):
+    _overlay["storage_backend"] = "local"
+    _overlay["data_dir"] = tmp_path / "files"
+    _overlay["thumb_dir"] = tmp_path / "thumbs"
+    (tmp_path / "files").mkdir()
+    (tmp_path / "thumbs").mkdir()
+    yield get_backend()
+    for key in ("storage_backend", "data_dir", "thumb_dir"):
+        _overlay.pop(key, None)
+
+
+@pytest.fixture
+def model(db_session: Session) -> Model:
+    model = Model(name="Bracket", slug="bracket", hash="h" * 64)
+    db_session.add(model)
+    db_session.commit()
+    db_session.refresh(model)
+    return model
+
+
+def _staged(tmp_path: Path, name: str = "bracket.stl") -> Path:
+    staged = tmp_path / name
+    staged.write_bytes(b"solid bracket\nendsolid\n")
+    return staged
+
+
+def _persist(db_session: Session, model: Model, staged: Path, **kwargs):
+    defaults = dict(
+        model=model,
+        staged_path=staged,
+        original_filename=staged.name,
+        file_type=FileType.STL,
+        blob_hash="b" * 64,
+        meta={"estimated_time_s": 120},
+        thumb_bytes=None,
+        overwrite_thumbnail=True,
+    )
+    defaults.update(kwargs)
+    return ingestion.persist_artifact(db_session, **defaults)
+
+
+def test_persists_file_and_metadata_together(
+    db_session: Session, storage, model: Model, tmp_path: Path
+) -> None:
+    file_row = _persist(db_session, model, _staged(tmp_path))
+
+    assert file_row.id is not None
+    md = db_session.exec(
+        select(Metadata).where(Metadata.file_id == file_row.id)
+    ).first()
+    assert md is not None and md.estimated_time_s == 120
+
+
+def test_failed_thumbnail_does_not_leave_partial_model(
+    db_session: Session,
+    storage,
+    model: Model,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(_data: bytes) -> bytes:
+        raise ValueError("corrupt image")
+
+    monkeypatch.setattr(thumbnail, "to_webp", _boom)
+
+    with pytest.raises(ValueError, match="corrupt image"):
+        _persist(db_session, model, _staged(tmp_path), thumb_bytes=b"not-an-image")
+
+    db_session.rollback()
+    assert db_session.exec(select(File).where(File.model_id == model.id)).all() == []
+    assert db_session.exec(select(Metadata)).all() == []
+
+
+def test_failed_metadata_does_not_leave_orphan_file_row(
+    db_session: Session,
+    storage,
+    model: Model,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A File row without its Metadata is the silent-corruption case."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("metadata boom")
+
+    # ``Metadata`` is only ever called to construct the row; model_fields is read
+    # first, so keep that attribute intact.
+    _boom.model_fields = ingestion.Metadata.model_fields
+    monkeypatch.setattr(ingestion, "Metadata", _boom)
+
+    with pytest.raises(RuntimeError, match="metadata boom"):
+        _persist(db_session, model, _staged(tmp_path))
+
+    db_session.rollback()
+    assert db_session.exec(select(File).where(File.model_id == model.id)).all() == []
+
+
+def test_version_numbers_increment_across_revisions(
+    db_session: Session, storage, model: Model, tmp_path: Path
+) -> None:
+    first = _persist(db_session, model, _staged(tmp_path, "v1.stl"))
+    second = _persist(db_session, model, _staged(tmp_path, "v2.stl"))
+
+    assert (first.version, second.version) == (1, 2)
+
+
+def test_thumbnail_is_written_and_selected(
+    db_session: Session, storage, model: Model, tmp_path: Path
+) -> None:
+    png = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00"
+        b"\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    file_row = _persist(db_session, model, _staged(tmp_path), thumb_bytes=png)
+
+    db_session.refresh(model)
+    assert model.thumbnail_file_id == file_row.id
+    assert Path(storage.thumbnail_key(file_row.id)).exists()
+
+
+def test_concurrent_same_hash_upload_dedups_instead_of_crashing(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Model.hash is UNIQUE. Two uploads of the same bytes race between the
+    lookup and the insert; the loser must dedup onto the winner's model, not
+    500 with an IntegrityError."""
+    from app.db.session import get_session_factory
+    from app.services import storage as storage_mod
+
+    dedup_hash = "c" * 64
+    real_ensure = storage_mod.ensure_unique_slug
+
+    def _insert_the_winner(base_slug, exists):
+        # Runs after resolve_or_create_model's SELECT found nothing and before
+        # its INSERT lands — exactly the window the race lives in.
+        with get_session_factory().session() as other:
+            other.add(Model(name="Winner", slug="winner", hash=dedup_hash))
+            other.commit()
+        return real_ensure(base_slug, exists)
+
+    monkeypatch.setattr(ingestion.storage, "ensure_unique_slug", _insert_the_winner)
+
+    model, created = ingestion.resolve_or_create_model(
+        db_session, dedup_hash=dedup_hash, model_name="Loser"
+    )
+
+    assert created is False
+    assert model.name == "Winner"
+    assert (
+        len(db_session.exec(select(Model).where(Model.hash == dedup_hash)).all()) == 1
+    )

--- a/backend/tests/test_job_import.py
+++ b/backend/tests/test_job_import.py
@@ -1,0 +1,142 @@
+"""Tests for services.job_import.import_print_jobs_from_printer."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from sqlmodel import Session, select
+
+from app.db.models import File, FileType, Model, Printer, PrintJob, PrintJobState
+from app.services import job_import
+
+
+_seed_counter = 0
+
+
+def _seed_model_and_file(db_session: Session, filename: str = "Benchy.gcode") -> File:
+    global _seed_counter
+    _seed_counter += 1
+    m = Model(name="Model", slug=f"model-{_seed_counter}", hash=f"{_seed_counter:064x}")
+    db_session.add(m)
+    db_session.commit()
+    db_session.refresh(m)
+
+    f = File(
+        model_id=m.id,
+        path="/data/benchy.gcode",
+        original_filename=filename,
+        file_type=FileType.GCODE,
+        version=1,
+        size_bytes=100,
+        sha256="c" * 64,
+    )
+    db_session.add(f)
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+def _seed_printer(db_session: Session) -> Printer:
+    p = Printer(name="Ender 3", moonraker_url="http://10.0.0.1:7125")
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+    return p
+
+
+def _run_import(session: Session, *, model_id: int, printer_id: int, history: list[dict]):
+    with patch(
+        "app.services.job_import.MoonrakerClient.get_print_history",
+        new=AsyncMock(return_value=history),
+    ):
+        return asyncio.run(
+            job_import.import_print_jobs_from_printer(
+                session,
+                model_id=model_id,
+                printer_id=printer_id,
+                moonraker_url="http://10.0.0.1:7125",
+                moonraker_api_key=None,
+            )
+        )
+
+
+def test_import_dedups_case_insensitively(db_session: Session):
+    f = _seed_model_and_file(db_session, filename="Benchy.gcode")
+    p = _seed_printer(db_session)
+    db_session.add(
+        PrintJob(
+            printer_id=p.id,
+            file_id=f.id,
+            model_id=f.model_id,
+            remote_filename="Benchy.gcode",
+            state=PrintJobState.COMPLETED,
+        )
+    )
+    db_session.commit()
+
+    results = _run_import(
+        db_session,
+        model_id=f.model_id,
+        printer_id=p.id,
+        history=[{"filename": "benchy.gcode", "status": "completed"}],
+    )
+
+    assert results[0].imported is False
+    jobs = db_session.exec(
+        select(PrintJob).where(PrintJob.model_id == f.model_id)
+    ).all()
+    assert len(jobs) == 1
+
+
+def test_import_is_idempotent(db_session: Session):
+    f = _seed_model_and_file(db_session)
+    p = _seed_printer(db_session)
+    history = [{"filename": "Benchy.gcode", "status": "completed"}]
+
+    _run_import(db_session, model_id=f.model_id, printer_id=p.id, history=history)
+    _run_import(db_session, model_id=f.model_id, printer_id=p.id, history=history)
+
+    jobs = db_session.exec(
+        select(PrintJob).where(PrintJob.model_id == f.model_id)
+    ).all()
+    assert len(jobs) == 1
+
+
+def test_import_maps_moonraker_status_to_job_state(db_session: Session):
+    f = _seed_model_and_file(db_session)
+    p = _seed_printer(db_session)
+    history = [
+        {"filename": "Benchy.gcode", "status": "completed"},
+    ]
+    _run_import(db_session, model_id=f.model_id, printer_id=p.id, history=history)
+    job = db_session.exec(
+        select(PrintJob).where(PrintJob.model_id == f.model_id)
+    ).one()
+    assert job.state == PrintJobState.COMPLETED
+
+    f2 = _seed_model_and_file(db_session, filename="Other.gcode")
+    history2 = [{"filename": "Other.gcode", "status": "cancelled"}]
+    _run_import(db_session, model_id=f2.model_id, printer_id=p.id, history=history2)
+    job2 = db_session.exec(
+        select(PrintJob).where(PrintJob.model_id == f2.model_id)
+    ).one()
+    assert job2.state == PrintJobState.CANCELLED
+
+
+def test_import_skips_files_not_in_this_model(db_session: Session):
+    f = _seed_model_and_file(db_session, filename="Benchy.gcode")
+    p = _seed_printer(db_session)
+
+    results = _run_import(
+        db_session,
+        model_id=f.model_id,
+        printer_id=p.id,
+        history=[{"filename": "unrelated.gcode", "status": "completed"}],
+    )
+
+    assert results == []
+    jobs = db_session.exec(
+        select(PrintJob).where(PrintJob.model_id == f.model_id)
+    ).all()
+    assert jobs == []

--- a/backend/tests/test_jwt_secret.py
+++ b/backend/tests/test_jwt_secret.py
@@ -1,0 +1,69 @@
+"""Nobody may run on the shipped JWT secret.
+
+It is published in the repo, in `.env.example` and in the compose defaults, so
+anyone can mint an admin token for an install that never overrode it. On boot we
+replace it with a generated secret persisted in ``system_config``, rather than
+refusing to start — a self-hoster who upgrades must not find a dead container.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session
+
+from app.core.config import DEFAULT_JWT_SECRET, _overlay, settings
+from app.services.runtime_config import ensure_jwt_secret, get_or_create
+
+
+@pytest.fixture(autouse=True)
+def _default_secret(monkeypatch: pytest.MonkeyPatch):
+    """Pin the frozen setting: the dev shell may export VAULT_JWT_SECRET, and
+    these tests are about what happens when nobody does."""
+    monkeypatch.setattr(settings._frozen, "jwt_secret", DEFAULT_JWT_SECRET)
+    yield
+    _overlay.pop("jwt_secret", None)
+
+
+def test_generates_and_persists_secret_when_default(db_session: Session) -> None:
+    ensure_jwt_secret(db_session)
+
+    stored = get_or_create(db_session).jwt_secret
+    assert stored and stored != DEFAULT_JWT_SECRET
+    assert len(stored) >= 32
+    assert settings.jwt_secret == stored, "generated secret must be the effective one"
+
+
+def test_generated_secret_is_stable_across_restarts(db_session: Session) -> None:
+    ensure_jwt_secret(db_session)
+    first = settings.jwt_secret
+
+    _overlay.pop("jwt_secret", None)  # simulate a restart
+    ensure_jwt_secret(db_session)
+
+    assert settings.jwt_secret == first, "a restart must not invalidate every session"
+
+
+def test_env_supplied_secret_is_left_alone(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator who sets VAULT_JWT_SECRET stays in charge of it."""
+    monkeypatch.setattr(settings._frozen, "jwt_secret", "operator-chosen-secret")
+
+    ensure_jwt_secret(db_session)
+
+    assert settings.jwt_secret == "operator-chosen-secret"
+    assert get_or_create(db_session).jwt_secret is None, "must not persist env secrets"
+
+
+def test_two_installs_get_different_secrets(db_session: Session) -> None:
+    ensure_jwt_secret(db_session)
+    first = settings.jwt_secret
+
+    config = get_or_create(db_session)
+    config.jwt_secret = None
+    db_session.add(config)
+    db_session.commit()
+    _overlay.pop("jwt_secret", None)
+
+    ensure_jwt_secret(db_session)
+    assert settings.jwt_secret != first

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -433,3 +433,69 @@ def test_sqlite_pragma_enforces_foreign_keys(tmp_path: Path) -> None:
                 )
     finally:
         engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# print_jobs.cost backfill (175be54ef975)
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_populates_existing_jobs(tmp_path: Path) -> None:
+    """A job completed before the migration gets its cost resolved from its
+    metadata/profile, exactly like a freshly-completed job would today."""
+    db_path = tmp_path / "precost.sqlite"
+    cfg = _upgrade_to(db_path, "b2d8f6a1c94e")  # the revision before this one
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO models (id, name, slug, hash, created_at, updated_at)"
+                " VALUES (1, 'M', 'm', 'h', '2026-01-01', '2026-01-01')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO files (id, model_id, path, original_filename,"
+                " file_type, version, size_bytes, sha256, is_recommended,"
+                " is_external, uploaded_at)"
+                " VALUES (1, 1, '/f', 'f.gcode', 'gcode', 1, 1, 'sha',"
+                " 0, 0, '2026-01-01')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO metadata (id, file_id, material_type, material_brand,"
+                " created_at)"
+                " VALUES (1, 1, 'PLA', 'Hatchbox', '2026-01-01')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO filament_profiles (id, name, material_type,"
+                " material_brand, cost_per_kg, created_at, updated_at)"
+                " VALUES (1, 'Hatchbox PLA', 'PLA', 'Hatchbox', 20.0,"
+                " '2026-01-01', '2026-01-01')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO print_jobs (id, file_id, model_id, remote_filename,"
+                " state, progress, source, filament_used_g, created_at, updated_at)"
+                " VALUES (1, 1, 1, 'f.gcode', 'completed', 1.0, 'vault', 100.0,"
+                " '2026-01-01', '2026-01-01')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        row = conn.execute(
+            text("SELECT cost, filament_g_effective FROM print_jobs WHERE id = 1")
+        ).one()
+        assert row.filament_g_effective == 100.0
+        # 100g @ 20/kg => 2.00.
+        assert row.cost == 2.0
+    engine.dispose()

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -303,3 +303,133 @@ def test_upgrade_from_pre_0_8_0_release_preserves_data(tmp_path: Path) -> None:
     finally:
         engine.dispose()
     assert _current(url) == _head_revision()
+
+
+# ---------------------------------------------------------------------------
+# Orphan-row repair before foreign key enforcement (b2d8f6a1c94e)
+# ---------------------------------------------------------------------------
+
+
+def _upgrade_to(db_path: Path, revision: str) -> Config:
+    cfg = Config(str(Path(__file__).resolve().parents[1] / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    command.upgrade(cfg, revision)
+    return cfg
+
+
+def test_fk_repair_clears_dangling_nullable_reference(tmp_path: Path) -> None:
+    """A document whose creator was purged keeps the document, loses the attribution.
+
+    ``documents.created_by`` is one of the columns the migration chain actually
+    constrains — the ORM declares more foreign keys than the shipped schema has.
+    """
+    db_path = tmp_path / "dirty.sqlite"
+    cfg = _upgrade_to(db_path, "a1c7e4f9b23d")  # the revision before the repair
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO documents (name, kind, created_by, created_at,"
+                " updated_at) VALUES ('orphaned', 'markdown', 999,"
+                " '2026-01-01', '2026-01-01')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        row = conn.execute(
+            text("SELECT name, created_by FROM documents WHERE name = 'orphaned'")
+        ).one()
+        assert row.name == "orphaned", "the document itself must survive"
+        assert row.created_by is None
+        assert conn.exec_driver_sql("PRAGMA foreign_key_check").fetchall() == []
+    engine.dispose()
+
+
+def test_fk_repair_deletes_row_with_dangling_required_reference(
+    tmp_path: Path,
+) -> None:
+    """A permission grant for a purged user cannot be loaded — drop it."""
+    db_path = tmp_path / "dirty.sqlite"
+    cfg = _upgrade_to(db_path, "a1c7e4f9b23d")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO collections (name, slug, path, created_at)"
+                " VALUES ('c', 'c', 'c', '2026-01-01')"
+            )
+        )
+        conn.execute(
+            text(
+                "INSERT INTO collection_permissions (user_id, collection_id, role,"
+                " created_at, updated_at)"
+                " VALUES (999, 1, 'view', '2026-01-01', '2026-01-01')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        count = conn.execute(
+            text("SELECT count(*) FROM collection_permissions")
+        ).scalar()
+        assert count == 0
+        assert conn.exec_driver_sql("PRAGMA foreign_key_check").fetchall() == []
+    engine.dispose()
+
+
+def test_fk_repair_leaves_clean_database_untouched(tmp_path: Path) -> None:
+    db_path = tmp_path / "clean.sqlite"
+    cfg = _upgrade_to(db_path, "a1c7e4f9b23d")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO models (name, slug, hash, created_at, updated_at)"
+                " VALUES ('kept', 'kept', 'h1', '2026-01-01', '2026-01-01')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(cfg, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        assert conn.execute(text("SELECT count(*) FROM models")).scalar() == 1
+    engine.dispose()
+
+
+def test_sqlite_pragma_enforces_foreign_keys(tmp_path: Path) -> None:
+    """The pragma is what makes the repair worth doing: without it SQLite happily
+    writes a child row pointing at a parent that was never there."""
+    import pytest
+    from sqlalchemy import event
+    from sqlalchemy.exc import IntegrityError
+
+    from app.db.session import _set_sqlite_pragmas
+
+    db_path = tmp_path / "vault.sqlite"
+    _upgrade_to(db_path, "head")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    event.listen(engine, "connect", _set_sqlite_pragmas)
+    try:
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "INSERT INTO api_keys (user_id, name, prefix, key_hash,"
+                        " created_at) VALUES (999, 'k', 'p', 'h', '2026-01-01')"
+                    )
+                )
+    finally:
+        engine.dispose()

--- a/backend/tests/test_model_views_n_plus_one.py
+++ b/backend/tests/test_model_views_n_plus_one.py
@@ -1,0 +1,132 @@
+"""Listing a page of models must cost a fixed number of queries.
+
+``effective_role`` was resolved per row, and each resolution ran two queries (the
+collection, then the grants). A 50-model page therefore issued ~100 extra
+queries, all returning the same handful of grants.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import pytest
+from sqlalchemy import event
+from sqlmodel import Session
+
+from app.db.models import CollectionPermission, CollectionRole, Model, User
+from app.services import model_views, taxonomy
+from app.services.auth import hash_password
+
+
+def _user(session: Session, username: str, *, superuser: bool = False) -> User:
+    user = User(
+        username=username,
+        hashed_password=hash_password("Password123"),
+        is_active=True,
+        is_superuser=superuser,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _seed_models(session: Session, count: int, collection_id: int) -> None:
+    for i in range(count):
+        session.add(
+            Model(
+                name=f"Model {i}",
+                slug=f"model-{i}",
+                hash=f"{i:064d}",
+                collection_id=collection_id,
+            )
+        )
+    session.commit()
+
+
+def _count_queries(session: Session, fn: Callable[[], object]) -> int:
+    statements: list[str] = []
+
+    def _record(conn, cursor, statement, *args):  # noqa: ANN001
+        statements.append(statement)
+
+    engine = session.get_bind()
+    event.listen(engine, "before_cursor_execute", _record)
+    try:
+        fn()
+    finally:
+        event.remove(engine, "before_cursor_execute", _record)
+    return len(statements)
+
+
+@pytest.mark.parametrize("superuser", [False, True])
+def test_list_query_count_is_independent_of_page_size(
+    db_session: Session, superuser: bool
+) -> None:
+    collection = taxonomy.resolve_or_create_collection(db_session, "Parts")
+    assert collection is not None
+    user = _user(db_session, f"lister-{superuser}", superuser=superuser)
+    if not superuser:
+        db_session.add(
+            CollectionPermission(
+                user_id=user.id,
+                collection_id=collection.id,
+                role=CollectionRole.EDIT,
+            )
+        )
+        db_session.commit()
+
+    _seed_models(db_session, 2, collection.id)
+    small = _count_queries(
+        db_session, lambda: model_views.list_items(db_session, user, limit=100)
+    )
+
+    _seed_models_more = 30
+    for i in range(_seed_models_more):
+        db_session.add(
+            Model(
+                name=f"Extra {i}",
+                slug=f"extra-{i}",
+                hash=f"e{i:063d}",
+                collection_id=collection.id,
+            )
+        )
+    db_session.commit()
+
+    large = _count_queries(
+        db_session, lambda: model_views.list_items(db_session, user, limit=100)
+    )
+
+    assert large == small, (
+        f"query count grew with page size ({small} -> {large}): a per-row lookup "
+        "is running inside the listing loop"
+    )
+
+
+def test_effective_role_is_still_correct_per_row(db_session: Session) -> None:
+    """Batching must not flatten roles: each model reports its own inherited role."""
+    parts = taxonomy.resolve_or_create_collection(db_session, "Parts")
+    toys = taxonomy.resolve_or_create_collection(db_session, "Toys")
+    assert parts is not None and toys is not None
+    user = _user(db_session, "mixed")
+    db_session.add(
+        CollectionPermission(
+            user_id=user.id, collection_id=parts.id, role=CollectionRole.ADMIN
+        )
+    )
+    db_session.add(
+        CollectionPermission(
+            user_id=user.id, collection_id=toys.id, role=CollectionRole.VIEW
+        )
+    )
+    db_session.commit()
+
+    db_session.add(Model(name="P", slug="p", hash="p" * 64, collection_id=parts.id))
+    db_session.add(Model(name="T", slug="t", hash="t" * 64, collection_id=toys.id))
+    db_session.commit()
+
+    items = model_views.list_items(db_session, user, limit=100)
+    roles = {item.name: item.effective_role for item in items}
+
+    assert roles["P"] == CollectionRole.ADMIN
+    assert roles["T"] == CollectionRole.VIEW

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,6 +1,6 @@
 """Coverage for the notification outbox: enqueue, dispatch, and hub edge-triggers.
 
-Network is always mocked at ``get_http_client``; the in-memory test engine
+Network is always mocked at ``notifications._client_for``; the in-memory test engine
 (see conftest) backs both the ``db_session`` fixture and the dispatcher's own
 sessions, so enqueue and delivery share one DB.
 """
@@ -22,6 +22,7 @@ from app.db.models import (
     Printer,
     PrinterStatus,
 )
+from app.core.url_safety import PinnedTarget, UnsafeUrlError
 from app.services import notifications
 from app.services.printer_hub import PrinterHub
 from app.services.runtime_config import set_notifications_enabled
@@ -54,13 +55,21 @@ def _deliveries(session, channel_id=None):
 
 
 def _http_returning(status_code=200, text="", headers=None):
+    """Fake for ``notifications._client_for``: an async-context-manager client."""
     resp = MagicMock()
     resp.status_code = status_code
     resp.text = text
     resp.headers = headers or {}
     client = MagicMock()
     client.request = AsyncMock(return_value=resp)
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
     return client
+
+
+def _client_factory(client):
+    """``_client_for(target)`` stub returning a prepared fake client."""
+    return lambda _target: client
 
 
 @pytest.fixture(autouse=True)
@@ -69,7 +78,10 @@ def _allow_public_urls():
 
     Tests that exercise the SSRF guard itself override this with their own patch.
     """
-    with patch.object(notifications, "is_public_url", return_value=True):
+    target = PinnedTarget(
+        url="https://hooks.example/x", host="hooks.example", port=443, ip="93.184.216.34"
+    )
+    with patch.object(notifications, "resolve_public_target", return_value=target):
         yield
 
 
@@ -172,7 +184,7 @@ async def test_dispatch_success_marks_sent_and_channel_status(db_session):
     )
     db_session.commit()
 
-    with patch.object(notifications, "get_http_client", return_value=_http_returning(204)):
+    with patch.object(notifications, "_client_for", new=_client_factory(_http_returning(204))):
         attempted = await notifications.dispatch_due()
     assert attempted == 1
 
@@ -194,7 +206,7 @@ async def test_dispatch_http_error_retries_with_backoff(db_session):
     )
     db_session.commit()
 
-    with patch.object(notifications, "get_http_client", return_value=_http_returning(500, "boom")):
+    with patch.object(notifications, "_client_for", new=_client_factory(_http_returning(500, "boom"))):
         await notifications.dispatch_due()
 
     db_session.expire_all()
@@ -221,7 +233,7 @@ async def test_dispatch_marks_failed_after_exhausting_retries(db_session):
     db_session.add(delivery)
     db_session.commit()
 
-    with patch.object(notifications, "get_http_client", return_value=_http_returning(500)):
+    with patch.object(notifications, "_client_for", new=_client_factory(_http_returning(500))):
         await notifications.dispatch_due()
 
     db_session.expire_all()
@@ -245,7 +257,7 @@ async def test_dispatch_render_error_fails_without_network(db_session):
     db_session.commit()
 
     client = _http_returning(200)
-    with patch.object(notifications, "get_http_client", return_value=client):
+    with patch.object(notifications, "_client_for", new=_client_factory(client)):
         await notifications.dispatch_due()
     client.request.assert_not_called()
 
@@ -265,8 +277,8 @@ async def test_dispatch_blocks_non_public_url(db_session):
 
     client = _http_returning(204)
     # Override the autouse allow-fixture: this URL is "not public".
-    with patch.object(notifications, "get_http_client", return_value=client), patch.object(
-        notifications, "is_public_url", return_value=False
+    with patch.object(notifications, "_client_for", new=_client_factory(client)), patch.object(
+        notifications, "resolve_public_target", side_effect=UnsafeUrlError("url_target_not_public")
     ):
         await notifications.dispatch_due()
     client.request.assert_not_called()  # never left the process
@@ -287,7 +299,7 @@ async def test_dispatch_honors_retry_after_without_spending_attempt(db_session):
     db_session.commit()
 
     client = _http_returning(429, "slow down", headers={"Retry-After": "120"})
-    with patch.object(notifications, "get_http_client", return_value=client):
+    with patch.object(notifications, "_client_for", new=_client_factory(client)):
         await notifications.dispatch_due()
 
     db_session.expire_all()
@@ -308,7 +320,7 @@ async def test_idempotency_key_header_sent(db_session):
     db_session.commit()
 
     client = _http_returning(204)
-    with patch.object(notifications, "get_http_client", return_value=client):
+    with patch.object(notifications, "_client_for", new=_client_factory(client)):
         await notifications.dispatch_due()
 
     headers = client.request.call_args.kwargs["headers"]
@@ -335,7 +347,7 @@ async def test_channel_auto_disabled_after_threshold(db_session):
     db_session.commit()
 
     client = _http_returning(500)
-    with patch.object(notifications, "get_http_client", return_value=client):
+    with patch.object(notifications, "_client_for", new=_client_factory(client)):
         await notifications.dispatch_due()
 
     db_session.refresh(ch)
@@ -356,7 +368,7 @@ async def test_success_resets_consecutive_failures(db_session):
     )
     db_session.commit()
 
-    with patch.object(notifications, "get_http_client", return_value=_http_returning(204)):
+    with patch.object(notifications, "_client_for", new=_client_factory(_http_returning(204))):
         await notifications.dispatch_due()
 
     db_session.refresh(ch)
@@ -384,7 +396,7 @@ async def test_stuck_sending_is_reclaimed(db_session):
     db_session.add(d)
     db_session.commit()
 
-    with patch.object(notifications, "get_http_client", return_value=_http_returning(204)):
+    with patch.object(notifications, "_client_for", new=_client_factory(_http_returning(204))):
         attempted = await notifications.dispatch_due()
 
     assert attempted == 1  # reclaimed and delivered
@@ -443,7 +455,7 @@ async def test_run_dispatcher_loop_delivers_then_cancels(db_session):
     db_session.commit()
 
     with patch.object(notifications, "_POLL_INTERVAL_S", 0.01), patch.object(
-        notifications, "get_http_client", return_value=_http_returning(204)
+        notifications, "_client_for", new=_client_factory(_http_returning(204))
     ):
         task = asyncio.create_task(notifications.run_dispatcher_loop())
         # Poll until the delivery is sent, then cancel the loop.

--- a/backend/tests/test_notifications_api.py
+++ b/backend/tests/test_notifications_api.py
@@ -52,10 +52,17 @@ def test_update_preserves_secret_when_blank(client: TestClient, auth_headers):
     # Verify by sending a test: a preserved URL renders/sends (mock the network).
     from unittest.mock import AsyncMock, MagicMock, patch
 
+    from app.core.url_safety import PinnedTarget
+
     resp = MagicMock(status_code=204, text="")
     fake = MagicMock(request=AsyncMock(return_value=resp))
-    with patch("app.services.notifications.get_http_client", return_value=fake), patch(
-        "app.services.notifications.is_public_url", return_value=True
+    fake.__aenter__ = AsyncMock(return_value=fake)
+    fake.__aexit__ = AsyncMock(return_value=False)
+    target = PinnedTarget(
+        url="https://hooks.example/x", host="hooks.example", port=443, ip="93.184.216.34"
+    )
+    with patch("app.services.notifications._client_for", return_value=fake), patch(
+        "app.services.notifications.resolve_public_target", return_value=target
     ):
         out = client.post(
             f"/api/v1/notifications/channels/{cid}/test", headers=auth_headers

--- a/backend/tests/test_print_results.py
+++ b/backend/tests/test_print_results.py
@@ -1,0 +1,107 @@
+"""Tests for services.print_results.resolve_completion_cost."""
+
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from app.db.models import File, FilamentProfile, FileType, Metadata, Model, PrintJob
+from app.services import print_results
+
+
+def _seed_file(db_session: Session, *, sha: str) -> File:
+    m = Model(name="M", slug=f"m-{sha}", hash=sha * 64)
+    db_session.add(m)
+    db_session.commit()
+    db_session.refresh(m)
+    f = File(
+        model_id=m.id,
+        path=f"/data/{sha}.gcode",
+        original_filename=f"{sha}.gcode",
+        file_type=FileType.GCODE,
+        version=1,
+        size_bytes=1,
+        sha256=sha * 64,
+    )
+    db_session.add(f)
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+def test_measured_values_win_over_slicer_estimate(db_session: Session):
+    db_session.add(
+        FilamentProfile(
+            name="Hatchbox PLA", material_type="PLA", material_brand="Hatchbox", cost_per_kg=20.0
+        )
+    )
+    db_session.commit()
+    f = _seed_file(db_session, sha="1")
+    db_session.add(Metadata(file_id=f.id, material_type="PLA", material_brand="Hatchbox"))
+    db_session.commit()
+
+    job = PrintJob(
+        file_id=f.id, model_id=f.model_id, remote_filename="x",
+        filament_used_g=50.0, actual_duration_s=600,
+    )
+    grams, cost = print_results.resolve_completion_cost(db_session, job)
+    assert (grams, cost) == (50.0, 1.0)
+
+
+def test_falls_back_to_slicer_estimate_grams(db_session: Session):
+    db_session.add(
+        FilamentProfile(
+            name="Hatchbox PLA", material_type="PLA", material_brand="Hatchbox", cost_per_kg=20.0
+        )
+    )
+    db_session.commit()
+    f = _seed_file(db_session, sha="2")
+    db_session.add(
+        Metadata(
+            file_id=f.id, material_type="PLA", material_brand="Hatchbox",
+            filament_weight_g=30.0,
+        )
+    )
+    db_session.commit()
+
+    job = PrintJob(file_id=f.id, model_id=f.model_id, remote_filename="x")
+    grams, cost = print_results.resolve_completion_cost(db_session, job)
+    assert (grams, cost) == (30.0, 0.6)
+
+
+def test_slicer_cost_used_when_no_profile_match(db_session: Session):
+    f = _seed_file(db_session, sha="3")
+    db_session.add(
+        Metadata(file_id=f.id, material_type="ABS", filament_weight_g=10.0, filament_cost=3.5)
+    )
+    db_session.commit()
+
+    job = PrintJob(file_id=f.id, model_id=f.model_id, remote_filename="x")
+    _, cost = print_results.resolve_completion_cost(db_session, job)
+    assert cost == 3.5
+
+
+def test_spool_linked_profile_preferred_over_fuzzy_match(db_session: Session):
+    db_session.add_all(
+        [
+            FilamentProfile(
+                name="Fuzzy PLA", material_type="PLA", material_brand="Hatchbox",
+                cost_per_kg=20.0,
+            ),
+            FilamentProfile(
+                name="Spool profile", material_type="PLA", material_brand="Other",
+                cost_per_kg=50.0, spoolman_filament_id=7,
+            ),
+        ]
+    )
+    db_session.commit()
+    f = _seed_file(db_session, sha="4")
+    db_session.add(Metadata(file_id=f.id, material_type="PLA", material_brand="Hatchbox"))
+    db_session.commit()
+
+    job = PrintJob(
+        file_id=f.id, model_id=f.model_id, remote_filename="x",
+        filament_used_g=100.0, spool_filament_id=7,
+    )
+    grams, cost = print_results.resolve_completion_cost(db_session, job)
+    # 100g @ 50/kg via the exact spool profile, not the fuzzy 20/kg match.
+    assert (grams, cost) == (100.0, 5.0)

--- a/backend/tests/test_print_statistics.py
+++ b/backend/tests/test_print_statistics.py
@@ -18,6 +18,7 @@ from app.db.models import (
     PrintJob,
     PrintJobState,
 )
+from app.services import print_results
 
 
 def _model(
@@ -75,19 +76,25 @@ def _job(
     grams: float | None = None,
     duration_s: int | None = None,
     finished_days_ago: float = 1,
-) -> None:
-    db_session.add(
-        PrintJob(
-            file_id=file_row.id,
-            model_id=model.id,
-            remote_filename=file_row.original_filename,
-            state=state,
-            filament_used_g=grams,
-            actual_duration_s=duration_s,
-            finished_at=utcnow() - timedelta(days=finished_days_ago),
-        )
+) -> PrintJob:
+    """Seed a PrintJob the way a real write path would: cost/effective grams
+    resolved and frozen at completion (mirrors printer_hub/manual-log/import)."""
+    job = PrintJob(
+        file_id=file_row.id,
+        model_id=model.id,
+        remote_filename=file_row.original_filename,
+        state=state,
+        filament_used_g=grams,
+        actual_duration_s=duration_s,
+        finished_at=utcnow() - timedelta(days=finished_days_ago),
     )
+    if state == PrintJobState.COMPLETED:
+        job.filament_g_effective, job.cost = print_results.resolve_completion_cost(
+            db_session, job
+        )
+    db_session.add(job)
     db_session.commit()
+    return job
 
 
 def test_print_stats_empty(
@@ -189,17 +196,19 @@ def test_print_stats_falls_back_to_slicer_estimate(
             estimated_time_s=1200,
         )
     )
-    db_session.add(
-        PrintJob(
-            file_id=file_row.id,
-            model_id=model.id,
-            remote_filename="c.gcode",
-            state=PrintJobState.COMPLETED,
-            filament_used_g=None,
-            actual_duration_s=None,
-            finished_at=utcnow() - timedelta(days=1),
-        )
+    job = PrintJob(
+        file_id=file_row.id,
+        model_id=model.id,
+        remote_filename="c.gcode",
+        state=PrintJobState.COMPLETED,
+        filament_used_g=None,
+        actual_duration_s=None,
+        finished_at=utcnow() - timedelta(days=1),
     )
+    job.filament_g_effective, job.cost = print_results.resolve_completion_cost(
+        db_session, job
+    )
+    db_session.add(job)
     db_session.commit()
 
     resp = client.get("/api/v1/models/stats/prints?period=30d", headers=auth_headers)
@@ -214,3 +223,220 @@ def test_print_stats_falls_back_to_slicer_estimate(
 def test_print_stats_requires_admin(client: TestClient) -> None:
     resp = client.get("/api/v1/models/stats/prints")
     assert resp.status_code in (401, 403)
+
+
+def _oracle_totals(db_session: Session, period: str) -> dict:
+    """Reimplements the pre-denormalization aggregation (live profile
+    matching, no persisted cost column) as a correctness oracle for the
+    SQL-based rewrite in ``model_views.print_statistics``."""
+    from sqlmodel import func, select
+
+    from app.db.scopes import live
+    from app.services import model_views as mv
+
+    lookback_days = mv._STATS_PERIODS.get(period, mv._STATS_PERIODS["30d"])
+    end_at = utcnow()
+    start_at = end_at - timedelta(days=lookback_days) if lookback_days is not None else None
+    anchor = func.coalesce(PrintJob.finished_at, PrintJob.created_at)
+
+    query = (
+        select(PrintJob, Metadata)
+        .join(File, File.id == PrintJob.file_id)
+        .outerjoin(Metadata, Metadata.file_id == File.id)
+        .where(live(PrintJob), PrintJob.state == PrintJobState.COMPLETED)
+    )
+    if start_at is not None:
+        query = query.where(anchor >= start_at)
+
+    rows = db_session.exec(query).all()
+    profiles = mv._load_filament_profiles(db_session)
+
+    total_cost, has_cost = 0.0, False
+    total_filament_g, has_filament = 0.0, False
+    total_duration_s = 0
+    for job, md in rows:
+        if job.filament_used_g is not None:
+            grams = job.filament_used_g
+            cost = mv.filament_cost_for_grams(profiles, md, grams)
+        elif md is not None:
+            grams = md.filament_weight_g
+            cost = mv.filament_cost_for_grams(profiles, md, grams)
+            if cost is None:
+                cost = md.filament_cost
+        else:
+            grams, cost = None, None
+
+        if cost is not None:
+            total_cost += cost
+            has_cost = True
+        if grams is not None:
+            total_filament_g += grams
+            has_filament = True
+        if job.actual_duration_s is not None:
+            total_duration_s += job.actual_duration_s
+
+    return {
+        "total_prints": len(rows),
+        "total_cost": round(total_cost, 4) if has_cost else None,
+        "total_filament_g": round(total_filament_g, 2) if has_filament else None,
+        "total_print_time_s": total_duration_s,
+    }
+
+
+def test_print_statistics_matches_oracle(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str]
+) -> None:
+    db_session.add_all(
+        [
+            FilamentProfile(name="PETG", material_type="PETG", cost_per_kg=20.0),
+            FilamentProfile(name="PLA", material_type="PLA", cost_per_kg=18.0),
+        ]
+    )
+    db_session.commit()
+
+    functional = Collection(name="Functional", slug="functional", path="functional")
+    db_session.add(functional)
+    db_session.commit()
+    db_session.refresh(functional)
+
+    bracket = _model(db_session, slug="bracket", collection_id=functional.id)
+    bracket_file = _file_with_material(db_session, bracket, sha="a", material_type="PETG")
+    _job(db_session, bracket, bracket_file, grams=100.0, duration_s=3600, finished_days_ago=2)
+    _job(db_session, bracket, bracket_file, grams=150.0, duration_s=1800, finished_days_ago=45)
+
+    loose = _model(db_session, slug="loose")
+    loose_file = _file_with_material(db_session, loose, sha="b", material_type="PLA")
+    _job(db_session, loose, loose_file, grams=50.0, duration_s=900, finished_days_ago=200)
+    _job(db_session, loose, loose_file, state=PrintJobState.FAILED, grams=999.0)
+
+    for period in ("7d", "30d", "90d", "1y", "all"):
+        expected = _oracle_totals(db_session, period)
+        resp = client.get(
+            f"/api/v1/models/stats/prints?period={period}", headers=auth_headers
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total_prints"] == expected["total_prints"], period
+        assert body["total_cost"] == expected["total_cost"], period
+        assert body["total_filament_g"] == expected["total_filament_g"], period
+        assert body["total_print_time_s"] == expected["total_print_time_s"], period
+
+
+def test_print_stats_period_windows_filter_correctly(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str]
+) -> None:
+    model = _model(db_session, slug="windowed")
+    file_row = _file_with_material(db_session, model, sha="w", material_type="PLA")
+    _job(db_session, model, file_row, grams=10.0, finished_days_ago=5)
+    _job(db_session, model, file_row, grams=10.0, finished_days_ago=45)
+    _job(db_session, model, file_row, grams=10.0, finished_days_ago=200)
+    _job(db_session, model, file_row, grams=10.0, finished_days_ago=800)
+
+    counts = {}
+    for period in ("7d", "30d", "90d", "1y", "all"):
+        resp = client.get(
+            f"/api/v1/models/stats/prints?period={period}", headers=auth_headers
+        )
+        counts[period] = resp.json()["total_prints"]
+
+    assert counts["7d"] == 1
+    assert counts["30d"] == 1
+    assert counts["90d"] == 2
+    assert counts["1y"] == 3
+    assert counts["all"] == 4
+
+
+def test_print_stats_manual_job_without_finished_at_uses_created_at(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str]
+) -> None:
+    model = _model(db_session, slug="manual")
+    file_row = _file_with_material(db_session, model, sha="m", material_type="PLA")
+    job = PrintJob(
+        file_id=file_row.id,
+        model_id=model.id,
+        remote_filename=file_row.original_filename,
+        state=PrintJobState.COMPLETED,
+        filament_used_g=20.0,
+        finished_at=None,
+    )
+    job.filament_g_effective, job.cost = print_results.resolve_completion_cost(
+        db_session, job
+    )
+    db_session.add(job)
+    db_session.commit()
+
+    resp = client.get("/api/v1/models/stats/prints?period=7d", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["total_prints"] == 1
+
+
+def test_print_stats_totals_are_none_when_no_job_has_cost(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str]
+) -> None:
+    # No FilamentProfile at all, and no slicer estimate — cost can't be
+    # resolved for anyone, so totals must read as None, not 0.
+    model = _model(db_session, slug="uncosted")
+    file_row = _file_with_material(db_session, model, sha="u", material_type="EXOTIC")
+    _job(db_session, model, file_row, grams=None, duration_s=600)
+
+    resp = client.get("/api/v1/models/stats/prints?period=30d", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_prints"] == 1
+    assert body["total_cost"] is None
+    assert body["total_filament_g"] is None
+
+
+def test_completed_job_persists_cost_via_manual_log(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str]
+) -> None:
+    from sqlmodel import select
+
+    db_session.add(FilamentProfile(name="PLA", material_type="PLA", cost_per_kg=20.0))
+    db_session.commit()
+    model = _model(db_session, slug="manual-log")
+    file_row = _file_with_material(db_session, model, sha="ml", material_type="PLA")
+    md = db_session.exec(
+        select(Metadata).where(Metadata.file_id == file_row.id)
+    ).one()
+    md.filament_weight_g = 100.0
+    db_session.add(md)
+    db_session.commit()
+
+    resp = client.post(
+        f"/api/v1/models/{model.id}/print-jobs",
+        json={"file_id": file_row.id, "printer_name": "Bench printer", "state": "completed"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    job = db_session.exec(select(PrintJob).where(PrintJob.model_id == model.id)).one()
+    # No measured filament_used_g on a manual log; falls back to the slicer
+    # estimate, resolved and persisted at creation time by the endpoint itself.
+    assert job.filament_g_effective == 100.0
+    assert job.cost == 2.0
+
+
+def test_editing_profile_price_does_not_change_historical_cost(
+    client: TestClient, db_session: Session, auth_headers: dict[str, str]
+) -> None:
+    profile = FilamentProfile(name="PLA", material_type="PLA", cost_per_kg=20.0)
+    db_session.add(profile)
+    db_session.commit()
+    db_session.refresh(profile)
+
+    model = _model(db_session, slug="frozen-cost")
+    file_row = _file_with_material(db_session, model, sha="fz", material_type="PLA")
+    _job(db_session, model, file_row, grams=100.0)
+
+    resp = client.get("/api/v1/models/stats/prints?period=30d", headers=auth_headers)
+    before = resp.json()["total_cost"]
+    assert before == 2.0
+
+    profile.cost_per_kg = 999.0
+    db_session.add(profile)
+    db_session.commit()
+
+    resp = client.get("/api/v1/models/stats/prints?period=30d", headers=auth_headers)
+    after = resp.json()["total_cost"]
+    assert after == before == 2.0

--- a/backend/tests/test_printer_hub.py
+++ b/backend/tests/test_printer_hub.py
@@ -12,7 +12,7 @@ from app.db.models import PrintJob, PrintJobState, Printer, PrinterStatus
 class TestPrinterHubLifecycle:
     def test_init_creates_empty_collections(self, hub):
         assert hub.snapshots == {}
-        assert hub.subscribers == {}
+        assert hub.bus is not None
         assert hub.tasks == {}
         assert hub.stop_events == {}
 

--- a/backend/tests/test_rbac_sql.py
+++ b/backend/tests/test_rbac_sql.py
@@ -1,0 +1,221 @@
+"""``accessible_collection_ids`` moved from a Python scan to one SQL query.
+
+The old implementation loaded every live collection and every grant and matched
+them pairwise in Python. It is kept here as an oracle: the query must return
+exactly the same set on any tree, or someone silently gains or loses access.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session, select
+
+from app.db.models import (
+    Collection,
+    CollectionPermission,
+    CollectionRole,
+    User,
+)
+from app.db.scopes import live
+from app.services import rbac, taxonomy
+from app.services.auth import hash_password
+from app.services.rbac import ROLE_ORDER, role_allows
+
+
+def _oracle(
+    session: Session,
+    user: User,
+    minimum: CollectionRole = CollectionRole.VIEW,
+) -> set[int]:
+    """The pre-rewrite Python implementation, verbatim."""
+    collections = list(session.exec(select(Collection).where(live(Collection))).all())
+    if user.is_superuser:
+        return {int(c.id) for c in collections if c.id is not None}
+
+    grants = session.exec(
+        select(CollectionPermission, Collection)
+        .join(Collection, Collection.id == CollectionPermission.collection_id)
+        .where(CollectionPermission.user_id == user.id, live(Collection))
+    ).all()
+    out: set[int] = set()
+    for collection in collections:
+        if collection.id is None:
+            continue
+        for permission, granted_collection in grants:
+            inherited = (
+                collection.path == granted_collection.path
+                or collection.path.startswith(granted_collection.path + "/")
+            )
+            if inherited and role_allows(permission.role, minimum):
+                out.add(collection.id)
+                break
+    return out
+
+
+def _user(session: Session, username: str, *, superuser: bool = False) -> User:
+    user = User(
+        username=username,
+        hashed_password=hash_password("Password123"),
+        is_active=True,
+        is_superuser=superuser,
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def _grant(
+    session: Session, user: User, collection_id: int, role: CollectionRole
+) -> None:
+    session.add(
+        CollectionPermission(user_id=user.id, collection_id=collection_id, role=role)
+    )
+    session.commit()
+
+
+def _seed_tree(session: Session) -> dict[str, Collection]:
+    """A tree with the shapes that break naive prefix matching.
+
+    ``parts`` and ``parts-extra`` share a string prefix but are siblings: a
+    grant on ``parts`` must never reach ``parts-extra``.
+    """
+    paths = [
+        "Parts",
+        "Parts/Brackets",
+        "Parts/Brackets/Small",
+        "Parts/Gears",
+        "Parts Extra",
+        "Toys",
+        "Toys/Dragons",
+    ]
+    return {p: taxonomy.resolve_or_create_collection(session, p) for p in paths}
+
+
+def test_sql_matches_python_for_superuser(db_session: Session) -> None:
+    _seed_tree(db_session)
+    root = _user(db_session, "root", superuser=True)
+
+    assert rbac.accessible_collection_ids(db_session, root) == _oracle(db_session, root)
+
+
+def test_sql_matches_python_with_no_grants(db_session: Session) -> None:
+    _seed_tree(db_session)
+    nobody = _user(db_session, "nobody")
+
+    assert rbac.accessible_collection_ids(db_session, nobody) == set()
+    assert rbac.accessible_collection_ids(db_session, nobody) == _oracle(
+        db_session, nobody
+    )
+
+
+@pytest.mark.parametrize(
+    "minimum", [CollectionRole.VIEW, CollectionRole.EDIT, CollectionRole.ADMIN]
+)
+def test_sql_matches_python_on_nested_grants(
+    db_session: Session, minimum: CollectionRole
+) -> None:
+    tree = _seed_tree(db_session)
+    user = _user(db_session, "alice")
+    _grant(db_session, user, tree["Parts/Brackets"].id, CollectionRole.EDIT)
+    _grant(db_session, user, tree["Toys"].id, CollectionRole.VIEW)
+
+    assert rbac.accessible_collection_ids(db_session, user, minimum) == _oracle(
+        db_session, user, minimum
+    )
+
+
+def test_grant_does_not_leak_to_prefix_sibling(db_session: Session) -> None:
+    """"Parts" must not grant "Parts Extra" — they only share a string prefix."""
+    tree = _seed_tree(db_session)
+    user = _user(db_session, "bob")
+    _grant(db_session, user, tree["Parts"].id, CollectionRole.VIEW)
+
+    got = rbac.accessible_collection_ids(db_session, user)
+
+    assert tree["Parts Extra"].id not in got
+    assert tree["Parts/Brackets"].id in got, "descendants must inherit"
+    assert got == _oracle(db_session, user)
+
+
+def test_highest_grant_wins_across_overlapping_scopes(db_session: Session) -> None:
+    tree = _seed_tree(db_session)
+    user = _user(db_session, "carol")
+    _grant(db_session, user, tree["Parts"].id, CollectionRole.VIEW)
+    _grant(db_session, user, tree["Parts/Brackets"].id, CollectionRole.ADMIN)
+
+    admin_ids = rbac.accessible_collection_ids(db_session, user, CollectionRole.ADMIN)
+
+    assert tree["Parts/Brackets"].id in admin_ids
+    assert tree["Parts/Brackets/Small"].id in admin_ids
+    assert tree["Parts"].id not in admin_ids, "the weaker grant must not be upgraded"
+    assert admin_ids == _oracle(db_session, user, CollectionRole.ADMIN)
+
+
+def test_trashed_collection_is_excluded(db_session: Session) -> None:
+    from app.core.time import utcnow
+
+    tree = _seed_tree(db_session)
+    user = _user(db_session, "dave")
+    _grant(db_session, user, tree["Parts"].id, CollectionRole.VIEW)
+
+    brackets = tree["Parts/Brackets"]
+    brackets.deleted_at = utcnow()
+    db_session.add(brackets)
+    db_session.commit()
+
+    got = rbac.accessible_collection_ids(db_session, user)
+    assert brackets.id not in got
+    assert got == _oracle(db_session, user)
+
+
+def test_like_metacharacters_in_path_do_not_widen_the_grant(
+    db_session: Session,
+) -> None:
+    """A path containing ``_`` is a literal, not the SQL single-char wildcard.
+
+    ``slugify`` strips both ``_`` and ``%`` today, so the paths are written
+    directly: going through the taxonomy helper would silently sanitise the
+    metacharacter and leave the escaping untested.
+    """
+    granted = Collection(name="a_b", slug="a_b", path="a_b")
+    sibling_child = Collection(name="inner", slug="inner", path="axb/inner")
+    granted_child = Collection(name="inner", slug="inner", path="a_b/inner")
+    db_session.add_all([granted, sibling_child, granted_child])
+    db_session.commit()
+    for c in (granted, sibling_child, granted_child):
+        db_session.refresh(c)
+
+    user = _user(db_session, "erin")
+    _grant(db_session, user, granted.id, CollectionRole.VIEW)
+
+    got = rbac.accessible_collection_ids(db_session, user)
+
+    assert granted.id in got and granted_child.id in got
+    assert sibling_child.id not in got, "'_' matched any char — LIKE was unescaped"
+    assert got == _oracle(db_session, user)
+
+
+def test_sql_matches_python_on_a_wide_tree(db_session: Session) -> None:
+    """The shape the rewrite exists for: many collections, several grants.
+
+    The old code compared every collection against every grant in Python. This
+    is the case where that stopped being free — and where an off-by-one in the
+    prefix match would show up.
+    """
+    tree = _seed_tree(db_session)
+    user = _user(db_session, "frank")
+    _grant(db_session, user, tree["Parts/Brackets"].id, CollectionRole.EDIT)
+    _grant(db_session, user, tree["Toys"].id, CollectionRole.VIEW)
+
+    for i in range(60):
+        taxonomy.resolve_or_create_collection(db_session, f"Parts/Brackets/Bulk{i}")
+        taxonomy.resolve_or_create_collection(db_session, f"Parts Extra/Bulk{i}")
+
+    got = rbac.accessible_collection_ids(db_session, user, CollectionRole.EDIT)
+    assert got == _oracle(db_session, user, CollectionRole.EDIT)
+    assert len(got) == 62, "60 bulk children + Brackets + Small"
+
+
+def test_role_order_is_total() -> None:
+    assert set(ROLE_ORDER) == set(CollectionRole)

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -1,0 +1,76 @@
+"""Tests for services.realtime.InProcessBus fan-out."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.services.realtime import InProcessBus
+
+
+class FakeSocket:
+    def __init__(self, *, delay: float = 0.0, raises: bool = False):
+        self.delay = delay
+        self.raises = raises
+        self.received: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.raises:
+            raise RuntimeError("send failed")
+        self.received.append(payload)
+
+
+def test_slow_subscriber_does_not_delay_others():
+    async def _run():
+        bus = InProcessBus()
+        slow = FakeSocket(delay=10.0)
+        fast = FakeSocket()
+        await bus.subscribe("printer:1", slow)
+        await bus.subscribe("printer:1", fast)
+
+        async with asyncio.timeout(3.0):
+            await bus.publish("printer:1", {"hello": "world"})
+
+        assert fast.received == [{"hello": "world"}]
+        assert slow.received == []
+
+    asyncio.run(_run())
+
+
+def test_slow_subscriber_is_dropped_after_timeout():
+    async def _run():
+        bus = InProcessBus()
+        slow = FakeSocket(delay=10.0)
+        await bus.subscribe("printer:1", slow)
+
+        async with asyncio.timeout(3.0):
+            await bus.publish("printer:1", {"hello": "world"})
+
+        assert slow not in bus._subscribers["printer:1"]
+
+    asyncio.run(_run())
+
+
+def test_dead_subscriber_is_dropped():
+    async def _run():
+        bus = InProcessBus()
+        dead = FakeSocket(raises=True)
+        alive = FakeSocket()
+        await bus.subscribe("printer:1", dead)
+        await bus.subscribe("printer:1", alive)
+
+        await bus.publish("printer:1", {"x": 1})
+
+        assert dead not in bus._subscribers["printer:1"]
+        assert alive.received == [{"x": 1}]
+
+    asyncio.run(_run())
+
+
+def test_publish_to_empty_channel_is_a_noop():
+    async def _run():
+        bus = InProcessBus()
+        await bus.publish("printer:999", {"x": 1})  # must not raise
+
+    asyncio.run(_run())

--- a/backend/tests/test_service_helpers.py
+++ b/backend/tests/test_service_helpers.py
@@ -19,7 +19,6 @@ from app.db.models import (
     ExternalLibraryCollectionMode,
     FilamentProfile,
     Metadata,
-    PrintJob,
 )
 from app.services import importer as imp
 from app.services import model_views as mv
@@ -195,33 +194,6 @@ class TestFilamentCostForGrams:
     def test_profile_without_cost_returns_none(self) -> None:
         md = Metadata(file_id=1, material_type="PLA", material_brand="NoCost")
         assert mv.filament_cost_for_grams(_profiles(), md, 100.0) is None
-
-
-class TestEffectivePrintMetrics:
-    def test_measured_values_win(self) -> None:
-        md = Metadata(file_id=1, material_type="PLA", material_brand="Hatchbox")
-        job = PrintJob(
-            file_id=1, model_id=1, remote_filename="x",
-            filament_used_g=50.0, actual_duration_s=600,
-        )
-        grams, cost, duration = mv._effective_print_metrics(_profiles(), md, job)
-        assert (grams, cost, duration) == (50.0, 1.0, 600)
-
-    def test_falls_back_to_slicer_estimate(self) -> None:
-        md = Metadata(
-            file_id=1, material_type="PLA", material_brand="Hatchbox",
-            filament_weight_g=30.0, estimated_time_s=900,
-        )
-        job = PrintJob(file_id=1, model_id=1, remote_filename="x")
-        grams, cost, duration = mv._effective_print_metrics(_profiles(), md, job)
-        assert (grams, cost, duration) == (30.0, 0.6, 900)
-
-    def test_slicer_cost_used_when_no_profile_match(self) -> None:
-        # No matching profile, but the slicer recorded a total cost.
-        md = Metadata(file_id=1, material_type="ABS", filament_weight_g=10.0, filament_cost=3.5)
-        job = PrintJob(file_id=1, model_id=1, remote_filename="x")
-        _, cost, _ = mv._effective_print_metrics(_profiles(), md, job)
-        assert cost == 3.5
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_url_safety.py
+++ b/backend/tests/test_url_safety.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-import pytest
+import socket
 
-from app.core.url_safety import is_public_ip, is_public_url
+import httpx
+import pytest
+from httpcore import AnyIOBackend
+
+from app.core.url_safety import (
+    UnsafeUrlError,
+    is_public_ip,
+    is_public_url,
+    pinned_transport,
+    resolve_public_target,
+)
 
 
 @pytest.mark.parametrize(
@@ -37,3 +47,80 @@ def test_is_public_ip(ip, expected):
 def test_is_public_url_blocks(url, expected):
     # Literal-IP and scheme/host cases resolve without touching real DNS.
     assert is_public_url(url) is expected
+
+
+# ---------------------------------------------------------------------------
+# DNS rebinding: validate once, connect to the address that was validated
+# ---------------------------------------------------------------------------
+
+
+def _fake_getaddrinfo(*answers: str):
+    """getaddrinfo stub that returns a different answer on each call."""
+    calls = {"n": 0}
+
+    def _resolver(host, port, *args, **kwargs):
+        idx = min(calls["n"], len(answers) - 1)
+        calls["n"] += 1
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (answers[idx], port or 80))]
+
+    return _resolver
+
+
+def test_resolve_public_target_rejects_private_answer(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("127.0.0.1"))
+    with pytest.raises(UnsafeUrlError) as exc:
+        resolve_public_target("http://rebind.example/hook")
+    assert exc.value.reason == "url_target_not_public"
+
+
+def test_resolve_public_target_rejects_mixed_answers(monkeypatch):
+    """A host answering with a public *and* a private address is an attack."""
+
+    def _resolver(host, port, *args, **kwargs):
+        return [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", port)),
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", _resolver)
+    with pytest.raises(UnsafeUrlError):
+        resolve_public_target("http://mixed.example/hook")
+
+
+def test_resolve_public_target_pins_the_validated_address(monkeypatch):
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    target = resolve_public_target("https://good.example/hook")
+    assert target.ip == "93.184.216.34"
+    assert target.host == "good.example"
+    assert target.port == 443
+
+
+@pytest.mark.anyio
+async def test_pinned_transport_dials_validated_ip_after_dns_flips(monkeypatch):
+    """The rebind: DNS says public at validation time, loopback at connect time.
+
+    The transport must still dial the validated address, and it must hand the
+    real hostname down the stack so TLS verification is unaffected.
+    """
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("93.184.216.34"))
+    target = resolve_public_target("http://rebind.example/hook")
+
+    # From here on, DNS is hostile.
+    monkeypatch.setattr(socket, "getaddrinfo", _fake_getaddrinfo("127.0.0.1"))
+
+    dialled: list[tuple[str, int]] = []
+
+    async def _fake_connect(self, host, port, **kwargs):  # noqa: ANN001
+        dialled.append((host, port))
+        raise RuntimeError("stop here — the peer is all we need to observe")
+
+    monkeypatch.setattr(AnyIOBackend, "connect_tcp", _fake_connect)
+
+    transport = pinned_transport(target)
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(Exception):
+            await client.get(target.url)
+
+    assert dialled == [("93.184.216.34", 80)], (
+        "connected to the rebound address instead of the validated one"
+    )

--- a/backend/tests/test_url_zip_import_real.py
+++ b/backend/tests/test_url_zip_import_real.py
@@ -38,6 +38,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, select
 
 import app.core.http_client as http_client
+from app.core import url_safety
 from app.core.config import _overlay, settings
 from app.db.models import Collection, File, FileType, Model
 from app.services import import_resolvers, importer
@@ -211,8 +212,9 @@ async def test_download_to_staging_fetches_real_file(
     }
 
     # Only the SSRF guard's IP classification is relaxed; the rest of the
-    # download (real httpx stream, header parsing, disk write) runs for real.
-    with patch.object(importer, "_is_public_ip", return_value=True):
+    # download (real httpx stream against the pinned peer, header parsing,
+    # disk write) runs for real.
+    with patch.object(url_safety, "is_public_ip", return_value=True):
         staged, filename = await importer.download_to_staging(f"{base}/download")
 
     assert filename == "3dbenchy.stl"
@@ -231,7 +233,7 @@ async def test_download_to_staging_follows_redirect(
     routes["/start"] = {"status": 302, "headers": {"Location": "/final.stl"}}
     routes["/final.stl"] = {"headers": {"Content-Type": "model/stl"}, "body": b"solid x\nendsolid x\n"}
 
-    with patch.object(importer, "_is_public_ip", return_value=True):
+    with patch.object(url_safety, "is_public_ip", return_value=True):
         staged, filename = await importer.download_to_staging(f"{base}/start")
 
     # Filename falls back to the final URL's path component.
@@ -249,7 +251,7 @@ async def test_download_to_staging_enforces_size_limit(
     routes["/big.stl"] = {"body": b"\0" * (2 * 1024 * 1024)}  # 2 MiB
 
     incoming_before = set(settings.incoming_dir.iterdir())
-    with patch.object(importer, "_is_public_ip", return_value=True):
+    with patch.object(url_safety, "is_public_ip", return_value=True):
         with pytest.raises(importer.ImportError_) as exc:
             await importer.download_to_staging(f"{base}/big.stl")
 
@@ -291,7 +293,7 @@ def test_ingest_url_downloads_and_ingests_for_real(
     }
     url = f"{base}/3dbenchy.stl"
 
-    with patch.object(importer, "_is_public_ip", return_value=True):
+    with patch.object(url_safety, "is_public_ip", return_value=True):
         payload = _job(
             client,
             client.post(

--- a/backend/tests/test_vault_stats_cache.py
+++ b/backend/tests/test_vault_stats_cache.py
@@ -1,0 +1,105 @@
+"""``vault_stats`` must not walk the storage tree on every dashboard load.
+
+The row counts are SQL aggregates and cheap. ``backend.usage()`` is not: locally
+it walks every file under the data dir, and on S3 it lists the bucket.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlmodel import Session
+
+from app.core.config import _overlay
+from app.db.models import User
+from app.services import model_views
+from app.services.auth import hash_password
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache(tmp_path: Path):
+    model_views._usage_cache.clear()
+    _overlay["storage_backend"] = "local"
+    _overlay["data_dir"] = tmp_path / "files"
+    _overlay["thumb_dir"] = tmp_path / "thumbs"
+    (tmp_path / "files").mkdir()
+    (tmp_path / "thumbs").mkdir()
+    yield
+    model_views._usage_cache.clear()
+    for key in ("storage_backend", "data_dir", "thumb_dir"):
+        _overlay.pop(key, None)
+
+
+@pytest.fixture
+def admin(db_session: Session) -> User:
+    user = User(
+        username="dash",
+        hashed_password=hash_password("Password123"),
+        is_active=True,
+        is_superuser=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+    return user
+
+
+class _CountingBackend:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def usage(self, prefix: str = "") -> dict:
+        self.calls += 1
+        return {"backend": "local", "ok": True, "total_size_bytes": 1, "object_count": 1}
+
+
+def test_storage_usage_is_computed_once_per_window(
+    db_session: Session, admin: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = _CountingBackend()
+    monkeypatch.setattr(model_views, "get_backend", lambda: backend)
+
+    model_views.vault_stats(db_session, admin)
+    model_views.vault_stats(db_session, admin)
+    model_views.vault_stats(db_session, admin)
+
+    assert backend.calls == 1, "storage was walked on every dashboard load"
+
+
+def test_cache_expires_after_the_ttl(
+    db_session: Session, admin: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = _CountingBackend()
+    monkeypatch.setattr(model_views, "get_backend", lambda: backend)
+
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(model_views, "monotonic", lambda: clock["now"])
+
+    model_views.vault_stats(db_session, admin)
+    clock["now"] += model_views._USAGE_TTL_S + 1
+    model_views.vault_stats(db_session, admin)
+
+    assert backend.calls == 2
+
+
+def test_failures_are_not_cached(
+    db_session: Session, admin: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient S3 error must not pin an error state for the whole window."""
+    calls = {"n": 0}
+
+    class _FlakyBackend:
+        def usage(self, prefix: str = "") -> dict:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("s3 down")
+            return {"backend": "s3", "ok": True, "total_size_bytes": 5, "object_count": 2}
+
+    monkeypatch.setattr(model_views, "get_backend", lambda: _FlakyBackend())
+
+    first = model_views.vault_stats(db_session, admin)
+    assert first.storage.ok is False
+
+    second = model_views.vault_stats(db_session, admin)
+    assert second.storage.ok is True, "an error response was served from the cache"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1051,7 +1051,7 @@ wheels = [
 
 [[package]]
 name = "printstash"
-version = "0.8.3"
+version = "0.8.4"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Merged release combining doc-14's 0.8.3 (integrity/security) and 0.8.4
(perf/handler correctness) plans, per `reports/14-implementation-plan-to-1.0.0.md`.
Builds on v0.8.3 (blob-census hotfix, already released).

- JWT secret generated on first boot; boot refuses the shipped default
- SQLite foreign keys enforced, with an orphan-row repair migration
- `accessible_collection_ids` and model-list role resolution: one SQL query
  instead of a per-row Python scan
- Ingestion (`persist_artifact`) is atomic — no half-built models on a failed
  thumbnail
- Outbound fetches pinned against DNS rebinding (SSRF guard)
- Dashboard storage-usage walk cached 60s
- **Print-job history import**: fixed a dedup bug that could re-import a
  printer's entire history (case mismatch, and one query indexed only the
  first character of the stored filename)
- **Backup restore**: quiesces GC / external scans / printer sync while a
  restore is in flight; refuses with 409 if ingestion is still running
- **Printer WebSocket fan-out**: no longer blocks on a slow client (new
  `RealtimeBus` seam, concurrent sends with a timeout)
- **Print statistics**: cost and effective filament grams are now resolved
  once at completion and summed, instead of re-hydrating every job and
  re-matching a filament profile on every dashboard load

**Behavior changes (see CHANGELOG.md):** JWT rotation invalidates existing
sessions once; FK enforcement repairs orphans on upgrade; print-job cost
freezes at completion time (editing a filament profile's price no longer
revises historical print costs).

## Test plan

- [x] `uv run pytest tests -v` — 907 passed, 1 skipped
- [x] `uv run ruff check app/ tests/` — clean
- [x] Real-data upgrade test: seeded a v0.8.2-era schema (`f6b3d0a8c2e9`) with
      models/files/documents/print-jobs plus one orphan FK row, upgraded to
      head — orphan repaired, `PRAGMA foreign_key_check` clean, cost backfill
      correct, app boots and reports v0.8.4
- [x] Compose smoke test (`docker-compose.light.yml`) — validates the compose
      file only, since it pulls the prebuilt `:latest` image, not this branch
- [x] Live-verified: WS fan-out doesn't block on a slow subscriber; a running
      ingestion job forces `restore_backup` to raise `RestoreConflictError`
      (409) and the gate clears afterward