### PR TITLE
fix(uploads): give the request ceiling headroom over the per-file cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,12 @@ VAULT_JWT_SECRET=changeme_jwt_secret_please_change
 # default admin. Open the UI immediately after the first start.
 
 # VAULT_MAX_UPLOAD_MB=512
+# Ceiling nginx puts on a whole request, which must stay ABOVE the per-file cap:
+# a multipart request carrying a file at the cap also carries boundaries, part
+# headers and the form fields beside it. The backend allows 16 MiB of that
+# headroom, so raising VAULT_MAX_UPLOAD_MB means raising this to match (+16).
+# Leave both unset and the defaults already agree.
+# VAULT_MAX_REQUEST_MB=528
 # Maximum portable manifest size. Export uses the same limit so every archive
 # produced by this version remains importable by this version.
 # VAULT_PORTABLE_MANIFEST_MAX_MB=128

--- a/backend/app/core/body_limit.py
+++ b/backend/app/core/body_limit.py
@@ -1,4 +1,12 @@
-"""ASGI request-body ceiling enforced before multipart parsing or route code."""
+"""ASGI request-body ceiling enforced before multipart parsing or route code.
+
+This is the backstop, not the upload limit. It bounds what the process will
+buffer for one request — a client that lies about `content-length`, or streams
+without end — and answers `request_too_large`. The limit a *user* is subject to
+is per file, checked by the routes against `max_upload_bytes`, which answer
+`upload_too_large`. The two are deliberately different numbers: see
+`MULTIPART_OVERHEAD_BYTES`.
+"""
 
 from __future__ import annotations
 
@@ -21,7 +29,11 @@ class RequestBodyLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        limit = settings.max_upload_bytes
+        # The *request* ceiling, not the per-file cap. A multipart body carrying a
+        # file at the cap is larger than the file, so limiting the body to the
+        # per-file number rejected legal uploads here and left every route's own
+        # `upload_too_large` guard unreachable.
+        limit = settings.max_request_bytes
         headers = {key.lower(): value for key, value in scope.get("headers", [])}
         raw_length = headers.get(b"content-length")
         if raw_length:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,6 +27,21 @@ _overlay_lock = asyncio.Lock()
 # generated one on first boot.
 DEFAULT_JWT_SECRET = "changeme_jwt_secret_please_change"
 
+# Headroom the whole-request ceiling gets over the per-file cap.
+#
+# `max_upload_mb` is a limit on one *file* — that is what it is called in the UI
+# and what a user reads it as. A multipart request carrying a file at the cap is
+# necessarily larger than the file: boundaries, part headers, and the form fields
+# beside it (`model_name`, `collection`, `tags`). With one number for both, the
+# outer ceiling always fired first and the per-file guard could never run, so a
+# file *at* the documented limit was rejected as `request_too_large` — and
+# nothing could ever answer `upload_too_large`.
+#
+# 16 MiB is far more than any part header set, and small enough that the outer
+# ceiling still bounds what a lying `content-length` or an endless stream can
+# make the process buffer.
+MULTIPART_OVERHEAD_BYTES = 16 * 1024 * 1024
+
 
 class Settings(BaseSettings):
     """Frozen env-only settings. Never mutated after import.
@@ -267,6 +282,10 @@ class Settings(BaseSettings):
     def max_upload_bytes(self) -> int:
         return self.max_upload_mb * 1024 * 1024
 
+    @property
+    def max_request_bytes(self) -> int:
+        return self.max_upload_bytes + MULTIPART_OVERHEAD_BYTES
+
 
 class ConfigResolver:
     """Single read-path for effective configuration: overlay wins, frozen falls back.
@@ -300,6 +319,10 @@ class ConfigResolver:
     def max_upload_bytes(self) -> int:
         max_mb = _overlay.get("max_upload_mb", self._frozen.max_upload_mb)
         return max_mb * 1024 * 1024
+
+    @property
+    def max_request_bytes(self) -> int:
+        return self.max_upload_bytes + MULTIPART_OVERHEAD_BYTES
 
 
 # Public: same name, new type — transparent to all existing call sites.

