### PR TITLE
docs: 0.12.0 is published, not pending

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,11 +4,9 @@ This guide covers supported self-hosted upgrades. SQLite plus local filesystem
 storage remains the default. Always upgrade from a fresh backup and retain the
 previous application image until validation is complete.
 
-## Pending 0.12.0 notes
+## 0.12.0 notes
 
-The `0.12.0` branch is not a published release yet. Its upgrade-relevant
-changes are documented here so the pull request can be reviewed without
-implying that an image or tag already exists.
+`0.12.0` was published on 2026-08-19. Its upgrade-relevant changes:
 
 - Existing bcrypt password hashes remain valid. A successful login verifies
   the legacy hash and replaces it with Argon2; no offline password migration is


### PR DESCRIPTION
`UPGRADE.md` still opens its 0.12.0 section with:

> The `0.12.0` branch is not a published release yet. Its upgrade-relevant changes are documented
> here so the pull request can be reviewed without implying that an image or tag already exists.

The tag published on 2026-08-19, so that framing now tells an operator the opposite of what is
true, on the page they read while deciding whether to upgrade.

The bullets are unchanged. Only the heading and the preamble move from pending to published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2rwPqvcAYVX9pmqfvw8sr
