### PR TITLE
fix(oidc): normalize trailing slash when validating id_token issuer

### DIFF
--- a/backend/app/services/oidc.py
+++ b/backend/app/services/oidc.py
@@ -178,7 +178,8 @@ async def exchange_code(
     }
     methods = document.get("token_endpoint_auth_methods_supported")
     if methods is not None and (
-        not isinstance(methods, list) or not all(isinstance(value, str) for value in methods)
+        not isinstance(methods, list)
+        or not all(isinstance(value, str) for value in methods)
     ):
         raise OIDCError("oidc_invalid_discovery")
     use_basic_auth = bool(
@@ -207,7 +208,6 @@ async def exchange_code(
             key.key,
             algorithms=[key.algorithm_name],
             audience=settings.oidc_client_id,
-            issuer=_issuer(),
             options={"require": ["exp", "iat", "iss", "sub", "aud"]},
         )
     except OIDCError:
@@ -216,6 +216,16 @@ async def exchange_code(
         raise OIDCError("oidc_invalid_id_token") from exc
     except Exception as exc:
         raise OIDCError("oidc_token_exchange_failed") from exc
+    # Issuer is checked manually (normalized on both sides) rather than via
+    # PyJWT's `issuer=` kwarg, which does an exact string match with no
+    # trailing-slash normalization. IdPs using a per-application issuer URL
+    # (e.g. Authentik's PER_PROVIDER issuer mode) commonly emit `iss` with a
+    # trailing slash, while `_issuer()` strips it -- so the built-in check
+    # never matches regardless of how VAULT_OIDC_ISSUER_URL is configured.
+    # This mirrors the normalization already applied to the discovery
+    # document's issuer above.
+    if str(claims.get("iss", "")).rstrip("/") != _issuer():
+        raise OIDCError("oidc_issuer_mismatch")
     if not secrets.compare_digest(str(claims.get("nonce", "")), nonce):
         raise OIDCError("oidc_nonce_mismatch")
     audiences = claims.get("aud")

--- a/backend/tests/test_oidc.py
+++ b/backend/tests/test_oidc.py
@@ -219,6 +219,120 @@ def test_exchange_validates_signature_audience_issuer_and_nonce(monkeypatch) -> 
         )
 
 
+def test_exchange_accepts_id_token_issuer_with_trailing_slash(monkeypatch) -> None:
+    """Regression test: some IdPs (e.g. Authentik in PER_PROVIDER issuer mode)
+    always emit `iss` with a trailing slash even when the configured
+    VAULT_OIDC_ISSUER_URL has none. PyJWT's `issuer=` kwarg does an exact
+    string match with no normalization, so without normalizing both sides
+    ourselves, every login from such an IdP fails with oidc_invalid_id_token
+    regardless of how the issuer URL is configured.
+    """
+    _enable_oidc()
+    assert not _overlay["oidc_issuer_url"].endswith("/")
+    issuer_with_slash = _overlay["oidc_issuer_url"] + "/"
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = json.loads(
+        jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key())
+    )
+    public_jwk["kid"] = "signing-key"
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "iss": issuer_with_slash,
+            "sub": "trailing-slash-user",
+            "aud": "printstash",
+            "iat": now,
+            "exp": now + timedelta(minutes=5),
+            "nonce": "expected-nonce",
+        },
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "signing-key"},
+    )
+
+    async def discovery() -> dict:
+        return {
+            "issuer": _overlay["oidc_issuer_url"],
+            "authorization_endpoint": "https://id.example.test/authorize",
+            "token_endpoint": "https://id.example.test/token",
+            "jwks_uri": "https://id.example.test/jwks",
+        }
+
+    async def post_token(_url: str, payload: dict[str, str], **kwargs) -> dict:
+        return {"id_token": token}
+
+    async def get_json(url: str) -> dict:
+        return {"keys": [public_jwk]}
+
+    monkeypatch.setattr(oidc, "_discovery", discovery)
+    monkeypatch.setattr(oidc, "_post_token", post_token)
+    monkeypatch.setattr(oidc, "_get_json", get_json)
+
+    claims = asyncio.run(
+        oidc.exchange_code(
+            "code", "https://stash.example.test/callback", "verifier", "expected-nonce"
+        )
+    )
+    assert claims["sub"] == "trailing-slash-user"
+    assert claims["iss"] == issuer_with_slash
+
+
+def test_exchange_rejects_id_token_from_wrong_issuer(monkeypatch) -> None:
+    """The manual issuer check added for trailing-slash tolerance must still
+    reject a token whose issuer genuinely does not match, not just normalize
+    away a trailing slash.
+    """
+    _enable_oidc()
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_jwk = json.loads(
+        jwt.algorithms.RSAAlgorithm.to_jwk(private_key.public_key())
+    )
+    public_jwk["kid"] = "signing-key"
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {
+            "iss": "https://not-the-configured-issuer.example.test",
+            "sub": "attacker-controlled-user",
+            "aud": "printstash",
+            "iat": now,
+            "exp": now + timedelta(minutes=5),
+            "nonce": "expected-nonce",
+        },
+        private_key,
+        algorithm="RS256",
+        headers={"kid": "signing-key"},
+    )
+
+    async def discovery() -> dict:
+        return {
+            "issuer": _overlay["oidc_issuer_url"],
+            "authorization_endpoint": "https://id.example.test/authorize",
+            "token_endpoint": "https://id.example.test/token",
+            "jwks_uri": "https://id.example.test/jwks",
+        }
+
+    async def post_token(_url: str, payload: dict[str, str], **kwargs) -> dict:
+        return {"id_token": token}
+
+    async def get_json(url: str) -> dict:
+        return {"keys": [public_jwk]}
+
+    monkeypatch.setattr(oidc, "_discovery", discovery)
+    monkeypatch.setattr(oidc, "_post_token", post_token)
+    monkeypatch.setattr(oidc, "_get_json", get_json)
+
+    with pytest.raises(oidc.OIDCError, match="oidc_issuer_mismatch"):
+        asyncio.run(
+            oidc.exchange_code(
+                "code",
+                "https://stash.example.test/callback",
+                "verifier",
+                "expected-nonce",
+            )
+        )
+
+
 def test_exchange_rejects_multi_audience_token_for_another_authorized_party(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## What

`exchange_code()` validates the ID token's issuer via PyJWT's `issuer=` kwarg,
which does an exact string comparison against `_issuer()` with no trailing-slash
normalization. IdPs that use a per-application issuer URL — e.g. **Authentik in
`PER_PROVIDER` issuer mode** — always emit `iss` with a trailing slash, while
`_issuer()` strips it from the configured `VAULT_OIDC_ISSUER_URL`. The two can
therefore never match, and login fails with `oidc_invalid_id_token` no matter
how the issuer URL is configured.

The discovery-document issuer check a few lines above this already normalizes
both sides before comparing:

```python
if document.get("issuer", "").rstrip("/") != issuer:
    raise OIDCError("oidc_issuer_mismatch")
```

This PR applies the same normalization to the ID token's `iss` claim: drops
the `issuer=` kwarg from `jwt.decode()` and checks it manually afterward,
mirroring the existing pattern instead of introducing a new one.

## How this was found

Hit this deploying PrintStash behind a real Authentik instance with a
per-provider OIDC application. Discovery and the authorization/token exchange
all succeeded (200 OK on every request), but the callback always silently
redirected to `?oidc_error=oidc_invalid_id_token`. Traced it to this exact
mismatch by comparing Authentik's actual `.well-known/openid-configuration`
`issuer` field (`https://sso.example.net/application/o/printstash/`) against
what `_issuer()` computes from the same configured URL
(`https://sso.example.net/application/o/printstash`, no trailing slash).

## Testing

- Added `test_exchange_accepts_id_token_issuer_with_trailing_slash`: proves a
  token whose `iss` has a trailing slash the configured issuer URL lacks is
  now accepted.
- Added `test_exchange_rejects_id_token_from_wrong_issuer`: proves the manual
  check still rejects a token from a genuinely different issuer — the fix
  only adds trailing-slash tolerance, it doesn't weaken the check.
- `uv run pytest tests/test_oidc.py -v` — 36/36 pass.
- `uv run pytest tests -q` — full suite passes except 4 pre-existing failures
  in `test_mesh_render.py` / `test_printer_files.py` that are unrelated to
  this change and reproduce identically on `main` without this diff (looks
  environment-specific, likely a `trimesh` version difference — happy to
  file a separate issue if useful).
- `ruff check` / `ruff format --check` clean on both changed files.
- Verified end-to-end against a live Authentik deployment: login now
  completes successfully.

## Scope

Two files, both directly related to the bug: the fix itself and its tests.
No data model or API changes.
