### PR TITLE
fix(ci): isolate release image digests

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.image }}-${{ matrix.arch }}
+          name: digests-${{ matrix.image }}--${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -131,7 +131,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digests-${{ matrix.image }}-*
+          pattern: digests-${{ matrix.image }}--*
           path: ${{ runner.temp }}/digests
           merge-multiple: true
 

--- a/backend/tests/repo/test_ci_workflows.py
+++ b/backend/tests/repo/test_ci_workflows.py
@@ -134,6 +134,27 @@ class TestMultiArchWorkflows:
         assert "docker buildx imagetools create" in merge_step["run"]
         assert "docker buildx imagetools inspect" in merge_step["run"]
 
+    def test_publish_digest_artifacts_use_an_exact_image_delimiter(self) -> None:
+        workflow = _workflow("container-publish.yml")
+        build_steps = workflow["jobs"]["build"]["steps"]
+        merge_steps = workflow["jobs"]["merge"]["steps"]
+
+        upload_step = next(
+            step
+            for step in build_steps
+            if str(step.get("uses", "")).startswith("actions/upload-artifact@")
+        )
+        download_step = next(
+            step
+            for step in merge_steps
+            if str(step.get("uses", "")).startswith("actions/download-artifact@")
+        )
+
+        assert upload_step["with"]["name"] == (
+            "digests-${{ matrix.image }}--${{ matrix.arch }}"
+        )
+        assert download_step["with"]["pattern"] == "digests-${{ matrix.image }}--*"
+
     def test_publish_entrypoints_share_the_native_multiarch_workflow(self) -> None:
         expected = "./.github/workflows/container-publish.yml"
         release = _workflow("ghcr.yml")


### PR DESCRIPTION
## Summary

- separate per-image digest artifact names with an exact `--` delimiter
- prevent the `printstash-api` manifest job from consuming `printstash-api-lite` digests
- add a repository invariant covering the artifact naming contract

## Why

The v0.13.0 release exposed that `digests-printstash-api-*` also matches `digests-printstash-api-lite-*`. The API manifest therefore received four digests and failed when it looked up a Lite digest in the API package.

## Testing

- Red: `uv run pytest tests/repo/test_ci_workflows.py::TestMultiArchWorkflows::test_publish_digest_artifacts_use_an_exact_image_delimiter -q` — 1 failed
- Green: `uv run pytest tests/repo/test_ci_workflows.py -q` — 6 passed
- `git diff --check`

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | `test_publish_digest_artifacts_use_an_exact_image_delimiter` | Error | `printstash-api` and `printstash-api-lite` share a name prefix | upload names and download patterns use an exact `--` image delimiter | Repo invariant | ✅ `tests/repo/test_ci_workflows.py::TestMultiArchWorkflows::test_publish_digest_artifacts_use_an_exact_image_delimiter` |