--- a/backend/tests/integration/api/v1/inbox/test_capture_upload.py
+++ b/backend/tests/integration/api/v1/inbox/test_capture_upload.py
@@ -23,6 +23,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session
 from starlette.requests import Request
 
+from app.core import config
 from app.core.config import _overlay
 from app.db.models import (
     CaptureUploadSlot,
@@ -266,37 +267,38 @@ class TestPutCaptureUploadSlot:
             content=BODY,
         )
 
-        # The app-wide body limit reads the same setting and answers first, so
-        # this is what a client actually sees.
+        # The route's own per-file guard answers, through the full HTTP stack: the
+        # request ceiling now sits above the per-file cap, so a body that is only
+        # over the *file* limit reaches route code instead of being swallowed by
+        # the middleware as a generic `request_too_large`.
+        assert response.status_code == 413, response.text
+        assert response.json()["detail"] == "upload_too_large"
+
+    def test_refuses_a_body_past_the_whole_request_ceiling(
+        self, client: TestClient, user_headers, slots, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The outer ceiling is still there, and still answers differently.
+
+        It bounds what the process will buffer at all — a lying `content-length`,
+        or a stream with no end — so it refuses before route code runs and says
+        `request_too_large`. Collapsing the two details would leave a client
+        unable to tell "your file is too big" from "your request is malformed".
+        """
+        headers = user_headers("slot-request-too-large")
+        _, opened = slots(headers)
+        # Zero per-file cap puts the request ceiling at the overhead allowance
+        # alone, which a padded body then exceeds.
+        monkeypatch.setitem(_overlay, "max_upload_mb", 0.000001)
+        monkeypatch.setattr(config, "MULTIPART_OVERHEAD_BYTES", 4)
+
+        response = client.put(
+            f"/api/v1/inbox/capture-upload-slots/{opened[0]['id']}",
+            headers={**headers, **OCTET},
+            content=b"x" * 64,
+        )
+
         assert response.status_code == 413, response.text
         assert response.json()["detail"] == "request_too_large"
-
-    def test_refuses_a_declared_length_past_the_cap_at_the_route_itself(
-        self, db_session: Session, slots, user_headers, monkeypatch
-    ) -> None:
-        from fastapi import HTTPException
-
-        from app.api.v1 import inbox as inbox_api
-
-        headers = user_headers("slot-route-declared")
-        _, opened = slots(headers)
-        monkeypatch.setitem(_overlay, "max_upload_mb", 0.000004)
-
-        with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(
-                inbox_api.put_capture_upload_slot(
-                    opened[0]["id"],
-                    _put_request(
-                        opened[0]["id"], _receives(BODY), content_length=len(BODY)
-                    ),
-                    current_user=_slot_owner(db_session, opened[0]["id"]),
-                    session=db_session,
-                )
-            )
-
-        # Defence in depth: the route refuses on its own, without the middleware.
-        assert exc_info.value.status_code == 413
-        assert exc_info.value.detail == "upload_too_large"
 
     def test_stores_the_streamed_body_at_the_route_itself(
         self, db_session: Session, slots, user_headers

--- a/backend/tests/integration/api/v1/models/test_revisions.py
+++ b/backend/tests/integration/api/v1/models/test_revisions.py
@@ -244,7 +244,9 @@ class TestAddGcodeRevision:
             files={"file": ("rev.gcode", GCODE, "text/plain")},
         )
 
-        # The route's own cap, behind the app-wide body limit that answers first.
+        # The route's own per-file cap, which a client can now actually see: the
+        # request ceiling sits above it, so a file over the file limit reaches
+        # route code instead of being answered as `request_too_large`.
         assert response.status_code == 413, response.text
         assert response.json()["detail"] == "upload_too_large"
 

--- a/backend/tests/integration/api/v1/test_documents.py
+++ b/backend/tests/integration/api/v1/test_documents.py
@@ -248,6 +248,34 @@ class TestUploadDocument:
         assert uploaded["kind"] == "pdf"
         assert uploaded["filename"]
 
+    def test_tells_a_client_its_file_is_too_big_rather_than_its_request(
+        self,
+        client: TestClient,
+        admin_headers: dict[str, str],
+        tiny_upload_limit,
+    ) -> None:
+        """The per-file cap is what the user is subject to, so it is what they hear.
+
+        The app-wide body ceiling sits above this cap on purpose. With one number
+        for both it fired first and every client saw `request_too_large` — which
+        reads as "your request is malformed" for a file that is merely large, and
+        offers nothing to act on.
+        """
+        response = client.post(
+            "/api/v1/documents/upload",
+            files={
+                "file": (
+                    "manual.pdf",
+                    b"%PDF" + b"x" * (2 * MEGABYTE),
+                    "application/pdf",
+                )
+            },
+            headers=admin_headers,
+        )
+
+        assert response.status_code == 413, response.text
+        assert response.json()["detail"] == "upload_too_large"
+
     def test_names_the_document_after_the_filename_when_none_is_given(
         self, client: TestClient, admin_headers: dict[str, str]
     ) -> None:
@@ -287,11 +315,11 @@ class TestUploadDocument:
     async def test_rejects_a_part_that_declares_more_than_the_upload_limit(
         self, db_session: Session, admin: User, tiny_upload_limit
     ) -> None:
-        # `BodyLimitMiddleware` reads the *same* setting and rejects the whole
-        # request first, so over HTTP this guard can never fire — a client always
-        # sees `request_too_large`. It is still the right check for a caller that
-        # is not coming through the HTTP stack, and this is the only way to reach
-        # it. The three tests here cover the three sizes this endpoint bounds.
+        # Called directly because these three cover the three *sizes* this endpoint
+        # bounds — the declared part size, the decoded markdown body, and the
+        # stored blob — and only the first is reachable through a client. The row
+        # below proves the HTTP path reaches this guard rather than the app-wide
+        # body ceiling swallowing it.
         oversized = UploadFile(
             filename="manual.pdf", file=io.BytesIO(_OVER_A_MEGABYTE), size=2 * MEGABYTE
         )

--- a/backend/tests/integration/main/test_api_hardening.py
+++ b/backend/tests/integration/main/test_api_hardening.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.core import config
 from app.core.config import _overlay
 
 
@@ -24,8 +26,15 @@ class TestOpenApiContract:
 
 class TestBodyLimit:
     def test_api_rejects_oversized_request_body_before_route(
-        self, client: TestClient
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The ceiling is the per-file cap plus multipart headroom, and it still bites.
+
+        The headroom is shrunk here rather than sending 17 MiB: what this test is
+        about is that *some* body is refused before any route runs, not the size at
+        which that happens.
+        """
+        monkeypatch.setattr(config, "MULTIPART_OVERHEAD_BYTES", 0)
         _overlay["max_upload_mb"] = 1
         try:
             response = client.post(

--- a/backend/tests/repo/test_proxy_config.py
+++ b/backend/tests/repo/test_proxy_config.py
@@ -60,23 +60,66 @@ class TestFrontendNginxConf:
         assert "Permissions-Policy" in conf
 
 
+def _default_request_ceiling_mb() -> int:
+    """What the backend will accept for a whole request, in whole MiB.
+
+    Derived rather than written down, so the deployment files are checked against
+    the code's own arithmetic instead of a number somebody remembered.
+    """
+    from app.core.config import MULTIPART_OVERHEAD_BYTES, Settings
+
+    return Settings().max_upload_mb + MULTIPART_OVERHEAD_BYTES // (1024 * 1024)
+
+
 class TestFrontendDockerfile:
-    def test_frontend_image_defaults_to_backend_upload_limit(self) -> None:
+    def test_frontend_image_defaults_to_the_backend_request_ceiling(self) -> None:
+        """nginx bounds the *request*, so its default must clear the per-file cap.
+
+        Set to the per-file number, nginx answers a file at exactly the documented
+        limit with its own HTML 413 — the request carrying that file is larger than
+        the file — and the API never gets to say `upload_too_large`.
+        """
         dockerfile = (_root() / "frontend" / "Dockerfile").read_text()
 
         assert (
             "COPY nginx.conf /etc/nginx/templates/default.conf.template" in dockerfile
         )
-        assert "ENV NGINX_CLIENT_MAX_BODY_SIZE=512m" in dockerfile
+        assert (
+            f"ENV NGINX_CLIENT_MAX_BODY_SIZE={_default_request_ceiling_mb()}m"
+            in dockerfile
+        )
 
 
 class TestComposeFiles:
-    def test_compose_wires_frontend_proxy_limit_from_upload_setting(self) -> None:
-        root = REPO_ROOT
-        compose = (root / "docker-compose.yml").read_text()
+    @pytest.mark.parametrize(
+        "compose_file",
+        [
+            "docker-compose.yml",
+            "docker-compose.light.yml",
+            "docker-compose.prod.yml",
+            "docker-compose.manual-test.yml",
+        ],
+    )
+    def test_every_deployment_gives_the_proxy_multipart_headroom(
+        self, compose_file: str
+    ) -> None:
+        compose = (REPO_ROOT / compose_file).read_text()
 
-        assert "NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_UPLOAD_MB:-512}m" in compose
+        assert (
+            f"NGINX_CLIENT_MAX_BODY_SIZE: ${{VAULT_MAX_REQUEST_MB:-{_default_request_ceiling_mb()}}}m"
+            in compose.replace('"', "")
+        )
+
+    def test_compose_wires_the_backend_upload_cap_from_one_setting(self) -> None:
+        compose = (REPO_ROOT / "docker-compose.yml").read_text()
+
         assert "VAULT_MAX_UPLOAD_MB: ${VAULT_MAX_UPLOAD_MB:-512}" in compose
+
+    def test_the_example_env_documents_the_request_ceiling(self) -> None:
+        """Two knobs with a relationship between them is only safe if it is written down."""
+        example = (REPO_ROOT / ".env.example").read_text()
+
+        assert f"# VAULT_MAX_REQUEST_MB={_default_request_ceiling_mb()}" in example
 
     @pytest.mark.parametrize(
         "compose_file",

--- a/backend/tests/unit/core/test_body_limit.py
+++ b/backend/tests/unit/core/test_body_limit.py
@@ -9,6 +9,11 @@ rejected before a response is produced, and one exactly at the limit reaches the
 application — an off-by-one here rejects legitimate uploads at the boundary the
 documentation promises.
 
+The number it enforces is the *request* ceiling, not the per-file cap. Those are
+deliberately different: a multipart body carrying a file at the cap is larger than
+the file, so one number for both rejected legal uploads here and left every
+route's own per-file guard unreachable.
+
 A malformed `Content-Length` is deliberately *not* handled here. Guessing at it
 would either reject a valid request or trust an attacker's number; leaving it to
 the application means one place decides, and that place already validates.
@@ -74,7 +79,7 @@ class TestBodyLimitMiddleware:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(
-            type(settings), "max_upload_bytes", property(lambda _self: 3)
+            type(settings), "max_request_bytes", property(lambda _self: 3)
         )
 
         async def app(_scope, receive, _send) -> None:
@@ -90,7 +95,7 @@ class TestBodyLimitMiddleware:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setattr(
-            type(settings), "max_upload_bytes", property(lambda _self: 3)
+            type(settings), "max_request_bytes", property(lambda _self: 3)
         )
 
         async def app(_scope, receive, send) -> None:

--- a/docker-compose.light.yml
+++ b/docker-compose.light.yml
@@ -12,7 +12,7 @@ services:
     # nginx must allow request bodies up to the configured upload limit, or large
     # uploads fail with 413 before reaching the api.
     environment:
-      NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_UPLOAD_MB:-512}m
+      NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_REQUEST_MB:-528}m
     networks:
       - printstash_net
     depends_on:

--- a/docker-compose.manual-test.yml
+++ b/docker-compose.manual-test.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "127.0.0.1:${PRINTSTASH_HTTP_PORT:-3100}:3000"
     environment:
-      NGINX_CLIENT_MAX_BODY_SIZE: "${VAULT_MAX_UPLOAD_MB:-512}m"
+      NGINX_CLIENT_MAX_BODY_SIZE: "${VAULT_MAX_REQUEST_MB:-528}m"
     depends_on:
       api:
         condition: service_healthy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - "127.0.0.1:${PRINTSTASH_HTTP_PORT:-3000}:3000"
     environment:
-      NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_UPLOAD_MB:-512}m
+      NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_REQUEST_MB:-528}m
     networks:
       - printstash_net
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     # The SPA is served by nginx, which proxies /api/v1 (incl. WebSockets) to
     # the api service same-origin — so no browser-side API/WS URL is needed.
     environment:
-      NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_UPLOAD_MB:-512}m
+      NGINX_CLIENT_MAX_BODY_SIZE: ${VAULT_MAX_REQUEST_MB:-528}m
     networks:
       - printstash_net
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,7 +25,11 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 COPY security-headers.conf /etc/nginx/security-headers.conf
 
-ENV NGINX_CLIENT_MAX_BODY_SIZE=512m
+# The whole-*request* ceiling, not the per-file upload cap: 512 MiB of file plus
+# the 16 MiB of multipart headroom the backend allows (`MULTIPART_OVERHEAD_BYTES`).
+# Set to the per-file number, nginx rejects a file *at* the documented limit with
+# an HTML 413 the SPA cannot read, before the API can say `upload_too_large`.
+ENV NGINX_CLIENT_MAX_BODY_SIZE=528m
 
 EXPOSE 3000
 

--- a/frontend/src/lib/__tests__/task-center.test.ts
+++ b/frontend/src/lib/__tests__/task-center.test.ts
@@ -467,13 +467,14 @@ describe("waitForImportJob", () => {
     // the life of the tab.
     listIngestJobs.mockResolvedValue([aJob({ state: "running" })]);
     const pending = tc.waitForImportJob("job-1", "Import", 5_000);
-    // The rejection fires *inside* the timer advance, so the handler has to be
-    // attached before it: awaiting afterwards makes node report an unhandled
-    // rejection, which vitest counts as an error even though the test passes.
-    const rejects = expect(pending).rejects.toThrow(/Timed out/);
+    // The rejection fires *inside* the timer advance, so something has to be
+    // listening before it: with the first handler attached only afterwards, node
+    // reports an unhandled rejection and vitest counts it as a run error even
+    // though the test passes.
+    void pending.catch(() => {});
     await vi.advanceTimersByTimeAsync(6_000);
 
-    await rejects;
+    await expect(pending).rejects.toThrow(/Timed out/);
   });
 
   it("keeps polling after a failed sync", async () => {

--- a/frontend/src/lib/__tests__/task-center.test.ts
+++ b/frontend/src/lib/__tests__/task-center.test.ts
@@ -467,9 +467,13 @@ describe("waitForImportJob", () => {
     // the life of the tab.
     listIngestJobs.mockResolvedValue([aJob({ state: "running" })]);
     const pending = tc.waitForImportJob("job-1", "Import", 5_000);
+    // The rejection fires *inside* the timer advance, so the handler has to be
+    // attached before it: awaiting afterwards makes node report an unhandled
+    // rejection, which vitest counts as an error even though the test passes.
+    const rejects = expect(pending).rejects.toThrow(/Timed out/);
     await vi.advanceTimersByTimeAsync(6_000);
 
-    await expect(pending).rejects.toThrow(/Timed out/);
+    await rejects;
   });
 
   it("keeps polling after a failed sync", async () => {

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -98,9 +98,9 @@ const ERROR_MESSAGES = {
   unsupported_file_type: "Unsupported file type.",
   file_too_large: "File exceeds the upload size limit.",
   upload_too_large: "File exceeds the upload size limit.",
-  // `BodyLimitMiddleware` rejects an oversized request before any route sees it,
-  // so for an upload this is the detail the client actually receives — the route's
-  // own `upload_too_large` never gets the chance to fire over HTTP.
+  // The backstop, not the upload limit: `BodyLimitMiddleware` bounds the whole
+  // request — which sits above the per-file cap — so a merely-large file gets the
+  // specific `upload_too_large` above and only a runaway body lands here.
   request_too_large: "Request exceeds the size limit.",
   no_importable_files: "No importable 3D files were found.",
   no_entries_selected: "Select at least one file to import.",


### PR DESCRIPTION
## What

`max_upload_mb` is a limit on one **file** — that is what the UI calls it and what a user reads it as. Three layers enforced that same number on the whole **request**, and a multipart request carrying a file at the cap is necessarily larger than the file: boundaries, part headers, and the form fields beside it (`model_name`, `collection`, `tags`).

So a file at exactly the documented limit was rejected — by nginx with an HTML 413 the SPA cannot parse, or by the body-limit middleware with `request_too_large`, which reads as *"your request is malformed"* for a file that is merely large and offers the user nothing to act on. And because the outer ceiling always answered first, **every route's own `upload_too_large` guard was unreachable over HTTP** (`ingest.py`, `models.py`, `documents.py`, `taxonomy.py`).

This was finding **F-6** of the test-infrastructure overhaul (#89), left open there as a design question rather than a bug.

## The fix

One derived value, no new tuning burden for the common case:

| Layer | Before | After |
| --- | --- | --- |
| route guards | `max_upload_bytes` → `upload_too_large` (unreachable) | unchanged — now **reachable and precise** |
| `RequestBodyLimitMiddleware` | `max_upload_bytes` → fired first | `max_upload_bytes + MULTIPART_OVERHEAD_BYTES` (16 MiB) → the backstop it was written to be |
| nginx `client_max_body_size` | `${VAULT_MAX_UPLOAD_MB:-512}m` | `${VAULT_MAX_REQUEST_MB:-528}m` |

16 MiB is far more than any part-header set, and small enough that the outer ceiling still bounds what a lying `content-length` or an endless stream can make the process buffer.

`VAULT_MAX_REQUEST_MB` is a second knob, so its relationship to the first is written down in `.env.example` **and** checked in CI: `tests/repo/test_proxy_config.py` derives the expected value from `Settings().max_upload_mb + MULTIPART_OVERHEAD_BYTES`, so the four compose files and the frontend Dockerfile are verified against the code's own arithmetic instead of a number somebody remembered. Raise one default without the other and the repo suite goes red.

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | the ceiling is the per-file cap plus the multipart headroom | Happy | default settings | `settings.max_request_bytes == max_upload_bytes + MULTIPART_OVERHEAD_BYTES` | Unit | ✅ `unit/core/test_body_limit.py` (all three cases repointed to `max_request_bytes`) |
| 2 | a declared length past the ceiling is refused before any route runs | Error | `content-length` over the ceiling | 413 `request_too_large`; route never entered | Unit | ✅ `unit/core/test_body_limit.py::TestRequestBodyLimitMiddleware` |
| 3 | a streamed body past the ceiling is refused mid-stream | Error | chunks summing past the ceiling, no honest `content-length` | 413 `request_too_large` | Unit | ✅ `unit/core/test_body_limit.py` |
| 4 | some body is still refused before route code | Error | `max_upload_mb=1`, headroom shrunk to 0 | 413 `request_too_large` on `/auth/login` | Integration | ✅ `integration/main/test_api_hardening.py::TestBodyLimit::test_api_rejects_oversized_request_body_before_route` |
| 5 | a file past the per-file cap hears `upload_too_large`, not `request_too_large` | Error | 2 MB PDF, 1 MB cap, real HTTP client | 413 `upload_too_large` | Integration | ✅ `integration/api/v1/test_documents.py::TestUploadDocument::test_tells_a_client_its_file_is_too_big_rather_than_its_request` |
| 6 | the same, on the capture-upload route | Error | declared part length past the cap | 413 `upload_too_large` | Integration | ✅ `integration/api/v1/inbox/test_capture_upload.py::test_refuses_a_declared_length_past_the_upload_cap` |
| 7 | a body past the whole-request ceiling is still refused there | Error | `MULTIPART_OVERHEAD_BYTES` monkeypatched to 4 | 413 `request_too_large` | Integration | ✅ `integration/api/v1/inbox/test_capture_upload.py::test_refuses_a_body_past_the_whole_request_ceiling` |
| 8 | the revision route's per-file cap answers over HTTP | Error | staged write reporting too-large | 413 `upload_too_large` | Integration | ✅ `integration/api/v1/models/test_revisions.py` (stale "answers first" comment corrected) |
| 9 | the frontend image default clears the per-file cap | Edge | `frontend/Dockerfile` | `ENV NGINX_CLIENT_MAX_BODY_SIZE=528m`, derived from the code | Repo | ✅ `repo/test_proxy_config.py::TestFrontendDockerfile::test_frontend_image_defaults_to_the_backend_request_ceiling` |
| 10 | every deployment gives the proxy the same headroom | Edge | all four compose files | `${VAULT_MAX_REQUEST_MB:-528}m`, derived | Repo | ✅ `repo/test_proxy_config.py::TestComposeFiles::test_every_deployment_gives_the_proxy_multipart_headroom` (parametrized ×4) |
| 11 | the backend cap still comes from one setting | Edge | `docker-compose.yml` | `VAULT_MAX_UPLOAD_MB: ${VAULT_MAX_UPLOAD_MB:-512}` | Repo | ✅ `repo/test_proxy_config.py::TestComposeFiles::test_compose_wires_the_backend_upload_cap_from_one_setting` |
| 12 | the two-knob relationship is documented | Edge | `.env.example` | `# VAULT_MAX_REQUEST_MB=528` present, derived value | Repo | ✅ `repo/test_proxy_config.py::TestComposeFiles::test_the_example_env_documents_the_request_ceiling` |
| 13 | `request_too_large` copy reflects its new role | Edge | `frontend/src/lib/errors.ts` | comment corrected; the mapped copy is unchanged | — | ⏭️ N/A — comment-only; the string it annotates already has coverage in `lib/__tests__/errors.test.ts` |
| 14 | the timeout waiter rejects without an unhandled rejection | Error | fake timers advanced past the timeout | rejection observed by an already-attached handler; vitest reports 0 errors | Frontend unit | ✅ `src/lib/__tests__/task-center.test.ts::gives up rather than waiting forever` |

## Verification

All run on this branch (tree identical to `0.13.0` plus this commit):

- `./scripts/test.sh full -q` — **6093 passed**
- `./scripts/test.sh coverage` — **6093 passed, 93.65% branches**, every floor held (11 floor tests pass)
- `uv run ruff check app/ tests/` — clean · `ruff format --check` (CI scope) — 77 files formatted · `uv run pyright` — **0 errors**
- `pnpm lint` · `pnpm format:check` · `pnpm typecheck` — clean
- `pnpm test` — **1456 passed** (107 files)
- `pnpm coverage` — app 80.75%/73.47%, domain 95.48%/92.63%, ui 98.78%/97.60% — *"coverage gate: every floor held."*

One flake seen and not reproducible: `integration/api/v1/printers/test_providers.py::TestPrusaLinkPrinter::test_create_api_key_credentials_are_redacted` failed once under the coverage lane and passed on re-run both alone and in a full re-run. Unrelated to this change; worth watching if it recurs.

## Notes for review

- The 10 MB image caps at `documents.py:438/443` and `taxonomy.py:403` are independent of `max_upload_mb` and were always well under the ceiling — untouched, and unaffected.
- No migration, no schema change, no API contract change. `request_too_large` remains a real answer for a runaway body; it is simply no longer the answer for an ordinary large file.
