### PR TITLE
fix(storage): include S3 in the shipped OpenDAL image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,8 +625,10 @@ jobs:
             arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
-            load: false
+            load: true
             step-smoke: false
+            storage-smoke: true
+            variant: full
           - image: printstash-api
             context: ./backend
             dockerfile: ./backend/Dockerfile
@@ -636,6 +638,8 @@ jobs:
             runner: ubuntu-24.04-arm
             load: true
             step-smoke: true
+            storage-smoke: true
+            variant: full
           - image: printstash-api-lite
             context: ./backend
             dockerfile: ./backend/Dockerfile
@@ -643,8 +647,10 @@ jobs:
             arch: amd64
             platform: linux/amd64
             runner: ubuntu-latest
-            load: false
+            load: true
             step-smoke: false
+            storage-smoke: true
+            variant: lite
           - image: printstash-api-lite
             context: ./backend
             dockerfile: ./backend/Dockerfile
@@ -652,8 +658,10 @@ jobs:
             arch: arm64
             platform: linux/arm64
             runner: ubuntu-24.04-arm
-            load: false
+            load: true
             step-smoke: false
+            storage-smoke: true
+            variant: lite
           - image: printstash-frontend
             context: ./frontend
             dockerfile: ./frontend/Dockerfile
@@ -702,3 +710,17 @@ jobs:
           printstash-api:arm64-ci
           /app/.venv/bin/python -c
           "from pathlib import Path; from app.services.mesh_processing import _load_mesh; mesh = _load_mesh(Path('/fixtures/cascadio_material.stp')); assert mesh is not None and len(mesh.faces) > 0"
+
+      - name: Install uv for image contracts
+        if: matrix.storage-smoke
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install image contract runner
+        if: matrix.storage-smoke
+        working-directory: backend
+        run: uv sync --extra dev --frozen
+
+      - name: Check final-image storage lifecycle
+        if: matrix.storage-smoke
+        working-directory: backend
+        run: ./scripts/test.sh image --image ${{ matrix.image }}:${{ matrix.arch }}-ci --variant ${{ matrix.variant }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixed
+
+- The full container image includes the S3 transport used by remote Library
+  sources and backup connections. Image checks now exercise remote-only S3
+  recovery on both supported architectures.
+
 ## 0.13.0
 
 **Back up before upgrading. This release includes additive database migrations

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -26,7 +26,7 @@ RUN curl -fsSL \
  && /tmp/maturin/bin/pip install --no-cache-dir 'maturin==1.9.6' \
  && cd /src/bindings/python \
  && /tmp/maturin/bin/maturin build --release --no-default-features \
-      --features pyo3/extension-module,abi3,services-memory,services-webdav,services-sftp,services-gdrive \
+      --features pyo3/extension-module,abi3,services-memory,services-s3,services-webdav,services-sftp,services-gdrive \
       --out /wheels
 
 FROM scratch AS opendal-wheel
@@ -65,7 +65,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && uv sync --frozen --no-dev --no-editable --extra full \
  && uv pip install --reinstall /tmp/opendal-wheels/opendal-0.47.6-*.whl \
- && .venv/bin/python -c 'import opendal; opendal.Operator("gdrive", root="/", client_id="build-check", client_secret="build-check", refresh_token="build-check")' \
+ && .venv/bin/python -c 'import opendal; opendal.Operator("s3", bucket="build-check", region="us-east-1", access_key_id="build-check", secret_access_key="build-check", disable_config_load="true", disable_ec2_metadata="true"); opendal.Operator("webdav", endpoint="https://example.invalid", root="/"); opendal.Operator("gdrive", root="/", client_id="build-check", client_secret="build-check", refresh_token="build-check"); import asyncssh' \
  && rm -rf /tmp/opendal-wheels \
  && uv cache clean \
  && rm -rf "$UV_CACHE_DIR"

--- a/backend/scripts/test.sh
+++ b/backend/scripts/test.sh
@@ -17,6 +17,8 @@ Lanes
              over a real loopback socket. Needs no external services; the
              container-backed provider contracts run in `full`.
   e2e        tests/e2e — the whole app over ASGITransport plus the fakes.
+  image      final-image transport and HTTP backup/restore contracts.
+             --image TAG --variant full|lite; requires an already built image.
   critical   release-blocking workflows across integration, contract and E2E.
              Includes real remote providers and therefore needs Docker.
   full       everything, including `slow`, minus the coverage gate.
@@ -94,6 +96,9 @@ add_paths() {
 }
 
 case "$lane" in
+  image)
+    exec uv run python -m tests.e2e.runtime_image "${pytest_args[@]}"
+    ;;
   fast)
     add_paths tests/unit tests/integration
     exec uv run pytest "${parallel[@]}" -m "not slow and not coverage_gate and $non_resource_expression" ${lane_paths[@]+"${lane_paths[@]}"} ${pytest_args[@]+"${pytest_args[@]}"}

