### PR TITLE
chore(release): bump to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.11.2
 
 ### Fixed
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -190,7 +190,7 @@ class Settings(BaseSettings):
     backup_s3_secret_key: str = ""
 
     app_name: str = "PrintStash"
-    app_version: str = "0.11.1"
+    app_version: str = "0.11.2"
 
     @property
     def incoming_dir(self) -> Path:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printstash"
-version = "0.11.1"
+version = "0.11.2"
 description = "PrintStash — self-hosted 3D printing asset manager"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1474,7 +1474,7 @@ wheels = [
 
 [[package]]
 name = "printstash"
-version = "0.11.1"
+version = "0.11.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "printstash-frontend",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/frontend/src/lib/changelog.ts
+++ b/frontend/src/lib/changelog.ts
@@ -22,6 +22,13 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "0.11.2",
+    date: "Aug 2026",
+    changes: [
+      "The theme toggle now switches on the first click instead of needing two",
+    ],
+  },
+  {
     version: "0.11.1",
     date: "Jul 2026",
     changes: [


### PR DESCRIPTION
Release prep for 0.11.2. The only user-facing change is the theme-toggle fix from #56 (issue #55).

- Version triple bumped in `backend/pyproject.toml`, `backend/app/core/config.py`, `frontend/package.json`, plus `backend/uv.lock` and a matching `CHANGELOG[0]` entry in `frontend/src/lib/changelog.ts`.
- `CHANGELOG.md` Unreleased section promoted to 0.11.2.

Validation: backend `pytest` 2112 passed / 22 skipped, `ruff check` clean; frontend lint clean, `tsc --noEmit` clean, 231 tests pass, `pnpm build` succeeds.