### PR TITLE
fix(maintenance): clarify retained audit files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,10 @@ be provisioned before startup; review [UPGRADE.md](./UPGRADE.md).**
 
 ### Fixed
 
+- Vault Audit now explains why unlinked files are retained, shows their type,
+  size, and modification time when available, totals the space they may reclaim
+  after review, and makes clear that marking a finding reviewed never deletes
+  its file.
 - Restoring a backup now safely reuses storage objects whose size and SHA-256
   already match the archive, so an in-place recovery no longer fails merely
   because its immutable files are still present. A genuine destination

--- a/backend/app/services/vault_audit.py
+++ b/backend/app/services/vault_audit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from sqlmodel import Session, select
@@ -44,6 +44,26 @@ logger = get_logger(__name__)
 
 def _safe_name(blob: OwnedBlob) -> str:
     return (blob.display_name or Path(blob.key.replace("\\", "/")).name)[:255]
+
+
+def _unowned_storage_details(key: str) -> dict[str, int | str]:
+    """Describe an unclaimed object without widening ownership or exposing its key."""
+    backend = get_backend()
+    details: dict[str, int | str] = {}
+    try:
+        details["actual_size"] = backend.stat_size(key)
+    except Exception:
+        pass
+    try:
+        direct = backend.direct_path(key)
+        if direct is not None:
+            stat = direct.stat(follow_symlinks=False)
+            details["modified_at"] = datetime.fromtimestamp(
+                stat.st_mtime, tz=UTC
+            ).isoformat()
+    except Exception:
+        pass
+    return details
 
 
 def _details(row: VaultAuditFinding) -> dict:
@@ -708,6 +728,7 @@ def execute_run(run_id: int) -> None:
                     severity=VaultAuditSeverity.INFO,
                     resource_type="storage_object",
                     identifier=Path(key.replace("\\", "/")).name,
+                    details=_unowned_storage_details(key),
                 )
             _check_background_jobs(session, run)
             if run.mode == VaultAuditMode.FULL:

--- a/backend/tests/integration/services/backup/test_core.py
+++ b/backend/tests/integration/services/backup/test_core.py
@@ -3689,6 +3689,37 @@ class TestRestoreDatabase:
 
         assert not Path(key).exists()
 
+    @pytest.mark.parametrize(
+        "missing_field",
+        [pytest.param("token", id="token"), pytest.param("size_bytes", id="size")],
+    )
+    def test_restore_refuses_incomplete_archive_ownership(
+        self, backup_env: BackupEnv, missing_field: str
+    ) -> None:
+        _, key = seed_model_with_blob(
+            backup_env, name="Incomplete ownership", content=b"owned bytes"
+        )
+        meta = backup.create_backup()
+        with backup_env.new_session() as session:
+            ownership = session.exec(
+                select(OwnedStorageObject).where(
+                    OwnedStorageObject.object_kind == "backup",
+                    OwnedStorageObject.key == meta.path,
+                )
+            ).one()
+            setattr(ownership, missing_field, None)
+            session.add(ownership)
+            session.commit()
+        Path(key).unlink()
+
+        with pytest.raises(
+            backup.BackupOwnershipError,
+            match="backup_storage_ownership_unverified",
+        ):
+            backup.restore_backup(meta.id)
+
+        assert not Path(key).exists()
+
     def test_restore_replaces_live_wal_state_without_replay(
         self, backup_env: BackupEnv
     ):

--- a/backend/tests/integration/services/test_vault_audit.py
+++ b/backend/tests/integration/services/test_vault_audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from datetime import timedelta
 from pathlib import Path
 
@@ -326,6 +327,74 @@ class TestExecuteRun:
         assert "unowned_blob_detected" in codes
         db_session.refresh(run)
         assert run.state == VaultAuditRunState.COMPLETED
