### PR TITLE
docs: Centauri Carbon upload shipped in 0.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ deliberately not a full manufacturing platform. Set expectations accordingly:
   Connect cloud is not used.
 - **Elegoo support covers Neptune 4, Pro, Plus, and Max** through Moonraker;
   Centauri Carbon and Carbon 2 additionally have beta local status/control
-  support through native SDCP/MQTT. Centauri upload/inventory is unavailable.
+  support through native SDCP/MQTT, plus beta G-code upload since 0.11.3.
+  Centauri file inventory and deletion remain unavailable.
 - **Hardware coverage is still thin.** Provider behavior needs more real-world
   validation across printers, firmware versions, and network/auth setups.
   Reports are very welcome.


### PR DESCRIPTION
The Known Limitations section still says `Centauri upload/inventory is unavailable`, which stopped
being true in 0.11.3:

> **Elegoo Centauri Carbon upload.** Both Centauri Carbon models can now receive Vault G-code
> directly (chunked HTTP upload, independent of the SDCP/MQTT control channel), via an upgraded
> `pycentauri` dependency (#57).

`docs/provider-support.md` and the landing site's compatibility matrix already describe upload as
beta and available, so the README is the only surface still saying otherwise.

This keeps the beta framing and the two things that genuinely remain unavailable, file inventory
and deletion, rather than claiming more than the release did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JDYadDsKc7sW95EqetkrC
