### PR TITLE
Fix/restore existing destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,7 +188,9 @@ be provisioned before startup; review [UPGRADE.md](./UPGRADE.md).**
   and releases maintenance mode instead of leaving the vault read-only. If an
   interrupted restore outlives the browser session, administrators can sign in
   through an access-only recovery session and resume it without admitting a
-  concurrent database write.
+  concurrent database write. Container restarts preserve valid local ownership
+  receipts, and backups affected by an earlier metadata-only ownership repair
+  can restore after exact SHA-256 and inode verification.
 - Interrupted OpenDAL backup publications can now reconcile their persisted
   ownership receipt instead of failing while constructing the verification
   copy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,11 @@ be provisioned before startup; review [UPGRADE.md](./UPGRADE.md).**
 
 ### Fixed
 
+- Restoring a backup now safely reuses storage objects whose size and SHA-256
+  already match the archive, so an in-place recovery no longer fails merely
+  because its immutable files are still present. A genuine destination
+  conflict still fails before any write, but now removes its preflight journal
+  and releases maintenance mode instead of leaving the vault read-only.
 - Interrupted OpenDAL backup publications can now reconcile their persisted
   ownership receipt instead of failing while constructing the verification
   copy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,7 +185,10 @@ be provisioned before startup; review [UPGRADE.md](./UPGRADE.md).**
   already match the archive, so an in-place recovery no longer fails merely
   because its immutable files are still present. A genuine destination
   conflict still fails before any write, but now removes its preflight journal
-  and releases maintenance mode instead of leaving the vault read-only.
+  and releases maintenance mode instead of leaving the vault read-only. If an
+  interrupted restore outlives the browser session, administrators can sign in
+  through an access-only recovery session and resume it without admitting a
+  concurrent database write.
 - Interrupted OpenDAL backup publications can now reconcile their persisted
   ownership receipt instead of failing while constructing the verification
   copy.

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -184,6 +184,7 @@ async def oidc_callback(
 )
 def login(
     body: LoginRequest,
+    request: Request,
     response: Response,
     session: Session = Depends(get_session),
 ) -> TokenResponse:
@@ -197,10 +198,21 @@ def login(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="provide_password_or_api_key",
         )
