### PR TITLE
fix(ui): apply theme toggle on the first click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- The theme toggle now reads the theme already applied to the page instead of re-resolving it from storage, so it switches on the first click ([#55](https://github.com/xiao-villamor/PrintStash/issues/55)).
+
 ## 0.11.1
 
 **This patch-version release is an explicit exception to normal 0.x patch policy: it adds features and append-only database migrations. Back up before upgrading.**

--- a/frontend/src/components/__tests__/theme-toggle.test.tsx
+++ b/frontend/src/components/__tests__/theme-toggle.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ThemeToggle } from "@/components/theme-toggle";
+
+afterEach(() => {
+  document.documentElement.classList.remove("dark");
+  localStorage.clear();
+});
+
+describe("ThemeToggle", () => {
+  it("leaves dark mode on the first click when the page painted dark", async () => {
+    document.documentElement.classList.add("dark");
+
+    render(<ThemeToggle />);
+    await userEvent.click(screen.getByLabelText("Toggle theme"));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(localStorage.getItem("printstash.theme")).toBe("light");
+  });
+
+  it("enters dark mode on the first click when the page painted light", async () => {
+    render(<ThemeToggle />);
+    await userEvent.click(screen.getByLabelText("Toggle theme"));
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(localStorage.getItem("printstash.theme")).toBe("dark");
+  });
+});

--- a/frontend/src/components/theme-toggle.tsx
+++ b/frontend/src/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Moon, Sun } from "lucide-react";
 
 const STORAGE_KEY = "printstash.theme";
@@ -21,17 +21,11 @@ function applyTheme(theme: Theme) {
 }
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>("light");
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    const stored =
-      (localStorage.getItem(STORAGE_KEY) as Theme | null) ??
-      (localStorage.getItem(LEGACY_STORAGE_KEY) as Theme | null) ??
-      (window.matchMedia?.("(prefers-color-scheme: dark)").matches ? "dark" : "light");
-    setTheme(stored);
-    setMounted(true);
-  }, []);
+  // The pre-paint script in index.html already resolved the theme onto <html>;
+  // read it back rather than re-resolving, so state can never disagree with the DOM.
+  const [theme, setTheme] = useState<Theme>(() =>
+    document.documentElement.classList.contains("dark") ? "dark" : "light",
+  );
 
   function toggle() {
     const next: Theme = theme === "dark" ? "light" : "dark";
@@ -40,8 +34,6 @@ export function ThemeToggle() {
     localStorage.removeItem(LEGACY_STORAGE_KEY);
     applyTheme(next);
   }
-
-  if (!mounted) return <div className="h-9 w-9" aria-hidden />;
 
   return (
     <button


### PR DESCRIPTION
Fixes #55.

The toggle seeded its state from `"light"` and re-resolved the theme from localStorage/`matchMedia` in a mount effect, duplicating the resolver in `index.html`'s pre-paint script. Any disagreement between the two (e.g. an empty or unrecognised stored value, where the script's `||` falls through to the media query but the component's `??` does not) left React state pointing at a theme different from the class actually on `<html>`, so the first click computed a no-op transition and only the second one appeared to work.

The component now seeds from `document.documentElement`, the single source of truth the pre-paint script already wrote, so the two can't diverge. The `mounted` gate went with it — it guarded against a hydration mismatch this SPA never has.

Regression test in `frontend/src/components/__tests__/theme-toggle.test.tsx` covers both starting themes; it fails on the previous component and passes on this one. `pnpm lint` and `pnpm typecheck` are clean.