--- a/backend/tests/e2e/runtime_image.py
+++ b/backend/tests/e2e/runtime_image.py
@@ -1,0 +1,274 @@
+"""Storage contracts against an already built, unmodified runtime image.
+
+Run through ``scripts/test.sh image --image TAG --variant full|lite``. This is
+the image-build lane: unlike ASGI tests, every application dependency comes
+from the final image. The host only supplies HTTP and container test clients.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+import unittest
+from urllib.parse import urlsplit
+from uuid import uuid4
+
+import boto3
+import httpx
+from botocore.config import Config
+from testcontainers.core.container import DockerContainer
+from testcontainers.core.wait_strategies import HttpWaitStrategy
+
+from tests.containers import (
+    S3_ACCESS_KEY,
+    S3_SECRET_KEY,
+    s3_endpoint,
+    shutdown_containers,
+)
+from tests.paths import FIXTURES_DIR
+
+IMAGE = ""
+VARIANT = ""
+SETUP_TOKEN = "image-contract-only-setup-token"
+
+TRANSPORT_PROBE = r"""
+import json
+from app.services.storage_opendal import OpenDALStorageBackend
+from app.services.storage_backend import StorageConfigurationError
+from app.services.storage_providers import TransportKind, TransportSpec, provider_catalogue
+
+options = {
+    "root": "image-contract", "bucket": "image-contract", "region": "us-east-1",
+    "access_key": "contract-only", "secret_key": "contract-only",
+    "endpoint_url": "https://example.invalid", "username": "contract-only",
+    "password": "contract-only", "host": "example.invalid", "port": 22,
+    "host_key": "contract-only", "client_id": "contract-only",
+    "client_secret": "contract-only", "refresh_token": "contract-only",
+}
+results = {}
+for kind in TransportKind:
+    if kind is TransportKind.LOCAL:
+        continue
+    try:
+        backend = OpenDALStorageBackend(TransportSpec(
+            kind=kind, provider=kind.value, namespace="image-contract", options=options,
+        ))
+    except StorageConfigurationError as exc:
+        results[kind.value] = {"available": False, "reason": str(exc)}
+    else:
+        results[kind.value] = {"available": True, "namespace": backend.source_namespace}
+print(json.dumps({
+    "transports": results,
+    "providers": {p.id: p.available for p in provider_catalogue()},
+}))
+"""
+
+
+def _probe() -> dict:
+    result = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-i",
+            "--entrypoint",
+            "/app/.venv/bin/python",
+            IMAGE,
+            "-",
+        ],
+        input=TRANSPORT_PROBE,
+        capture_output=True,
+        text=True,
+        timeout=90,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+class TestFullImageTransports(unittest.TestCase):
+    def test_constructs_advertised_image_transports(self) -> None:
+        result = _probe()
+
+        self.assertEqual(
+            result["transports"],
+            {
+                kind: {"available": True, "namespace": "image-contract"}
+                for kind in ("s3", "webdav", "sftp", "gdrive")
+            },
+        )
+
+
+class TestLiteImageTransports(unittest.TestCase):
+    def test_reports_unavailable_image_capabilities(self) -> None:
+        result = _probe()
+
+        self.assertEqual(
+            result["transports"],
+            {
+                kind: {"available": False, "reason": "Requires the full image"}
+                for kind in ("s3", "webdav", "sftp", "gdrive")
+            },
+        )
+        self.assertTrue(result["providers"]["local"])
+        self.assertTrue(result["providers"]["s3"])
+        self.assertFalse(result["providers"]["webdav"])
+        self.assertFalse(result["providers"]["sftp"])
+        self.assertFalse(result["providers"]["gdrive"])
+
+
+class TestRuntimeImageBackup(unittest.TestCase):
+    def test_restores_s3_backup_from_shipped_image(self) -> None:
+        endpoint = s3_endpoint()
+        bucket = f"image-recovery-{uuid4().hex[:12]}"
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            region_name="us-east-1",
+            aws_access_key_id=S3_ACCESS_KEY,
+            aws_secret_access_key=S3_SECRET_KEY,
+            config=Config(s3={"addressing_style": "path"}),
+        )
+        s3.create_bucket(Bucket=bucket)
+        # Linux native runners expose the suite-owned service through Docker's
+        # host gateway; no provider image/version is defined a second time here.
+        remote_endpoint = f"http://host.docker.internal:{urlsplit(endpoint).port}"
+        container = (
+            DockerContainer(IMAGE)
+            .with_kwargs(extra_hosts={"host.docker.internal": "host-gateway"})
+            .with_env("VAULT_SETUP_TOKEN", SETUP_TOKEN)
+            .with_exposed_ports(8000)
+            .waiting_for(
+                HttpWaitStrategy(8000, "/api/v1/setup").with_startup_timeout(120)
+            )
+        )
+        try:
+            with container:
+                base = f"http://{container.get_container_host_ip()}:{container.get_exposed_port(8000)}"
+                try:
+                    with httpx.Client(base_url=base, timeout=180) as api:
+                        self._recover(api, container, bucket, remote_endpoint)
+                except Exception:
+                    stdout, stderr = container.get_logs()
+                    print(stdout.decode(errors="replace"))
+                    print(stderr.decode(errors="replace"))
+                    raise
+        finally:
+            s3.close()
+
+    def _recover(
+        self,
+        api: httpx.Client,
+        container: DockerContainer,
+        bucket: str,
+        endpoint: str,
+    ) -> None:
+        setup = api.post(
+            "/api/v1/setup",
+            json={
+                "setup_token": SETUP_TOKEN,
+                "username": "image-owner",
+                "password": "ImageContractPassword123",
+                "storage_backend": "local",
+                "data_dir": "/data/files",
+                "thumb_dir": "/data/thumbs",
+            },
+        )
+        self.assertEqual(setup.status_code, 201, setup.text)
+        api.headers["Authorization"] = f"Bearer {setup.json()['access_token']}"
+        configured = api.put(
+            "/api/v1/config", json={"manual_local_backup_enabled": False}
+        )
+        self.assertEqual(configured.status_code, 200, configured.text)
+        connection = api.post(
+            "/api/v1/storage-connections",
+            json={
+                "name": "Image S3 recovery",
+                "kind": "s3",
+                "purpose": "backup",
+                "configuration": {
+                    "provider": "s3_self_hosted",
+                    "bucket": bucket,
+                    "endpoint_url": endpoint,
+                    "region": "us-east-1",
+                    "root": "off-site",
+                    "addressing_style": "path",
+                },
+                "secrets": {"access_key": S3_ACCESS_KEY, "secret_key": S3_SECRET_KEY},
+            },
+        )
+        self.assertEqual(connection.status_code, 201, connection.text)
+        payload = (FIXTURES_DIR / "sample.gcode").read_bytes()
+        uploaded = api.post(
+            "/api/v1/ingest/orca",
+            files={"file": ("sample.gcode", payload, "text/plain")},
+            data={"model_name": "Image recovery"},
+        )
+        self.assertEqual(uploaded.status_code, 202, uploaded.text)
+        deadline = time.monotonic() + 120
+        job = {}
+        while time.monotonic() < deadline:
+            job = api.get(f"/api/v1/ingest/jobs/{uploaded.json()['job_id']}").json()
+            if job["state"] in {"completed", "failed", "duplicate"}:
+                break
+            time.sleep(0.1)
+        self.assertEqual(job.get("state"), "completed", job)
+        models = api.get("/api/v1/models").json()
+        model = next(row for row in models if row["name"] == "Image recovery")
+        detail = api.get(f"/api/v1/models/{model['id']}").json()
+        file_id = detail["files"][0]["id"]
+        created = api.post("/api/v1/backups")
+        self.assertEqual(created.status_code, 202, created.text)
+        meta = created.json()
+        self.assertEqual(meta["location"], "opendal:s3")
+        listed = api.get("/api/v1/backups/sources").json()
+        self.assertIn(meta["source_ref"], [row["source_ref"] for row in listed])
+        removed = api.delete(f"/api/v1/models/{model['id']}")
+        self.assertEqual(removed.status_code, 204, removed.text)
+        purged = api.delete(f"/api/v1/models/{model['id']}/purge")
+        self.assertEqual(purged.status_code, 200, purged.text)
+        self.assertEqual(api.get(f"/api/v1/files/{file_id}/download").status_code, 404)
+        restored = api.post(
+            f"/api/v1/backups/{meta['backup_id']}/restore",
+            params={"source_ref": meta["source_ref"]},
+        )
+        self.assertEqual(restored.status_code, 200, restored.text)
+        downloaded = api.get(f"/api/v1/files/{file_id}/download")
+        self.assertEqual(downloaded.status_code, 200, downloaded.text)
+        self.assertEqual(downloaded.content, payload)
+        no_local_archive = container.exec(
+            [
+                "/app/.venv/bin/python",
+                "-c",
+                "from pathlib import Path; assert not list(Path('/data/backups').glob('*.tar.gz'))",
+            ]
+        )
+        self.assertEqual(no_local_archive.exit_code, 0, no_local_archive.output)
+
+
+def main() -> int:
+    global IMAGE, VARIANT
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--variant", required=True, choices=("full", "lite"))
+    arguments = parser.parse_args()
+    IMAGE, VARIANT = arguments.image, arguments.variant
+    classes = (
+        (TestFullImageTransports, TestRuntimeImageBackup)
+        if VARIANT == "full"
+        else (TestLiteImageTransports,)
+    )
+    suite = unittest.TestSuite(
+        unittest.defaultTestLoader.loadTestsFromTestCase(case) for case in classes
+    )
+    try:
+        return (
+            0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+        )
+    finally:
+        shutdown_containers()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/e2e/runtime_image.py
+++ b/backend/tests/e2e/runtime_image.py
@@ -140,7 +140,7 @@ class TestRuntimeImageBackup(unittest.TestCase):
             .with_env("VAULT_SETUP_TOKEN", SETUP_TOKEN)
             .with_exposed_ports(8000)
             .waiting_for(
-                HttpWaitStrategy(8000, "/api/v1/setup").with_startup_timeout(120)
+                HttpWaitStrategy(8000, "/api/v1/setup/status").with_startup_timeout(120)
             )
         )
         try:

--- a/backend/tests/repo/test_storage_image.py
+++ b/backend/tests/repo/test_storage_image.py
@@ -1,0 +1,49 @@
+"""The release wheel and native image jobs cover every advertised transport.
+
+Development wheels cannot prove which services a custom release wheel compiled.
+These build contracts keep the final-image lifecycle check on both architectures.
+"""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from tests.paths import BACKEND_DIR, REPO_ROOT
+
+
+class TestStorageImage:
+    def test_builds_the_required_s3_service(self) -> None:
+        dockerfile = (BACKEND_DIR / "Dockerfile").read_text()
+
+        feature_line = re.search(r"--features\s+([^\s]+)", dockerfile)
+
+        assert feature_line is not None
+        assert "services-s3" in feature_line.group(1).split(",")
+
+    def test_checks_each_backend_image_on_its_native_architecture(self) -> None:
+        workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci.yml").read_text())
+        job = next(
+            value
+            for value in workflow["jobs"].values()
+            if "matrix" in value.get("strategy", {})
+            and any(
+                row.get("image") == "printstash-api"
+                for row in value["strategy"]["matrix"].get("include", [])
+            )
+        )
+        images = [
+            row
+            for row in job["strategy"]["matrix"]["include"]
+            if row["image"].startswith("printstash-api")
+        ]
+
+        assert {(row["image"], row["arch"]) for row in images} == {
+            ("printstash-api", "amd64"),
+            ("printstash-api", "arm64"),
+            ("printstash-api-lite", "amd64"),
+            ("printstash-api-lite", "arm64"),
+        }
+        assert all(row["load"] and row["storage-smoke"] for row in images)
+        assert any("test.sh image" in step.get("run", "") for step in job["steps"])


### PR DESCRIPTION
## Summary

The full image's custom OpenDAL wheel omitted S3, so remote S3 Library sources and backup profiles could fail despite passing against the development wheel. Include the S3 service and add a final-image storage lane that checks transport construction, lite-image availability, and remote-only S3 recovery through the running HTTP API on amd64 and arm64.

## Testing

- [x] `cd backend && ./scripts/test.sh full -q` — 7,768 non-resource + 82 resource tests passed locally; backend coverage, Ruff and Pyright gates passed in CI.
- [x] Frontend checks not needed
- [x] Final-image checks — full amd64: 2 passed (transport construction and HTTP S3 recovery); lite amd64: 1 passed; both architectures passed in CI
- Build/CI regression tests: 8 passed. Ruff and Pyright passed.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | builds the required S3 service | Error | Custom wheel feature list | S3 explicitly compiled | Unit | ✅ repo/test_storage_image.py::TestStorageImage::test_builds_the_required_s3_service |
| 2 | checks each backend image on its native architecture | Edge | CI build matrix | All backend variants loaded and exercised | Unit | ✅ repo/test_storage_image.py::TestStorageImage::test_checks_each_backend_image_on_its_native_architecture |
| 3 | constructs advertised image transports | Happy | Final full image | Production adapters construct | Contract | ✅ e2e/runtime_image.py::TestFullImageTransports::test_constructs_advertised_image_transports |
| 4 | reports unavailable image capabilities | Edge | Final lite image | Optional transports unavailable; native S3 available | Contract | ✅ e2e/runtime_image.py::TestLiteImageTransports::test_reports_unavailable_image_capabilities |
| 5 | restores S3 backup from shipped image | Happy | Container API, remote-only S3 | Recovered bytes equal original fixture | E2E | ✅ e2e/runtime_image.py::TestRuntimeImageBackup::test_restores_s3_backup_from_shipped_image |

The image lane uses the already built image without installing test dependencies into it. Its host runner reuses the suite's pinned SeaweedFS service. Test hygiene: 1,922 passed.

## Notes

No schema or response-shape changes. Reproduce with `cd backend && ./scripts/test.sh image --image TAG --variant full` (or `lite`) after building the corresponding image.
