### PR TITLE
fix(ci): align storage safety gates

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -82,9 +82,7 @@ class Settings(BaseSettings):
     s3_bucket: str = ""
     s3_endpoint_url: str = ""
     s3_region: str = "auto"
-    s3_addressing_style: str = Field(
-        default="auto", pattern=r"^(auto|path|virtual)$"
-    )
+    s3_addressing_style: str = Field(default="auto", pattern=r"^(auto|path|virtual)$")
     s3_access_key: str = ""
     s3_secret_key: str = ""
     # Historical installs default to the literal ``vault-data`` prefix. Typed

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1690,7 +1690,9 @@ class ExternalLibrary(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(max_length=128)
     root_path: str = Field(max_length=1024)
-    source_kind: LibrarySourceKind = Field(default=LibrarySourceKind.MOUNTED, index=True)
+    source_kind: LibrarySourceKind = Field(
+        default=LibrarySourceKind.MOUNTED, index=True
+    )
     connection_id: Optional[int] = Field(
         default=None, foreign_key="storage_connections.id", index=True
     )
@@ -1771,7 +1773,9 @@ class ExternalLibraryCheckpoint(SQLModel, table=True):
     epoch: str = Field(max_length=64, index=True)
     cursor: Optional[str] = Field(default=None, max_length=2048)
     complete: bool = Field(default=False, index=True)
-    observed_keys_json: str = Field(default="[]", sa_column=Column(Text, nullable=False))
+    observed_keys_json: str = Field(
+        default="[]", sa_column=Column(Text, nullable=False)
+    )
     metadata_ops: int = 0
     bytes_read: int = Field(default=0, sa_column=Column(BigInteger, nullable=False))
     backoff_until: Optional[datetime] = Field(default=None, index=True)

--- a/frontend/src/components/__tests__/settings-panel.test.tsx
+++ b/frontend/src/components/__tests__/settings-panel.test.tsx
@@ -986,6 +986,27 @@ describe("SettingsPanel", () => {
       expect(await screen.findByText("GC plan #12 · preview")).toBeVisible();
     });
 
+    it("aborts an active preview without issuing a destructive transition", async () => {
+      const user = userEvent.setup();
+      const { requestsWithMethod } = renderSettings({
+        at: "/settings?section=trash",
+        routes: {
+          "GET /api/v1/admin/gc": json(GC_PLAN),
+          "POST /api/v1/admin/gc/12/abort": json({ ...GC_PLAN, state: "aborted" }),
+        },
+      });
+
+      await user.click(await screen.findByRole("button", { name: "Abort plan" }));
+
+      await waitFor(() =>
+        expect(requestsWithMethod("POST").some((call) => call.url.endsWith("/gc/12/abort"))).toBe(
+          true,
+        ),
+      );
+      expect(requestsWithMethod("DELETE")).toHaveLength(0);
+      expect(await screen.findByText("GC plan #12 · aborted")).toBeVisible();
+    });
+
     it("restores a model out of the trash", async () => {
       const user = userEvent.setup();
       const { requestsWithMethod } = renderSettings({

--- a/frontend/tests/e2e-real/storage/storage-provider.spec.ts
+++ b/frontend/tests/e2e-real/storage/storage-provider.spec.ts
@@ -50,10 +50,40 @@ async function webdavRemoteHrefs(page: Page): Promise<string[]> {
   return [...xml.matchAll(/<(?:d|D):href>([^<]+)<\/(?:d|D):href>/g)].map((match) => match[1]);
 }
 
+async function previewExpiredTrashWithoutApproval(page: Page, modelName: string): Promise<void> {
+  await page.goto("/settings?section=trash");
+  await expect(page.getByText(modelName)).toBeVisible();
+  await page.getByRole("spinbutton").fill("0");
+  await page.getByRole("button", { name: "Save retention" }).click();
+  await page.getByRole("button", { name: "Review expired" }).click();
+  const dialog = page.getByRole("dialog", { name: "Create a safe GC preview?" });
+  await expect(dialog).toContainText("It does not delete catalog rows or storage bytes.");
+  await dialog.getByRole("button", { name: "Create preview" }).click();
+
+  await expect(page.getByText(/GC plan #\d+ · preview/)).toBeVisible();
+  await expect(page.getByText(modelName)).toBeVisible();
+  const digest = await page.getByText(/^[0-9a-f]{64}$/).textContent();
+  expect(digest).not.toBeNull();
+  await page.getByLabel("Confirm GC plan digest").fill(digest!);
+
+  const refused = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1/admin/gc/") &&
+      response.url().endsWith("/approve") &&
+      response.request().method() === "POST",
+  );
+  await page.getByRole("button", { name: "Verify backup and quarantine" }).click();
+  expect((await refused).status()).toBe(409);
+  await expect(page.getByText(modelName)).toBeVisible();
+
+  await page.getByRole("button", { name: "Abort plan" }).click();
+  await expect(page.getByText(/GC plan #\d+ · aborted/)).toBeVisible();
+}
+
 test.describe("storage provider setup", () => {
   test.describe.configure({ mode: "serial" });
 
-  test("configures WebDAV through restart to its probed tier", async ({ page }) => {
+  test("configures WebDAV through restart with safe GC preview", async ({ page }) => {
     await page.goto("/setup");
     await page.getByLabel("Setup token").fill("playwright-storage-token-123");
     await page.getByLabel("Username").fill("storage-admin");
@@ -95,7 +125,7 @@ test.describe("storage provider setup", () => {
     await expect(page.getByPlaceholder("Stored — leave blank to keep")).toBeVisible();
 
     // Continue through the public UI after restart. This deliberately does not
-    // bind a backend instance: the upload, trash, confirmation, and cleanup
+    // bind a backend instance: the upload, trash, preview, and refusal
     // result must all cross the configured provider boundary.
     const modelName = `storage-lifecycle-${Date.now()}`;
     const remoteBefore = await webdavRemoteHrefs(page);
@@ -116,30 +146,14 @@ test.describe("storage provider setup", () => {
     await clickModelAction(page, "Delete model");
     await page.getByRole("dialog").getByRole("button", { name: "Delete" }).click();
 
-    await page.goto("/settings?section=trash");
-    await expect(page.getByText(modelName)).toBeVisible();
-    await page.getByRole("spinbutton").fill("0");
-    await page.getByRole("button", { name: "Save retention" }).click();
-    await page.getByRole("button", { name: "Purge expired" }).click();
-    const purgeResponse = page.waitForResponse(
-      (response) =>
-        response.request().method() === "DELETE" &&
-        response.url().includes("/models/trash/expired") &&
-        response.url().includes("confirm_storage_risk=true"),
-    );
-    await page.getByRole("dialog").getByRole("button", { name: "Purge forever" }).click();
-    const purgeBody = await (await purgeResponse).json();
-    expect(purgeBody).toMatchObject({ storage_cleanup_status: "blocked" });
-    expect(purgeBody.storage_blocked).toBeGreaterThan(0);
-    await expect(page.getByText(modelName)).toHaveCount(0);
-    await expect(page.getByRole("status")).toContainText("retained");
+    await previewExpiredTrashWithoutApproval(page, modelName);
     const retainedBytes = await page.request.fetch(remoteObjectUrl);
     expect(retainedBytes.status()).toBe(200);
     expect(Number(retainedBytes.headers()["content-length"] ?? 0)).toBe(expectedBytes.length);
     expect(await retainedBytes.body()).toEqual(expectedBytes);
   });
 
-  test("configures real Nextcloud with confirmed cleanup", async ({ page }) => {
+  test("configures real Nextcloud with safe GC preview", async ({ page }) => {
     test.skip(
       !nextcloudUrl,
       "Set PLAYWRIGHT_STORAGE_NEXTCLOUD_URL and run the optional Nextcloud container to enable this contract.",
@@ -195,37 +209,7 @@ test.describe("storage provider setup", () => {
     await clickModelAction(page, "Delete model");
     await page.getByRole("dialog").getByRole("button", { name: "Delete" }).click();
 
-    await page.goto("/settings?section=trash");
-    await expect(page.getByText(modelName)).toBeVisible();
-    await page.getByRole("spinbutton").fill("0");
-    await page.getByRole("button", { name: "Save retention" }).click();
-
-    // The first dialog is the guard: no destructive request is sent without the
-    // explicit storage-risk confirmation.
-    let unconfirmedDeleteRequests = 0;
-    page.on("request", (request) => {
-      if (request.method() === "DELETE" && request.url().includes("/models/trash/expired")) {
-        unconfirmedDeleteRequests += 1;
-      }
-    });
-    await page.getByRole("button", { name: "Purge expired" }).click();
-    await expect(page.getByRole("dialog")).toContainText(/one-time storage risk acknowledgement/i);
-    await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
-    expect(unconfirmedDeleteRequests).toBe(0);
-
-    await page.getByRole("button", { name: "Purge expired" }).click();
-    const purgeResponse = page.waitForResponse(
-      (response) =>
-        response.request().method() === "DELETE" &&
-        response.url().includes("/models/trash/expired") &&
-        response.url().includes("confirm_storage_risk=true"),
-    );
-    await page.getByRole("dialog").getByRole("button", { name: "Purge forever" }).click();
-    const purgeBody = await (await purgeResponse).json();
-    expect(purgeBody).toMatchObject({ storage_cleanup_status: "blocked" });
-    expect(purgeBody.storage_blocked).toBeGreaterThan(0);
-    await expect(page.getByText(modelName)).toHaveCount(0);
-    await expect(page.getByRole("status")).toContainText("retained");
+    await previewExpiredTrashWithoutApproval(page, modelName);
     const retainedBytes = await page.request.fetch(remoteObjectUrl, {
       headers: {
         Authorization: `Basic ${Buffer.from(`${nextcloudUsername}:${nextcloudPassword}`).toString("base64")}`,
@@ -236,7 +220,7 @@ test.describe("storage provider setup", () => {
     expect(await retainedBytes.body()).toEqual(expectedBytes);
   });
 
-  test("configures real SFTP with guarded cleanup", async ({ page }) => {
+  test("configures real SFTP with safe GC preview", async ({ page }) => {
     test.skip(
       !sftpHost || !sftpHostKey,
       "Set PLAYWRIGHT_STORAGE_SFTP_HOST and PLAYWRIGHT_STORAGE_SFTP_HOST_KEY for the optional OpenSSH harness.",
@@ -272,24 +256,6 @@ test.describe("storage provider setup", () => {
     await modelCard(page, modelName).click();
     await clickModelAction(page, "Delete model");
     await page.getByRole("dialog").getByRole("button", { name: "Delete" }).click();
-    await page.goto("/settings?section=trash");
-    await expect(page.getByText(modelName)).toBeVisible();
-    await page.getByRole("spinbutton").fill("0");
-    await page.getByRole("button", { name: "Save retention" }).click();
-    await page.getByRole("button", { name: "Purge expired" }).click();
-    await page.getByRole("dialog").getByRole("button", { name: "Cancel" }).click();
-    await page.getByRole("button", { name: "Purge expired" }).click();
-    const purgeResponse = page.waitForResponse(
-      (response) =>
-        response.request().method() === "DELETE" &&
-        response.url().includes("/models/trash/expired") &&
-        response.url().includes("confirm_storage_risk=true"),
-    );
-    await page.getByRole("dialog").getByRole("button", { name: "Purge forever" }).click();
-    const purgeBody = await (await purgeResponse).json();
-    expect(purgeBody).toMatchObject({ storage_cleanup_status: "blocked" });
-    expect(purgeBody.storage_blocked).toBeGreaterThan(0);
-    await expect(page.getByText(modelName)).toHaveCount(0);
-    await expect(page.getByRole("status")).toContainText("retained");
+    await previewExpiredTrashWithoutApproval(page, modelName);
   });
 });


### PR DESCRIPTION
## Summary

- format the OpenDAL configuration and external-library models with the exact Ruff scope enforced by CI
- replace the removed direct trash purge flow in real-provider Playwright coverage with the ADR3 GC preview, digest verification, guarded refusal, and explicit abort flow
- cover aborting a GC preview in the frontend and prove that it sends no destructive request

## Testing

- [ ] `cd backend && ./scripts/test.sh full` green, or not needed
- [x] `cd frontend && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` green, or not needed
- [x] Manual test notes included, or not needed

Backend CI-equivalent formatting and lint are green. The local fast suite reached 1,980 passing tests, but staging tests fail closed because the host has only 1.6 GB free while the safety minimum requires more; failures consistently report `staging_capacity_exceeded`. No backend behavior changed in this PR.

Additional checks:

- `uv run ruff format --check app/core app/db app/schemas packages/printstash-core/src`
- `uv run ruff check app/ tests/`
- `pnpm exec vitest run src/components/__tests__/settings-panel.test.tsx` — 98 passed
- `pnpm test:e2e:storage` — WebDAV passed; optional Nextcloud and SFTP services were not configured locally
- `pnpm coverage` — app 80.78% statements / 73.68% branches; domain 95.48% / 92.63%; UI 98.78% / 97.60%; every floor held
- `git diff --check`

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|-----------|----------|----------------------|--------------------|------|--------|
| 1 | Aborts an active GC preview without a destructive transition | Happy | Active plan in `preview` state | Sends the abort request, renders `aborted`, and sends zero DELETE requests | Frontend unit | ✅ `frontend/src/components/__tests__/settings-panel.test.tsx::aborts an active preview without issuing a destructive transition` |
| 2 | WebDAV lifecycle uses the safe GC preview | Edge | Guarded WebDAV storage with a trashed model | Approval is refused with 409; model and remote bytes remain; plan can be aborted | Playwright real backend | ✅ `frontend/tests/e2e-real/storage/storage-provider.spec.ts::configures WebDAV through restart with safe GC preview` |
| 3 | Nextcloud lifecycle uses the safe GC preview | Edge | Guarded real Nextcloud storage with a trashed model | Approval is refused with 409; model and remote bytes remain; plan can be aborted | Playwright real backend | ✅ `frontend/tests/e2e-real/storage/storage-provider.spec.ts::configures real Nextcloud with safe GC preview` |
| 4 | SFTP lifecycle uses the safe GC preview | Edge | Guarded real OpenSSH storage with a trashed model | Approval is refused with 409; model remains; plan can be aborted | Playwright real backend | ✅ `frontend/tests/e2e-real/storage/storage-provider.spec.ts::configures real SFTP with safe GC preview` |

### Tier check

- [ ] `unit/` — pure logic, or a fault that cannot be reproduced for real
- [ ] `integration/` — the default: any router, any DB write, any RBAC or live/trashed rule
- [ ] `contract/` — our client against a real fake over a loopback socket, with no mocking inside
- [ ] `e2e/` — one test for the feature headline capability
- [x] `frontend/src/**/__tests__/` or `frontend/tests/e2e-real/`

### Self-check

- [x] Every new test file opens with a contract header saying what it defends
- [x] Every new test asserts one behaviour — no name contains "and"
- [x] No new `skip`/`xfail`/`.skip` or commented-out tests
- [x] No new endpoint

### Fixtures and factories

- [x] No backend rows, fixtures, factories, or entities changed

## Notes

No schema, API, storage-provider, or production behavior changes. This aligns the CI expectations with the already-merged ADR3 guarded-GC contract. Nextcloud and SFTP retain their environment-gated real-service tests; the same helper is exercised locally through WebDAV.