+    recovery_login = bool(getattr(request.state, "restore_recovery_login", False))
     user = (
-        authenticate_user(session, body.username, body.password)
+        authenticate_user(
+            session,
+            body.username,
+            body.password,
+            persist_password_upgrade=not recovery_login,
+        )
         if body.password
-        else authenticate_api_key(session, body.username, body.api_key or "")
+        else authenticate_api_key(
+            session,
+            body.username,
+            body.api_key or "",
+            persist_usage=not recovery_login,
+        )
     )
     if user is None:
         raise HTTPException(
@@ -218,7 +230,9 @@ def login(
         expires_delta=expires_delta,
         auth_version=user.auth_version,
     )
-    refresh_token = create_refresh_token(session, user_id=user.id)
+    refresh_token = (
+        None if recovery_login else create_refresh_token(session, user_id=user.id)
+    )
     max_age = (
         int(timedelta(days=settings.remember_me_days).total_seconds())
         if body.remember_me

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from app.services.backup import (
     begin_mutating_operation,
     end_mutating_operation,
     inspect_restore_recovery,
+    restore_in_progress,
 )
 from app.services.backup_schedule import run_due_backup
 from app.services.gc_planner import run_scheduled_gc
@@ -522,6 +523,13 @@ async def quiesce_writes_during_restore(request: Request, call_next):
         and path.endswith("/restore")
     )
     if is_restore_request:
+        return await call_next(request)
+    is_login_request = request.method == "POST" and path == "/api/v1/auth/login"
+    if is_login_request and restore_in_progress():
+        # An interrupted restore may outlive the browser session. Permit the
+        # router's access-only recovery login without admitting a database
+        # mutation; every other POST remains quiesced.
+        request.state.restore_recovery_login = True
         return await call_next(request)
     if not begin_mutating_operation():
         return JSONResponse(

--- a/backend/app/services/auth.py
+++ b/backend/app/services/auth.py
@@ -310,7 +310,13 @@ def get_user_by_id(session: Session, user_id: int) -> Optional[User]:
     return session.get(User, user_id)
 
 
-def authenticate_user(session: Session, username: str, password: str) -> Optional[User]:
+def authenticate_user(
+    session: Session,
+    username: str,
+    password: str,
+    *,
+    persist_password_upgrade: bool = True,
+) -> Optional[User]:
     user = get_user_by_username(session, username)
     if not user or not user.is_active:
         logger.info("login failed: user=%s not found or inactive", username)
@@ -322,7 +328,7 @@ def authenticate_user(session: Session, username: str, password: str) -> Optiona
     if not valid:
         logger.info("login failed: user=%s bad password", username)
         return None
-    if updated_hash is not None:
+    if updated_hash is not None and persist_password_upgrade:
         user.hashed_password = updated_hash
         session.add(user)
         # The credential upgrade must be durable before a token can be issued.
@@ -369,7 +375,11 @@ def revoke_api_key(session: Session, user_id: int, key_id: int) -> bool:
 
 
 def authenticate_api_key(
-    session: Session, username: str, api_key: str
+    session: Session,
+    username: str,
+    api_key: str,
+    *,
+    persist_usage: bool = True,
 ) -> Optional[User]:
     user = get_user_by_username(session, username)
     if not user or not user.is_active:
@@ -384,8 +394,9 @@ def authenticate_api_key(
     if record is None:
         logger.info("api key login failed: user=%s bad key", username)
         return None
-    record.last_used_at = utcnow()
-    session.add(record)
-    session.commit()
+    if persist_usage:
+        record.last_used_at = utcnow()
+        session.add(record)
+        session.commit()
     logger.info("api key login success: user=%s", username)
     return user

--- a/backend/app/services/backup.py
+++ b/backend/app/services/backup.py
@@ -2594,22 +2594,69 @@ def _require_backup_archive_owned(
     with get_session_factory().session() as session:
         if meta.location == "local":
             backend = LocalStorageBackend()
-            try:
-                require_owned_key(session, backend, meta.path)
-            except Exception as exc:
-                raise BackupOwnershipError(
-                    "backup_storage_ownership_unverified"
-                ) from exc
-            row = session.exec(
+            rows = session.exec(
                 select(OwnedStorageObject).where(
                     OwnedStorageObject.backend == "local",
                     OwnedStorageObject.namespace == backend.namespace_for(meta.path),
                     OwnedStorageObject.key == meta.path,
+                    OwnedStorageObject.provider_ref
+                    == provider_ref_for_backend(
+                        backend, namespace=backend.namespace_for(meta.path)
+                    ),
+                    OwnedStorageObject.object_kind.in_(  # type: ignore[union-attr]
+                        ("backup", "backup-legacy")
+                    ),
                     OwnedStorageObject.state == StorageObjectState.COMMITTED,
                 )
-            ).first()
-            assert row is not None
-            return row
+            ).all()
+            for row in rows:
+                if row.token is None or row.size_bytes is None:
+                    continue
+                receipt = CreationReceipt(
+                    key=row.key,
+                    size=row.size_bytes,
+                    token=row.token,
+                    backend=row.backend,
+                    namespace=row.namespace,
+                    etag=row.etag,
+                    version_id=row.version_id,
+                    device=row.device,
+                    inode=row.inode,
+                    ctime_ns=row.ctime_ns,
+                    provider_ref=row.provider_ref,
+                )
+                try:
+                    if backend.creation_matches(receipt):
+                        return row
+                    if (
+                        row.sha256 is None
+                        or row.device is None
+                        or row.inode is None
+                    ):
+                        continue
+                    refreshed = backend.adopt_existing(
+                        row.key,
+                        expected_size=row.size_bytes,
+                        expected_sha256=row.sha256,
+                    )
+                except Exception:
+                    continue
+                # A root-level metadata repair can change ctime, but it cannot
+                # replace the directory entry. Require the original inode in
+                # addition to exact bytes before refreshing the receipt.
+                if (refreshed.device, refreshed.inode) != (row.device, row.inode):
+                    continue
+                owned = record_creation(
+                    session,
+                    refreshed,
+                    object_kind=row.object_kind,
+                    sha256=row.sha256,
+                    provider_ref=row.provider_ref,
+                )
+                session.commit()
+                session.refresh(owned)
+                return owned
+            raise BackupOwnershipError("backup_storage_ownership_unverified")
 
         if meta.location.startswith("opendal:"):
             candidates = session.exec(

--- a/backend/app/services/backup.py
+++ b/backend/app/services/backup.py
@@ -3798,12 +3798,13 @@ def _apply_staged_blobs(
     journal_path: Path | None = None,
     journal_state: _RestoreJournalState | None = None,
 ) -> tuple[list[_AppliedBlob], list[_AppliedBlob]]:
-    """Publish a restore only into empty, in-bound destinations.
+    """Publish a restore into empty or byte-identical, in-bound destinations.
 
     Restore used to overwrite every manifest key and then attempt a best-effort
     rollback. A malicious/stale manifest or remapped root could therefore
-    clobber unrelated bytes. Colliding restores now fail before the first write;
-    operators must restore into dedicated empty storage.
+    clobber unrelated bytes. Conflicting restores now fail before the first
+    write. Existing bytes are reused only when their size and SHA-256 match the
+    archive, and that adoption is journalled before it can affect ownership.
     """
     del rollback_dir
     backend = get_backend()
@@ -3811,6 +3812,7 @@ def _apply_staged_blobs(
     created: list[_AppliedBlob] = []
 
     seen: set[str] = set()
+    matching_existing: list[_StagedBlob] = []
     for blob in blobs:
         _validate_restore_key(blob.key)
         if blob.key in seen:
@@ -3819,10 +3821,35 @@ def _apply_staged_blobs(
         if not backend.exists(blob.key):
             continue
         intent = journal_state.intents.get(blob.key) if journal_state else None
-        if intent is None or not _journal_intent_matches(intent, blob):
+        if intent is None:
+            if not _stored_blob_matches(blob):
+                raise RestoreConflictError("restore_destination_exists")
+            matching_existing.append(blob)
+            continue
+        if not _journal_intent_matches(intent, blob):
             raise RestoreConflictError("restore_destination_exists")
         if not _stored_blob_matches(blob):
             raise RestoreConflictError("restore_destination_changed")
+
+    # Complete collision preflight before recording adoption intent. This
+    # keeps a later conflicting key from leaving partial restore evidence.
+    for blob in matching_existing:
+        if journal_path is None or journal_state is None:
+            raise RestoreConflictError("restore_destination_exists")
+        generation = journal_state.generations.get(blob.key, 0) + 1
+        adoption_intent: dict[str, object] = {
+            "event": "intent",
+            "key": blob.key,
+            "size": blob.size,
+            "sha256": blob.sha256,
+            "namespace": blob.namespace,
+            "generation": generation,
+        }
+        if journal_state.started.get("version") == _RESTORE_JOURNAL_VERSION:
+            adoption_intent.update(_journal_binding(journal_state.started))
+        _append_restore_journal(journal_path, adoption_intent)
+        journal_state.intents[blob.key] = adoption_intent
+        journal_state.generations[blob.key] = generation
 
     try:
         for blob in blobs:
@@ -3942,6 +3969,22 @@ class _RestoreJournalState:
     database_active: bool = False
     complete: bool = False
     cache_paths: set[str] = field(default_factory=set)
+
+
+def _journal_has_mutation_evidence(state: _RestoreJournalState) -> bool:
+    """Return whether a restore journal must remain for recovery.
+
+    A validated journal containing only ``started`` (and an optional cache pin)
+    cannot have authorized a storage write or database swap. It is therefore
+    safe to remove after deterministic preflight rejection.
+    """
+    return bool(
+        state.intents
+        or state.published
+        or state.database_swap_intent
+        or state.database_active
+        or state.complete
+    )
 
 
 def _restore_provider_ref(blobs: list[_StagedBlob] | None = None) -> str:
@@ -4526,8 +4569,9 @@ def restore_backup(backup_id: str, *, source_ref: str | None = None) -> dict:
     """Restore a backup with staged blobs and SQLite's online backup API.
 
     Downloads from S3 if the backup is only in cloud storage.
-    WARNING: This replaces the current database, but publishes archived files
-    only into empty destinations and refuses conflicting live storage keys.
+    WARNING: This replaces the current database. Archived files are created or
+    reused when byte-identical; conflicting live storage keys are never
+    overwritten.
 
     Sets a process-wide gate so background loops (GC, external scans, printer
     sync) skip their tick instead of racing the restore. Refuses with
@@ -4755,12 +4799,17 @@ def restore_backup(backup_id: str, *, source_ref: str | None = None) -> dict:
                     # permission to publish a replacement generation.
                     maintenance_required = True
                     raise RestoreConflictError("restore_destination_changed")
-                applied, created = _apply_staged_blobs(
-                    staged_blobs,
-                    rollback_dir,
-                    journal_path=journal_path,
-                    journal_state=journal_state,
-                )
+                try:
+                    applied, created = _apply_staged_blobs(
+                        staged_blobs,
+                        rollback_dir,
+                        journal_path=journal_path,
+                        journal_state=journal_state,
+                    )
+                except Exception:
+                    if not _journal_has_mutation_evidence(journal_state):
+                        _remove_restore_journal(journal_path)
+                    raise
                 db_swapped = False
                 try:
                     if any(not _stored_blob_matches(blob) for blob in staged_blobs):

--- a/backend/docker-entrypoint.sh
+++ b/backend/docker-entrypoint.sh
@@ -67,16 +67,22 @@ if [ "$(id -u)" = "0" ]; then
     /data/db
 
   # Numeric ownership works for host-created bind mounts even when the
-  # requested uid/gid has no matching /etc/passwd entry in the image. Re-own
-  # every startup: the data paths are runtime-writable, so a persistent marker
-  # there could be replaced by an unprivileged process (including a symlink)
-  # before the next root startup.
-  chown -hR "$requested_identity" \
+  # requested uid/gid has no matching /etc/passwd entry in the image. Inspect
+  # every startup because a persistent marker is unsafe, but chown only entries
+  # that actually differ: even a no-op chown changes ctime and would invalidate
+  # PrintStash's inode-bound ownership receipts. `find` does not follow symlinks
+  # and `chown -h` changes a mismatched symlink itself, never its target.
+  for managed_root in \
     "${VAULT_DATA_DIR:-/data/files}" \
     "${VAULT_THUMB_DIR:-/data/thumbs}" \
     "${VAULT_STAGING_DIR:-/data/staging}" \
     "${VAULT_BACKUP_DIR:-/data/backups}" \
     /data/db
+  do
+    find "$managed_root" -xdev \
+      \( ! -uid "$PUID" -o ! -gid "$PGID" \) \
+      -exec chown -h "$requested_identity" {} +
+  done
   # Re-exec the same entrypoint as the requested numeric identity. This keeps
   # migration and operator-supplied commands in the exact existing order while
   # allowing arbitrary positive host IDs without mutating the image's user DB.

--- a/backend/tests/integration/api/v1/test_auth.py
+++ b/backend/tests/integration/api/v1/test_auth.py
@@ -21,10 +21,10 @@ from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
-from app.db.models import ApiKey, User
-from app.services import oidc
+from app.db.models import ApiKey, RefreshToken, User
+from app.services import backup, oidc
 from app.services.auth import ACCESS_BLOCKLIST, create_api_key
 from tests.factories import build_user
 
@@ -76,6 +76,46 @@ class TestAuthProviders:
 
 
 class TestLogin:
+    def test_returns_an_access_only_session_during_restore_recovery(
+        self, client: TestClient, db_session: Session, account
+    ) -> None:
+        account("recovery-owner", is_superuser=True)
+        backup._restore_gate.set()
+        try:
+            response = client.post(
+                "/api/v1/auth/login",
+                json={"username": "recovery-owner", "password": PASSWORD},
+            )
+            me = client.get("/api/v1/auth/me")
+        finally:
+            backup._restore_gate.clear()
+
+        assert response.status_code == 200, response.text
+        assert response.json()["refresh_token"] is None
+        assert me.status_code == 200, me.text
+        assert db_session.exec(select(RefreshToken)).all() == []
+
+    def test_keeps_api_key_login_read_only_during_restore_recovery(
+        self, client: TestClient, db_session: Session, account
+    ) -> None:
+        user = account("recovery-script", is_superuser=True)
+        key, raw_key = create_api_key(db_session, user.id, "Recovery key")
+        backup._restore_gate.set()
+        try:
+            response = client.post(
+                "/api/v1/auth/login",
+                json={"username": "recovery-script", "api_key": raw_key},
+            )
+        finally:
+            backup._restore_gate.clear()
+
+        db_session.expire_all()
+        stored_key = db_session.get(ApiKey, key.id)
+        assert response.status_code == 200, response.text
+        assert response.json()["refresh_token"] is None
+        assert stored_key is not None
+        assert stored_key.last_used_at is None
+
     def test_returns_an_access_token(
         self, client: TestClient, account, sign_in
     ) -> None:

--- a/backend/tests/integration/services/backup/test_core.py
+++ b/backend/tests/integration/services/backup/test_core.py
@@ -3688,6 +3688,26 @@ class TestRestoreDatabase:
         assert Path(key).exists(), "restored blob is missing at its storage key"
         assert Path(key).read_bytes() == content
 
+    def test_restore_reuses_a_matching_destination(self, backup_env: BackupEnv):
+        content = b"solid matching widget\nendsolid\n"
+        _model_id, key = seed_model_with_blob(
+            backup_env, name="Matching Widget", content=content
+        )
+        meta = backup.create_backup()
+        with backup_env.new_session() as session:
+            model = session.exec(
+                select(Model).where(Model.name == "Matching Widget")
+            ).one()
+            model.name = "Post-backup name"
+            session.add(model)
+            session.commit()
+
+        result = backup.restore_backup(meta.id)
+
+        assert result == {"backup_id": meta.id, "restored_files": 1}
+        assert _read_model_names(backup_env) == ["Matching Widget"]
+        assert Path(key).read_bytes() == content
+
     def test_restore_writes_complete_row_on_success(self, backup_env: BackupEnv):
         from app.db.models import AuditLog
 
@@ -3752,6 +3772,39 @@ class TestRestoreDatabase:
         assert Path(first_key).read_bytes() == b"current-first"
         assert Path(second_key).read_bytes() == b"current-second"
         assert "Current First" in _read_model_names(backup_env)
+
+    def test_restore_collision_removes_its_preflight_journal(
+        self, backup_env: BackupEnv
+    ):
+        _, matching_key = seed_model_with_blob(
+            backup_env, name="Matching before collision", content=b"matching"
+        )
+        _, conflicting_key = seed_model_with_blob(
+            backup_env, name="Journal collision", content=b"backup"
+        )
+        meta = backup.create_backup()
+        Path(conflicting_key).write_bytes(b"current")
+        journal = backup_env.backup_dir / f".restore-{meta.id}.journal"
+
+        with pytest.raises(backup.RestoreConflictError, match="destination_exists"):
+            backup.restore_backup(meta.id)
+
+        assert Path(matching_key).read_bytes() == b"matching"
+        assert not journal.exists()
+
+    def test_restore_collision_releases_the_mutation_gate(self, backup_env: BackupEnv):
+        _, key = seed_model_with_blob(
+            backup_env, name="Gate collision", content=b"backup"
+        )
+        meta = backup.create_backup()
+        Path(key).write_bytes(b"current")
+
+        with pytest.raises(backup.RestoreConflictError, match="destination_exists"):
+            backup.restore_backup(meta.id)
+
+        assert backup.restore_in_progress() is False
+        assert backup.begin_mutating_operation() is True
+        backup.end_mutating_operation()
 
     def test_failed_blob_restore_removes_only_receipted_partial_creates(
         self, backup_env: BackupEnv, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/integration/services/backup/test_core.py
+++ b/backend/tests/integration/services/backup/test_core.py
@@ -3640,6 +3640,55 @@ class TestRestoreDatabase:
             )
             assert get_backend().creation_matches(receipt)
 
+    def test_restore_refreshes_archive_receipt_after_metadata_only_change(
+        self, backup_env: BackupEnv
+    ) -> None:
+        content = b"metadata-only-recovery"
+        _, key = seed_model_with_blob(
+            backup_env, name="Metadata recovery", content=content
+        )
+        meta = backup.create_backup()
+        archive = Path(meta.path)
+        before = archive.stat()
+
+        os.chown(archive, before.st_uid, before.st_gid)
+        after = archive.stat()
+        assert (after.st_dev, after.st_ino, after.st_size) == (
+            before.st_dev,
+            before.st_ino,
+            before.st_size,
+        )
+        assert after.st_ctime_ns != before.st_ctime_ns
+        Path(key).unlink()
+
+        result = backup.restore_backup(meta.id)
+
+        assert result == {"backup_id": meta.id, "restored_files": 1}
+        assert Path(key).read_bytes() == content
+
+    def test_restore_rejects_identical_archive_at_a_replaced_inode(
+        self, backup_env: BackupEnv
+    ) -> None:
+        _, key = seed_model_with_blob(
+            backup_env, name="Replaced archive", content=b"same archive bytes"
+        )
+        meta = backup.create_backup()
+        archive = Path(meta.path)
+        original_inode = archive.stat().st_ino
+        replacement = archive.with_suffix(".replacement")
+        replacement.write_bytes(archive.read_bytes())
+        os.replace(replacement, archive)
+        assert archive.stat().st_ino != original_inode
+        Path(key).unlink()
+
+        with pytest.raises(
+            backup.BackupOwnershipError,
+            match="backup_storage_ownership_unverified",
+        ):
+            backup.restore_backup(meta.id)
+
+        assert not Path(key).exists()
+
     def test_restore_replaces_live_wal_state_without_replay(
         self, backup_env: BackupEnv
     ):

--- a/backend/tests/repo/test_docker_entrypoint.py
+++ b/backend/tests/repo/test_docker_entrypoint.py
@@ -169,13 +169,35 @@ class TestDockerEntrypointIdentity:
         )
 
         assert result.returncode == 0, result.stderr
-        ownership_repair = next(
+        ownership_repairs = [
             line
             for line in log.read_text().splitlines()
-            if line.startswith("chown:-hR 1234:2345 ")
-        )
+            if line.startswith("chown:-h 1234:2345 ")
+        ]
         for root in ("files", "thumbs", "staging", "backups", "db"):
-            assert str(tmp_path / root) in ownership_repair
+            assert any(str(tmp_path / root) in line for line in ownership_repairs)
+
+    def test_preserves_metadata_for_entries_already_owned_by_runtime_identity(
+        self, tmp_path: Path
+    ) -> None:
+        script, log, fake_bin, server = _entrypoint_harness(tmp_path)
+        archive = tmp_path / "backups" / "owned-backup.tar.gz"
+        archive.parent.mkdir()
+        archive.write_bytes(b"owned")
+
+        result = _run_entrypoint(
+            script,
+            fake_bin,
+            server,
+            tmp_path=tmp_path,
+            puid=str(os.getuid()),
+            pgid=str(os.getgid()),
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert not any(
+            line.startswith("chown:") for line in log.read_text().splitlines()
+        )
 
     def test_passes_the_operator_command_through_unchanged(
         self, tmp_path: Path
@@ -223,10 +245,10 @@ class TestDockerEntrypointIdentity:
         ownership_repairs = [
             line
             for line in log.read_text().splitlines()
-            if line.startswith("chown:-hR ")
+            if line.startswith("chown:-h ")
         ]
-        assert sum("1111:2222" in line for line in ownership_repairs) == 1
-        assert sum("3333:4444" in line for line in ownership_repairs) == 1
+        assert any("1111:2222" in line for line in ownership_repairs)
+        assert any("3333:4444" in line for line in ownership_repairs)
 
     def test_managed_descendant_symlink_cannot_clobber_target(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

- 

## Testing

- [ ] `cd backend && ./scripts/test.sh full` green, or not needed
- [ ] `cd frontend && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` green, or not needed
- [ ] Manual test notes included, or not needed

## Coverage matrix

<!-- Required whenever tests were added or changed — a one-line assertion edit
counts. One row per observable behaviour, which is also one test function.
Derive the rows from requirements (the issue, CONTEXT.md, docs/provider-support.md,
the router contract), never from reading the implementation: matrixing what the
code happens to do reproduces its bugs as "expected".

Every row ends at ✅ `<tier dir>/<file>::<test>`, ❌ missing, or ⏭️ N/A — reason.
Zero unexplained ❌ is the definition of done.

Format: .agents/skills/printstash/references/testing.md -->

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|-----------|----------|----------------------|--------------------|------|--------|
|   |           |          |                      |                    |      |        |

### Tier check

<!-- The directory is the tier. Tick the ones this PR added to. -->

- [ ] `unit/` — pure logic, or a fault that cannot be reproduced for real
- [ ] `integration/` — **the default**: any router, any DB write, any RBAC or live/trashed rule
- [ ] `contract/` — our client against a real fake over a loopback socket, with **no mocking inside**
- [ ] `e2e/` — one test for the feature's headline capability
- [ ] `frontend/src/**/__tests__/` or `frontend/tests/e2e-real/`

### Self-check

- [ ] Every new test file opens with a contract header saying what it defends
- [ ] Every new test asserts **one** behaviour — no name contains "and"
- [ ] No `skip`/`xfail`/`.skip` without an issue URL, and no commented-out tests
- [ ] Every new endpoint has a 401 row and, if it is role-gated, a 403 row

### Fixtures and factories

<!-- `tests/factories/` is the only place that knows how library state is
encoded. A hand-built row that encodes it wrongly inserts cleanly and is then
invisible to the code under test — the test passes against nothing.
Rules: .agents/skills/printstash/references/tests/fixtures.md -->

- [ ] Rows come from the `make_*` fixtures — nothing assembled inline, no new
      module-local `_make_*` helper, no hard-coded value in a unique column
- [ ] Intent keywords used instead of their columns (`trashed=`, `provider=`,
      `recommended=`, `scanning=`, `uploaded=`)
- [ ] **Entity changed?** Its builder, protocol and `make_*` fixture updated in
      this PR, and any new promise has a row in `tests/repo/test_factories.py`
- [ ] Any new scenario has three callers and says why its shape is a unit

## Notes

Mention any schema, API, storage, or printer-provider behaviour changes.
