### PR TITLE
docs: stop asking for a JWT secret that is generated anyway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
 
 ### Security
 
+- **First-run setup is gated by a setup token.** The endpoint that creates the initial superuser cannot require a login, so it now requires `VAULT_SETUP_TOKEN` and returns `403 invalid_setup_token` without it. When the variable is unset the API generates a token per process and logs it while the vault is unconfigured, so a fresh install reads it with `docker compose logs api | grep "setup token"` and pastes it into the wizard. Restarting the API before finishing setup invalidates the logged token; set the variable for a stable one.
 - Portable imports reject path traversal, missing blobs, unsupported manifests, oversized archives, and SHA-256 mismatches before database or storage writes.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ print history.
 ![Vite](https://img.shields.io/badge/vite-8-646CFF?logo=vite&style=flat-square)
 ![Status: beta](https://img.shields.io/badge/status-beta%20%C2%B7%20self--hosted-f59e0b?style=flat-square)
 
-[**Quick Start**](#quick-start) · [**Features**](#features) · [**Comparison**](#printstash-vs-a-simple-model-vault) · [**Wiki / Docs**](https://xiao-villamor.github.io/PrintStash) · [**Limitations**](#known-limitations--beta-notes) · [**Security**](#security)
+[**Quick Start**](#quick-start) · [**Features**](#features) · [**Comparison**](#printstash-vs-a-simple-model-vault) · [**Wiki / Docs**](https://www.printstash.org/docs/) · [**Limitations**](#known-limitations--beta-notes) · [**Security**](#security)
 
 </div>
 
@@ -138,8 +138,9 @@ are welcome in
 > [!WARNING]
 > **Run PrintStash only on a trusted self-hosted network.** Do not expose it
 > directly to the public internet. If you need remote access, put it behind a
-> reverse proxy with TLS and your own authentication, and change
-> `VAULT_JWT_SECRET` from its placeholder default first.
+> reverse proxy with TLS and your own authentication, and use
+> `docker-compose.prod.yml`, which keeps the API off the host and requires you to
+> set your own `VAULT_JWT_SECRET`.
 > See [Security](#security).
 
 Requirements: Docker and Docker Compose. Prebuilt images are published for
@@ -165,17 +166,32 @@ The default `docker-compose.yml` pulls prebuilt images from GHCR — no build st
 git clone https://github.com/xiao-villamor/PrintStash.git
 cd PrintStash
 
-cp .env.example .env
-# Edit .env and set a strong, random value for VAULT_JWT_SECRET,
-# e.g. `openssl rand -hex 32`.
+docker compose up -d
+```
 
+There is nothing to edit before that first start. Every variable in the Compose
+file has a working default, so `.env` is optional; copy `.env.example` to `.env`
+when you actually want to change something. In particular you do **not** need to
+invent a JWT secret: the placeholder in the Compose file is public, so the API
+refuses to sign with it and instead generates a real secret on first boot and
+stores it in its own database (see 0.8.4 in the [changelog](CHANGELOG.md)). Set
+`VAULT_JWT_SECRET` yourself only when you want to own that value.
+
+If you only want to run it, the Compose file is the single file you need:
+
+```bash
+mkdir printstash && cd printstash
+curl -O https://raw.githubusercontent.com/xiao-villamor/PrintStash/main/docker-compose.yml
 docker compose up -d
 ```
 
 For a hardened production setup (API kept internal, frontend bound to localhost
-behind your own TLS reverse proxy), use the production compose instead:
+behind your own TLS reverse proxy), use the production compose instead. That file
+declares `VAULT_JWT_SECRET` as required and refuses to start without it, on the
+grounds that a deliberately exposed host should not run on a secret nobody chose:
 
 ```bash
+echo "VAULT_JWT_SECRET=$(openssl rand -hex 32)" >> .env
 docker compose -f docker-compose.prod.yml up -d
 ```
 
@@ -190,17 +206,40 @@ echo "PRINTSTASH_VERSION=0.9.0" >> .env   # pin latest shipped release; omit to 
 ```
 
 By default the compose files track `latest`. Pin `PRINTSTASH_VERSION` when you
-want deliberate upgrades. See [Upgrading](https://xiao-villamor.github.io/PrintStash/guides/upgrading/).
+want deliberate upgrades. See [Upgrading](https://www.printstash.org/docs/guides/upgrading/).
 
 Open:
 
 | Service | URL |
 | --- | --- |
 | Web UI | http://localhost:3000 |
-| API docs | http://localhost:8000/docs |
-| Health check | http://localhost:8000/api/v1/health |
+| Health check | http://localhost:3000/api/v1/health |
 
-On first launch, the web UI creates the first admin account. There is no default
+The `api` service only exposes port 8000 on the internal Compose network, so it
+is not reachable from the host. The frontend's nginx proxies `/api/v1` to it, which
+is why the health check answers on port 3000. The Swagger and ReDoc pages are not
+proxied, so seeing them means publishing the port yourself from a
+`docker-compose.override.yml`:
+
+```yaml
+services:
+  api:
+    ports:
+      - "127.0.0.1:8000:8000"
+```
+
+On first launch the web UI creates the first admin account, gated by a **setup
+token**, because the endpoint that creates the very first account cannot require a
+login. With `VAULT_SETUP_TOKEN` unset, the API generates one per process and logs
+it while the vault is unconfigured:
+
+```bash
+docker compose logs api | grep "setup token"
+```
+
+Paste that into the wizard at `http://localhost:3000/setup`. The token is
+per process, so restarting the `api` container before you finish invalidates it;
+set `VAULT_SETUP_TOKEN` in `.env` if you want a stable one. There is no default
 username or password.
 
 ## Screenshots
@@ -271,7 +310,7 @@ PrintStash is designed for trusted self-hosted networks; do not expose it
 directly to the public internet without a reverse proxy, TLS, and your own
 access controls. The production compose (`docker-compose.prod.yml`) binds only
 the frontend to `127.0.0.1`; copy-pasteable Caddy / Traefik / nginx examples are
-in [Reverse proxy with TLS](https://xiao-villamor.github.io/PrintStash/getting-started/installation/#reverse-proxy-with-tls).
+in [Reverse proxy with TLS](https://www.printstash.org/docs/getting-started/installation/#reverse-proxy-with-tls).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,11 @@ are running.
 
 ## Deployment Notes
 
-- Change `VAULT_JWT_SECRET` before use.
+- `VAULT_JWT_SECRET` does not have to be set: the shipped placeholder is public,
+  so the API replaces it with a generated secret on first boot. Set your own to
+  manage the value, and note that `docker-compose.prod.yml` requires it. Never set
+  it to an empty string, which is treated as a chosen value and bypasses the
+  generated one.
 - Prefer a reverse proxy with TLS if the UI is reachable outside your LAN.
 - Do not publish printer access codes, Moonraker API keys, database files, or
   backups.

--- a/docker-compose.light.yml
+++ b/docker-compose.light.yml
@@ -32,9 +32,12 @@ services:
       VAULT_BACKUP_DIR: /data/backups
       # DB path must always point at the persistent volume (see docker-compose.yml).
       VAULT_DB_URL: sqlite:////data/db/printstash.sqlite
-      # CHANGE THIS: generate a strong secret with `openssl rand -hex 32`, then set
-      # VAULT_JWT_SECRET in a .env file or your shell. The default is public, so
-      # leaving it unchanged lets anyone forge admin login tokens.
+      # Optional. The placeholder below is public, so the API never signs with it:
+      # on first boot it generates a real secret and persists it (see 0.8.4). Set
+      # this explicitly (`openssl rand -hex 32`) only to manage the value
+      # yourself, e.g. to keep it across a rebuild of the database.
+      # Do not set it to an empty string; that is taken as a deliberate choice
+      # and skips the generated secret.
       VAULT_JWT_SECRET: ${VAULT_JWT_SECRET:-changeme_jwt_secret_please_change}
       VAULT_SETUP_TOKEN: ${VAULT_SETUP_TOKEN:-}
       VAULT_SECRETS_KEY: ${VAULT_SECRETS_KEY:-}

--- a/unraid/README.md
+++ b/unraid/README.md
@@ -106,16 +106,20 @@ That's it — you're in your vault.
 ## Alternative: Docker Compose Manager plugin
 
 PrintStash ships an official `docker-compose.yml` that already wires both
-services, the network, volumes, and the migration command. If you have the
+services, the network, and volumes. Migrations run from the image entrypoint on
+every start, so there is no command to wire up. If you have the
 **Compose Manager** plugin (from Community Applications), this is the simplest
 path:
 
 1. Install the *Docker Compose Manager* plugin.
 2. Add a new stack and paste the repo's
    [`docker-compose.yml`](https://github.com/xiao-villamor/PrintStash/blob/main/docker-compose.yml).
-3. Set `VAULT_JWT_SECRET` and adjust volume paths to
-   `/mnt/user/appdata/printstash/...` if you like.
-4. Compose up, then open `http://<server-ip>:3000`.
+3. Adjust volume paths to `/mnt/user/appdata/printstash/...` if you like. You do
+   not need to set `VAULT_JWT_SECRET`; the API generates and persists one on first
+   boot.
+4. Compose up, then read the first-run setup token out of the API log
+   (`docker logs printstash-api | grep "setup token"`) and open
+   `http://<server-ip>:3000`.
 
 ---
 
@@ -127,7 +131,8 @@ container variables are mainly bootstrap defaults:
 
 | Variable | Container | Required | Notes |
 |----------|-----------|----------|-------|
-| `VAULT_JWT_SECRET` | API | ✅ | Signs auth tokens. Use `openssl rand -hex 32`. |
+| `VAULT_JWT_SECRET` | API | – | Signs auth tokens. Generated and persisted on first boot if you leave it alone; set it (`openssl rand -hex 32`) only to own the value. Do not add it as an empty template variable, which is read as a deliberate choice and skips the generated secret. |
+| `VAULT_SETUP_TOKEN` | API | – | First-run credential for the setup wizard. Unset means the API logs a random one per process while the vault is unconfigured; set it for a token that survives a container restart. |
 | `VAULT_MAX_UPLOAD_MB` | API | – | Max upload size in MB (default `512`). |
 | `NGINX_CLIENT_MAX_BODY_SIZE` | Frontend | – | Keep in sync with the above, e.g. `512m`. |
 | `VAULT_BACKUP_RETENTION_DAYS` | API | – | `0` keeps backups forever. |


### PR DESCRIPTION
Install-time documentation that no longer matches the code. Everything below was read from this repo at `v0.11.4`, and each claim names where it came from.

## The JWT secret is not something the user has to set

Since 0.8.4, `runtime_config.ensure_jwt_secret` replaces the shipped placeholder with a generated secret on first boot and persists it, and the changelog says so. Four places still open by telling people to change it first:

- `README.md` quick start (`cp .env.example .env` plus an edit) and the warning block above it
- `SECURITY.md` deployment notes: "Change `VAULT_JWT_SECRET` before use."
- `docker-compose.light.yml`, which is now actively wrong: it warns that leaving the default "lets anyone forge admin login tokens", which is exactly what `ensure_jwt_secret` prevents
- `unraid/README.md`, which marks the variable required

This is the first thing a new reader sees, and it is a large part of why third-party roundups describe the install as more work than it is. All four now say the secret is optional and point at `docker-compose.prod.yml` as the one file that genuinely requires it, since it declares `${VAULT_JWT_SECRET:?...}`.

## The setup token was documented nowhere

`VAULT_SETUP_TOKEN` shipped in 0.10.0 and gates first-run account creation: `POST /api/v1/setup` returns `403 invalid_setup_token` without it, and when the variable is unset the API generates one per process and logs it while the vault is unconfigured. Nothing in any `.md` file mentions it, so a fresh install reaches the wizard and stops there with no instruction to grep the log.

Added to the README quick start and the Unraid steps, and backfilled into the 0.10.0 changelog under Security, following the precedent of the 0.8.5 backfill in 734d464.

## Install-time facts that drifted

- The README's service table pointed at `http://localhost:8000/docs` and `.../health`. The `api` service has been `expose`-only since 0.10.0, so nothing answers on 8000 from the host. The health check answers on port 3000 through the frontend's nginx, which proxies `/api/v1`. Swagger and ReDoc are not proxied, so the table now carries the `docker-compose.override.yml` that publishes the port.
- The three Wiki/Docs links pointed at `xiao-villamor.github.io/PrintStash`, which returns 404. Repointed at the live docs on `printstash.org`, verified 200.
- `unraid/README.md` credited the compose file with wiring "the migration command", which the image entrypoint has done since #29.
- Added the single-file `curl` install alongside the clone, since running PrintStash needs one file rather than a source tree.

## Docs only, plus one thing for you to decide

No code or compose behavior changes. The only functional file touched is `docker-compose.light.yml`, and only its comments.

One gap I deliberately did not fix, because it is a behavior change and I could not run your test suite: **setting `VAULT_JWT_SECRET` to an empty string bypasses the generated secret.** `ensure_jwt_secret` returns early whenever the value differs from `DEFAULT_JWT_SECRET`, and `""` differs, so the app signs tokens with an empty secret. Compose users are safe because `${VAR:-default}` substitutes on empty, but an Unraid template variable that is defined-and-empty passes `""` straight through. A validator in `Settings` rejecting an empty `jwt_secret` would close it. For now the docs I touched warn against it in each place.