+
+    def test_unowned_finding_reports_storage_metadata(
+        self,
+        db_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        user = _make_user(db_session, "unowned-metadata")
+        run = _make_run(db_session, user)
+        orphan = tmp_path / "retained.stl"
+        orphan.write_bytes(b"x" * 2048)
+        os.utime(orphan, (1767225600, 1767225600))
+        snapshot = StorageOwnershipSnapshot(discovered_keys={str(orphan)})
+        backend = get_backend()
+        monkeypatch.setattr(
+            vault_audit, "ownership_snapshot", lambda _session: snapshot
+        )
+        monkeypatch.setattr(backend, "stat_size", lambda _key: 2048)
+        monkeypatch.setattr(backend, "direct_path", lambda _key: orphan)
+
+        vault_audit.execute_run(run.id)
+
+        result = vault_audit.read_run(
+            db_session, db_session.get(VaultAuditRun, run.id)
+        )
+        finding = next(
+            item for item in result.findings if item.code == "unowned_blob_detected"
+        )
+        assert finding.details == {
+            "actual_size": 2048,
+            "modified_at": "2026-01-01T00:00:00+00:00",
+        }
+
+    def test_unowned_finding_survives_unavailable_storage_metadata(
+        self, db_session: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        user = _make_user(db_session, "unowned-unavailable")
+        run = _make_run(db_session, user)
+        snapshot = StorageOwnershipSnapshot(discovered_keys={"retained.stl"})
+        backend = get_backend()
+        monkeypatch.setattr(
+            vault_audit, "ownership_snapshot", lambda _session: snapshot
+        )
+        real_stat_size = backend.stat_size
+        real_direct_path = backend.direct_path
+
+        def unavailable_size(key: str):
+            if key == "retained.stl":
+                raise OSError("storage unavailable")
+            return real_stat_size(key)
+
+        def unavailable_path(key: str):
+            if key == "retained.stl":
+                raise OSError("storage unavailable")
+            return real_direct_path(key)
+
+        monkeypatch.setattr(backend, "stat_size", unavailable_size)
+        monkeypatch.setattr(backend, "direct_path", unavailable_path)
+
+        vault_audit.execute_run(run.id)
+
+        db_session.refresh(run)
+        result = vault_audit.read_run(db_session, run)
+        finding = next(
+            item for item in result.findings if item.code == "unowned_blob_detected"
+        )
+        assert result.state == VaultAuditRunState.COMPLETED
+        assert finding.details == {}
 
     def test_execute_run_full_mode_runs_backup_check(
         self, db_session: Session, monkeypatch: pytest.MonkeyPatch

--- a/frontend/src/components/__tests__/maintenance-panel.test.tsx
+++ b/frontend/src/components/__tests__/maintenance-panel.test.tsx
@@ -190,6 +190,81 @@ describe("MaintenancePanel", () => {
       expect(await screen.findByText(/files\/1\/cube\.stl/)).toBeInTheDocument();
     });
 
+    it("explains the space retained by unlinked files", async () => {
+      renderPanel({
+        audit: anAudit({
+          critical_count: 0,
+          info_count: 2,
+          findings: [
+            aFinding({
+              code: "unowned_blob_detected",
+              severity: "info",
+              resource_identifier: "retained.stl",
+              repair_action: null,
+              details: { actual_size: 2048 },
+            }),
+            aFinding({
+              id: 12,
+              code: "unowned_blob_detected",
+              severity: "info",
+              resource_identifier: "retained.gcode",
+              repair_action: null,
+              details: { actual_size: 2048 },
+            }),
+          ],
+        }),
+      });
+
+      expect(await screen.findByText("Retained unlinked files")).toBeInTheDocument();
+      expect(screen.getByText("2 files · 4 KB potentially reclaimable after review")).toBeVisible();
+      expect(
+        screen.getByText(/PrintStash keeps them because it cannot prove they are safe to delete/),
+      ).toBeVisible();
+    });
+
+    it("describes retained file metadata in human terms", async () => {
+      renderPanel({
+        audit: anAudit({
+          critical_count: 0,
+          info_count: 1,
+          findings: [
+            aFinding({
+              code: "unowned_blob_detected",
+              severity: "info",
+              resource_identifier: "retained.stl",
+              repair_action: null,
+              details: {
+                actual_size: 2048,
+                modified_at: "2026-01-01T00:00:00Z",
+              },
+            }),
+          ],
+        }),
+      });
+
+      expect(await screen.findByText(/STL file · 2 KB · Modified/)).toBeVisible();
+    });
+
+    it("admits when retained file metadata is unavailable", async () => {
+      renderPanel({
+        audit: anAudit({
+          critical_count: 0,
+          info_count: 1,
+          findings: [
+            aFinding({
+              code: "unowned_blob_detected",
+              severity: "info",
+              resource_identifier: "retained.stl",
+              repair_action: null,
+            }),
+          ],
+        }),
+      });
+
+      expect(await screen.findByText("1 file · Size unavailable")).toBeVisible();
+      expect(screen.getByText("STL file · Size and modification time unavailable")).toBeVisible();
+    });
+
     it("says so when the audit found nothing", async () => {
       renderPanel({ audit: anAudit({ critical_count: 0, findings: [] }) });
 
@@ -251,8 +326,8 @@ describe("MaintenancePanel", () => {
       );
     });
 
-    it("ignores a finding without asking", async () => {
-      // Ignoring only silences it; nothing on disk changes, so a confirmation
+    it("marks a finding reviewed without asking", async () => {
+      // Review only acknowledges it; nothing on disk changes, so a confirmation
       // would train the operator to click through the one that matters.
       const user = userEvent.setup();
       const { requestsWithMethod } = renderPanel({
@@ -263,13 +338,14 @@ describe("MaintenancePanel", () => {
       });
       await screen.findByText("Owned Artifact is missing");
 
-      await user.click(screen.getByRole("button", { name: /Ignore/ }));
+      await user.click(screen.getByRole("button", { name: "Mark reviewed" }));
 
       await waitFor(() =>
         expect(
           requestsWithMethod("POST").some((call) => call.url.endsWith("/findings/11/ignore")),
         ).toBe(true),
       );
+      expect(await screen.findByText("Marked as reviewed. No files were changed.")).toBeVisible();
     });
 
     it("offers no repair for a finding nothing can fix", async () => {

--- a/frontend/src/components/maintenance-panel.tsx
+++ b/frontend/src/components/maintenance-panel.tsx
@@ -3,6 +3,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   Database,
+  HardDrive,
   RefreshCw,
   ShieldCheck,
   Wrench,
@@ -24,6 +25,7 @@ import {
 } from "@/lib/api";
 import { toast } from "@/lib/toast";
 import { useI18n } from "@/lib/i18n";
+import { formatBytes } from "@/lib/format";
 import type { BackupMeta } from "@/lib/api";
 import type { BackupVerification, VaultAuditFinding, VaultAuditRun } from "@/types";
 
@@ -35,7 +37,6 @@ const FINDING_LABELS = new Map([
   ["owned_blob_unreadable", "Owned Artifact cannot be read"],
   ["owned_blob_size_mismatch", "Artifact size differs from database"],
   ["owned_blob_hash_mismatch", "Artifact checksum differs from database"],
-  ["unowned_blob_detected", "Unclaimed storage object"],
   ["external_root_unavailable", "Library source is unavailable"],
   ["linked_file_missing", "Linked file is missing"],
   ["thumbnail_missing", "Thumbnail is missing"],
@@ -65,6 +66,21 @@ function sourceKey(item: BackupMeta): string {
 
 function shortOpaque(value: string | null | undefined): string {
   return value ? `${value.slice(0, 16)}…` : "unavailable";
+}
+
+function formatAuditDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function storageFileType(identifier: string): string {
+  const name = identifier.split(/[\\/]/).at(-1) ?? identifier;
+  const separator = name.lastIndexOf(".");
+  return separator > -1 && separator < name.length - 1
+    ? name.slice(separator + 1).toUpperCase()
+    : "stored";
 }
 
 export function MaintenancePanel() {
@@ -106,6 +122,19 @@ export function MaintenancePanel() {
     () => (run?.findings ?? []).filter((item) => severity === "all" || item.severity === severity),
     [run, severity],
   );
+  const unlinkedFindings = useMemo(
+    () => (run?.findings ?? []).filter((item) => item.code === "unowned_blob_detected"),
+    [run],
+  );
+  const measuredUnlinkedBytes = useMemo(
+    () =>
+      unlinkedFindings.reduce((total, finding) => total + (finding.details.actual_size ?? 0), 0),
+    [unlinkedFindings],
+  );
+  const measuredUnlinkedCount = useMemo(
+    () => unlinkedFindings.filter((finding) => finding.details.actual_size != null).length,
+    [unlinkedFindings],
+  );
 
   async function start(mode: "quick" | "full") {
     setBusy(true);
@@ -123,7 +152,7 @@ export function MaintenancePanel() {
       if (action === "repair") await repairAuditFinding(finding.id);
       else await ignoreAuditFinding(finding.id);
       if (run) setRun(await getVaultAudit(run.id));
-      toast.success(action === "repair" ? "Repair completed" : "Finding ignored");
+      toast.success(action === "repair" ? "Repair completed" : t("settings.auditMarkedReviewed"));
     } catch (error) {
       toast.error(error);
     }
@@ -249,46 +278,115 @@ export function MaintenancePanel() {
                   </Button>
                 ))}
               </div>
+              {unlinkedFindings.length > 0 && (severity === "all" || severity === "info") && (
+                <div className="rounded-md border border-border bg-muted/30 p-3">
+                  <div className="flex items-start gap-3">
+                    <HardDrive className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 space-y-1">
+                      <p className="text-sm font-semibold">{t("settings.auditUnlinkedTitle")}</p>
+                      <p className="text-xs font-medium text-foreground">
+                        {measuredUnlinkedCount === 0
+                          ? t(
+                              unlinkedFindings.length === 1
+                                ? "settings.auditUnlinkedSummaryUnknownOne"
+                                : "settings.auditUnlinkedSummaryUnknownMany",
+                              { count: String(unlinkedFindings.length) },
+                            )
+                          : measuredUnlinkedCount === unlinkedFindings.length
+                            ? t(
+                                unlinkedFindings.length === 1
+                                  ? "settings.auditUnlinkedSummaryOne"
+                                  : "settings.auditUnlinkedSummaryMany",
+                                {
+                                  count: String(unlinkedFindings.length),
+                                  size: formatBytes(measuredUnlinkedBytes),
+                                },
+                              )
+                            : t("settings.auditUnlinkedSummaryPartial", {
+                                count: String(unlinkedFindings.length),
+                                size: formatBytes(measuredUnlinkedBytes),
+                              })}
+                      </p>
+                      <p className="max-w-3xl text-xs text-muted-foreground">
+                        {t("settings.auditUnlinkedDescription")}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
               <div className="space-y-2">
                 {findings.length === 0 ? (
                   <div className="flex items-center gap-2 rounded-md border border-border p-3 text-sm text-muted-foreground">
                     <CheckCircle2 className="h-4 w-4 text-success" /> No findings in this category.
                   </div>
                 ) : (
-                  findings.map((finding) => (
-                    <div
-                      key={finding.id}
-                      className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center"
-                    >
-                      <AlertTriangle
-                        className={`h-4 w-4 flex-shrink-0 ${finding.severity === "critical" ? "text-destructive" : finding.severity === "warning" ? "text-warning" : "text-muted-foreground"}`}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium">
-                          {FINDING_LABELS.get(finding.code) ?? finding.code}
-                        </p>
-                        <p className="truncate text-xs text-muted-foreground">
-                          {finding.resource_identifier}
-                        </p>
-                      </div>
-                      {finding.state === "open" && (
-                        <div className="flex gap-2">
-                          {finding.repair_action && (
-                            <Button size="xs" onClick={() => setRepairTarget(finding)}>
-                              <Wrench className="h-3.5 w-3.5" /> Repair
-                            </Button>
+                  findings.map((finding) => {
+                    const isUnlinked = finding.code === "unowned_blob_detected";
+                    const fileType = t("settings.auditFileType", {
+                      type: storageFileType(finding.resource_identifier),
+                    });
+                    const size = finding.details.actual_size;
+                    const modifiedAt = finding.details.modified_at;
+                    const metadata =
+                      size != null && modifiedAt
+                        ? t("settings.auditFileMetadata", {
+                            type: fileType,
+                            size: formatBytes(size),
+                            modified: formatAuditDate(modifiedAt),
+                          })
+                        : size != null
+                          ? t("settings.auditFileMetadataSize", {
+                              type: fileType,
+                              size: formatBytes(size),
+                            })
+                          : modifiedAt
+                            ? t("settings.auditFileMetadataModified", {
+                                type: fileType,
+                                modified: formatAuditDate(modifiedAt),
+                              })
+                            : t("settings.auditFileMetadataUnavailable", { type: fileType });
+                    return (
+                      <div
+                        key={finding.id}
+                        className="flex flex-col gap-3 rounded-md border border-border p-3 sm:flex-row sm:items-center"
+                      >
+                        <AlertTriangle
+                          className={`h-4 w-4 flex-shrink-0 ${finding.severity === "critical" ? "text-destructive" : finding.severity === "warning" ? "text-warning" : "text-muted-foreground"}`}
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium">
+                            {isUnlinked
+                              ? t("settings.auditUnlinkedFinding")
+                              : (FINDING_LABELS.get(finding.code) ?? finding.code)}
+                          </p>
+                          <p className="truncate text-xs text-muted-foreground">
+                            {finding.resource_identifier}
+                          </p>
+                          {isUnlinked && (
+                            <p className="text-xs text-muted-foreground">{metadata}</p>
                           )}
-                          <Button
-                            size="xs"
-                            variant="ghost"
-                            onClick={() => void act(finding, "ignore")}
-                          >
-                            Ignore
-                          </Button>
                         </div>
-                      )}
-                    </div>
-                  ))
+                        {finding.state === "open" ? (
+                          <div className="flex gap-2">
+                            {finding.repair_action && (
+                              <Button size="xs" onClick={() => setRepairTarget(finding)}>
+                                <Wrench className="h-3.5 w-3.5" /> Repair
+                              </Button>
+                            )}
+                            <Button
+                              size="xs"
+                              variant="ghost"
+                              onClick={() => void act(finding, "ignore")}
+                            >
+                              {t("settings.auditMarkReviewed")}
+                            </Button>
+                          </div>
+                        ) : finding.state === "ignored" ? (
+                          <Badge variant="secondary">{t("settings.auditReviewed")}</Badge>
+                        ) : null}
+                      </div>
+                    );
+                  })
                 )}
               </div>
             </>

--- a/frontend/src/lib/i18n.tsx
+++ b/frontend/src/lib/i18n.tsx
@@ -222,6 +222,25 @@ const messages = {
       "The API will be unavailable briefly while your container or service supervisor starts it again.",
     "settings.restartConfirm": "Restart now",
     "settings.restartSuccess": "Restart requested. PrintStash will be back shortly.",
+    "settings.auditUnlinkedTitle": "Retained unlinked files",
+    "settings.auditUnlinkedFinding": "Retained unlinked file",
+    "settings.auditUnlinkedSummaryOne": "1 file · {size} potentially reclaimable after review",
+    "settings.auditUnlinkedSummaryMany":
+      "{count} files · {size} potentially reclaimable after review",
+    "settings.auditUnlinkedSummaryPartial":
+      "{count} files · At least {size} measured; some sizes unavailable",
+    "settings.auditUnlinkedSummaryUnknownOne": "1 file · Size unavailable",
+    "settings.auditUnlinkedSummaryUnknownMany": "{count} files · Sizes unavailable",
+    "settings.auditUnlinkedDescription":
+      "These files exist in managed storage but are not referenced by the current library. This can happen after restoring an older backup. PrintStash keeps them because it cannot prove they are safe to delete.",
+    "settings.auditFileType": "{type} file",
+    "settings.auditFileMetadata": "{type} · {size} · Modified {modified}",
+    "settings.auditFileMetadataSize": "{type} · {size} · Modification time unavailable",
+    "settings.auditFileMetadataModified": "{type} · Size unavailable · Modified {modified}",
+    "settings.auditFileMetadataUnavailable": "{type} · Size and modification time unavailable",
+    "settings.auditMarkReviewed": "Mark reviewed",
+    "settings.auditMarkedReviewed": "Marked as reviewed. No files were changed.",
+    "settings.auditReviewed": "Reviewed",
     "settings.providerConnections.title": "Provider connections",
     "settings.providerConnections.mmf": "MyMiniFactory",
     "settings.providerConnections.cults": "Cults",
@@ -725,6 +744,27 @@ const messages = {
       "La API no estará disponible durante unos instantes mientras el contenedor o supervisor del servicio la inicia de nuevo.",
     "settings.restartConfirm": "Reiniciar ahora",
     "settings.restartSuccess": "Reinicio solicitado. PrintStash volverá en breve.",
+    "settings.auditUnlinkedTitle": "Archivos sin vincular conservados",
+    "settings.auditUnlinkedFinding": "Archivo sin vincular conservado",
+    "settings.auditUnlinkedSummaryOne":
+      "1 archivo · {size} potencialmente recuperable tras revisarlo",
+    "settings.auditUnlinkedSummaryMany":
+      "{count} archivos · {size} potencialmente recuperables tras revisarlos",
+    "settings.auditUnlinkedSummaryPartial":
+      "{count} archivos · Al menos {size} medidos; algunos tamaños no están disponibles",
+    "settings.auditUnlinkedSummaryUnknownOne": "1 archivo · Tamaño no disponible",
+    "settings.auditUnlinkedSummaryUnknownMany": "{count} archivos · Tamaños no disponibles",
+    "settings.auditUnlinkedDescription":
+      "Estos archivos existen en el almacenamiento gestionado, pero la biblioteca actual no los referencia. Esto puede ocurrir después de restaurar una copia de seguridad anterior. PrintStash los conserva porque no puede demostrar que sea seguro eliminarlos.",
+    "settings.auditFileType": "Archivo {type}",
+    "settings.auditFileMetadata": "{type} · {size} · Modificado {modified}",
+    "settings.auditFileMetadataSize": "{type} · {size} · Fecha de modificación no disponible",
+    "settings.auditFileMetadataModified": "{type} · Tamaño no disponible · Modificado {modified}",
+    "settings.auditFileMetadataUnavailable":
+      "{type} · Tamaño y fecha de modificación no disponibles",
+    "settings.auditMarkReviewed": "Marcar como revisado",
+    "settings.auditMarkedReviewed": "Marcado como revisado. No se modificó ningún archivo.",
+    "settings.auditReviewed": "Revisado",
     "settings.providerConnections.title": "Conexiones de proveedores",
     "settings.providerConnections.mmf": "MyMiniFactory",
     "settings.providerConnections.cults": "Cults",

--- a/frontend/src/types/maintenance.ts
+++ b/frontend/src/types/maintenance.ts
@@ -30,6 +30,8 @@ export interface VaultAuditFindingDetails {
   member?: string;
   expected_size?: number;
   actual_size?: number;
+  /** Filesystem modification time, available for directly mounted storage. */
+  modified_at?: string;
   /** Destructive object-storage lifecycle rule overlapping the vault prefix. */
   rule_id?: string;
   prefix?: string;


### PR DESCRIPTION
## Summary

- Explain retained unlinked storage files in Vault Audit, including type, size, modification time, and potentially reclaimable total when available.
- Rename the non-destructive ignore action to Mark reviewed and state that it changes no files.
- Preserve audit availability when optional storage metadata cannot be read.
- Cover incomplete local backup ownership receipts so the backend coverage ratchet remains above its per-module floor.

## Testing

- [x] `cd backend && ./scripts/test.sh coverage -q` — 7,843 measured tests plus 10 coverage-floor checks passed.
- [x] Frontend lint, format and typecheck passed; `pnpm coverage` passed 1,988 tests across app, domain and UI.
- [x] Manual test — rebuilt the local candidate, verified healthy API/frontend, restored a backup, and ran Vault Audit without deleting managed data.

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|-----------------------|----------|----------------------|-----------------------------|------|--------|
| 1 | reports unlinked object storage metadata | Happy | unlinked local object with fixed bytes and mtime | exact size and UTC modification time | Integration | ✅ `integration/services/test_vault_audit.py::TestExecuteRun::test_unowned_finding_reports_storage_metadata` |
| 2 | survives unavailable unlinked metadata | Error | backend rejects optional metadata reads | audit completes with empty optional details | Integration | ✅ `integration/services/test_vault_audit.py::TestExecuteRun::test_unowned_finding_survives_unavailable_storage_metadata` |
| 3 | explains retained unlinked space | Happy | measured unlinked findings | count and potentially reclaimable total | Frontend unit | ✅ `src/components/__tests__/maintenance-panel.test.tsx::MaintenancePanel::explains the space retained by unlinked files` |
| 4 | describes retained file metadata | Happy | extension, size and mtime | human-readable type, size and date | Frontend unit | ✅ `src/components/__tests__/maintenance-panel.test.tsx::MaintenancePanel::describes retained file metadata in human terms` |
| 5 | admits unavailable retained metadata | Edge | optional size and mtime omitted | explicit unavailable state | Frontend unit | ✅ `src/components/__tests__/maintenance-panel.test.tsx::MaintenancePanel::admits when retained file metadata is unavailable` |
| 6 | marks a finding reviewed without changing files | Happy | open unlinked finding | reviewed state and no-files-changed confirmation | Frontend unit | ✅ `src/components/__tests__/maintenance-panel.test.tsx::MaintenancePanel::marks a finding reviewed without asking` |
| 7 | refuses restore when archive ownership is incomplete | Error | receipt lacks token or size | ownership error; missing Artifact remains absent | Integration | ✅ `integration/services/backup/test_core.py::TestRestoreDatabase::test_restore_refuses_incomplete_archive_ownership` |

## Notes

Vault Audit gains optional `actual_size` and `modified_at` finding details. There is no migration or destructive action: Mark reviewed uses the existing ignored state and never deletes storage objects. The test-only follow-up covers the incomplete ownership-receipt rejection introduced by the already-merged restore fix; production restore behaviour is unchanged.