### PR TITLE
fix(storage): close SFTP resources after partial acquisition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - The full container image includes the S3 transport used by remote Library
   sources and backup connections. Image checks now exercise remote-only S3
   recovery on both supported architectures.
+- SFTP streaming releases its connection, reader, and event loop when opening
+  fails, a read is cancelled, or cleanup itself encounters an error.
 
 ## 0.13.0
 

--- a/backend/app/services/storage_opendal.py
+++ b/backend/app/services/storage_opendal.py
@@ -9,6 +9,7 @@ import os
 import posixpath
 import tempfile
 import uuid
+from contextlib import ExitStack
 from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path
@@ -997,22 +998,26 @@ class _AsyncSSHSFTPOperator:
     def stream_chunks(self, relative: str, chunk_size: int) -> Iterator[bytes]:
         import asyncssh
 
-        loop = asyncio.new_event_loop()
-        connection = loop.run_until_complete(
-            asyncssh.connect(**self._connection_options())
-        )
-        client = loop.run_until_complete(connection.start_sftp_client())
-        reader = loop.run_until_complete(client.open(self._path(relative), "rb"))
-        try:
+        # Register each resource as soon as acquisition succeeds. ExitStack
+        # runs the remaining cleanups even if closing an inner resource fails.
+        # Acquisition failures and GeneratorExit own the loop just as EOF does.
+        with ExitStack() as resources:
+            loop = asyncio.new_event_loop()
+            resources.callback(loop.close)
+            connection = loop.run_until_complete(
+                asyncssh.connect(**self._connection_options())
+            )
+            resources.callback(
+                lambda: loop.run_until_complete(connection.wait_closed())
+            )
+            resources.callback(connection.close)
+            client = loop.run_until_complete(connection.start_sftp_client())
+            resources.callback(lambda: loop.run_until_complete(client.wait_closed()))
+            resources.callback(client.exit)
+            reader = loop.run_until_complete(client.open(self._path(relative), "rb"))
+            resources.callback(lambda: loop.run_until_complete(reader.close()))
             while chunk := loop.run_until_complete(reader.read(chunk_size)):
                 yield bytes(chunk)
-        finally:
-            loop.run_until_complete(reader.close())
-            client.exit()
-            loop.run_until_complete(client.wait_closed())
-            connection.close()
-            loop.run_until_complete(connection.wait_closed())
-            loop.close()
 
     def delete(self, relative: str) -> None:
         async def operation(client) -> None:

--- a/backend/tests/contract/services/test_storage_opendal.py
+++ b/backend/tests/contract/services/test_storage_opendal.py
@@ -164,6 +164,8 @@ def sftp_password_endpoint(tmp_path: Path):
             str(tmp_path / "password-server"),
             "--password",
             "contract-secret",
+            "--events",
+            str(tmp_path / "sftp-events"),
             "--known-hosts",
             str(known_hosts),
         ],
@@ -391,6 +393,44 @@ class TestOpenDALStorageBackend:
 
         assert b"".join(backend.stream_chunks(key, 64 * 1024)) == payload
         assert receipt.size == len(payload)
+
+    def test_sftp_closes_an_abandoned_stream(
+        self,
+        sftp_password_endpoint,
+        tmp_path: Path,
+    ) -> None:
+        port, known_hosts = sftp_password_endpoint
+        source = tmp_path / "password-server" / "vault-data" / "stream.gcode"
+        source.parent.mkdir()
+        source.write_bytes(b"streamed" * 1024)
+        backend = OpenDALStorageBackend(
+            TransportSpec(
+                kind=TransportKind.SFTP,
+                provider="sftp",
+                namespace="vault-data",
+                options={
+                    "host": "127.0.0.1",
+                    "port": port,
+                    "username": "printstash",
+                    "password": "contract-secret",
+                    "host_key": str(known_hosts),
+                    "root": "vault-data",
+                },
+            )
+        )
+        stream = backend.stream_chunks("vault-data/stream.gcode", 8)
+
+        assert next(stream) == b"streamed"
+        stream.close()
+
+        events_path = tmp_path / "sftp-events"
+        deadline = time.monotonic() + 5
+        events = events_path.read_text().splitlines()
+        while events.count("connected") != events.count("disconnected"):
+            assert time.monotonic() < deadline, events
+            time.sleep(0.01)
+            events = events_path.read_text().splitlines()
+        assert events == ["connected", "disconnected"]
 
     def test_sftp_accepts_a_pinned_known_host_entry(self, sftp_endpoint) -> None:
         port, private_key, known_hosts = sftp_endpoint

--- a/backend/tests/fakes/mock_sftp.py
+++ b/backend/tests/fakes/mock_sftp.py
@@ -10,8 +10,20 @@ import asyncssh
 
 
 class _AuthenticationServer(asyncssh.SSHServer):
-    def __init__(self, password: str | None) -> None:
+    def __init__(self, password: str | None, events: Path | None = None) -> None:
         self._password = password
+        self._events = events
+
+    def _record(self, event: str) -> None:
+        if self._events is not None:
+            with self._events.open("a") as output:
+                output.write(f"{event}\n")
+
+    def connection_made(self, conn: asyncssh.SSHServerConnection) -> None:
+        self._record("connected")
+
+    def connection_lost(self, exc: Exception | None) -> None:
+        self._record("disconnected")
 
     def begin_auth(self, username: str) -> bool:
         del username
@@ -38,6 +50,7 @@ async def serve(
     root: Path,
     password: str | None,
     known_hosts: Path | None,
+    events: Path | None = None,
 ) -> None:
     root.mkdir(parents=True, exist_ok=True)
     host_key = asyncssh.generate_private_key("ssh-ed25519")
@@ -50,7 +63,7 @@ async def serve(
         host,
         port,
         server_host_keys=[host_key],
-        server_factory=lambda: _AuthenticationServer(password),
+        server_factory=lambda: _AuthenticationServer(password, events),
         sftp_factory=lambda channel: asyncssh.SFTPServer(
             channel, chroot=str(root).encode()
         ),
@@ -67,6 +80,7 @@ def main() -> None:
     parser.add_argument("--authorized-keys", type=Path)
     parser.add_argument("--password")
     parser.add_argument("--known-hosts", type=Path)
+    parser.add_argument("--events", type=Path)
     args = parser.parse_args()
     asyncio.run(
         serve(
@@ -75,6 +89,7 @@ def main() -> None:
             root=args.root,
             password=args.password,
             known_hosts=args.known_hosts,
+            events=args.events,
         )
     )
 

--- a/backend/tests/unit/services/storage_opendal/test_stream_cleanup.py
+++ b/backend/tests/unit/services/storage_opendal/test_stream_cleanup.py
@@ -1,0 +1,162 @@
+"""A streaming SFTP read owns resources even when acquisition only partly succeeds.
+
+Transport faults are injected before each acquisition and during reads/cleanup;
+the observed outcome is that every acquired resource is closed, including the
+private event loop, without replacing the streaming implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+import asyncssh
+import pytest
+
+from app.services.storage_opendal import _AsyncSSHSFTPOperator
+
+
+@dataclass
+class StreamResources:
+    fail_at: str = ""
+    acquired: set[str] = field(default_factory=set)
+    closed: set[str] = field(default_factory=set)
+    chunks: list[bytes] = field(default_factory=lambda: [b"first", b"last", b""])
+
+    def fail(self, stage: str) -> None:
+        if self.fail_at == stage:
+            raise OSError(f"stream fault: {stage}")
+
+
+class Reader:
+    def __init__(self, resources: StreamResources) -> None:
+        self.resources = resources
+
+    async def read(self, size: int) -> bytes:
+        self.resources.fail("read")
+        return self.resources.chunks.pop(0)
+
+    async def close(self) -> None:
+        self.resources.closed.add("reader")
+        self.resources.fail("reader_close")
+
+
+class Client:
+    def __init__(self, resources: StreamResources) -> None:
+        self.resources = resources
+
+    async def open(self, path: str, mode: str) -> Reader:
+        self.resources.fail("open")
+        self.resources.acquired.add("reader")
+        return Reader(self.resources)
+
+    def exit(self) -> None:
+        self.resources.closed.add("client")
+
+    async def wait_closed(self) -> None:
+        self.resources.fail("client_close")
+
+
+class Connection:
+    def __init__(self, resources: StreamResources) -> None:
+        self.resources = resources
+
+    async def start_sftp_client(self) -> Client:
+        self.resources.fail("client")
+        self.resources.acquired.add("client")
+        return Client(self.resources)
+
+    def close(self) -> None:
+        self.resources.closed.add("connection")
+
+    async def wait_closed(self) -> None:
+        self.resources.fail("connection_close")
+
+
+@pytest.fixture
+def stream_resources(monkeypatch: pytest.MonkeyPatch):
+    resources = StreamResources()
+    loop = asyncio.new_event_loop()
+
+    async def connect(**options: object) -> Connection:
+        resources.fail("connect")
+        resources.acquired.add("connection")
+        return Connection(resources)
+
+    monkeypatch.setattr(asyncssh, "connect", connect)
+    monkeypatch.setattr(asyncio, "new_event_loop", lambda: loop)
+    operator = _AsyncSSHSFTPOperator(
+        {
+            "host": "example.invalid",
+            "port": 22,
+            "username": "contract-only",
+            "root": "vault",
+            "host_key": "contract-only",
+        }
+    )
+    monkeypatch.setattr(operator, "_connection_options", lambda: {})
+    try:
+        yield operator, resources, loop
+    finally:
+        loop.close()
+
+
+class TestStreamChunks:
+    def test_closes_resources_after_early_consumer_exit(self, stream_resources) -> None:
+        operator, resources, loop = stream_resources
+        stream = operator.stream_chunks("file", 1024)
+
+        assert next(stream) == b"first"
+        stream.close()
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
+    def test_closes_resources_after_cancellation(self, stream_resources) -> None:
+        operator, resources, loop = stream_resources
+        stream = operator.stream_chunks("file", 1024)
+        next(stream)
+
+        with pytest.raises(asyncio.CancelledError):
+            stream.throw(asyncio.CancelledError())
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
+    @pytest.mark.parametrize(
+        "stage",
+        ["connect", "client", "open", "read"],
+        ids=str,
+    )
+    def test_closes_acquired_resources_after_transport_failure(
+        self,
+        stream_resources,
+        stage: str,
+    ) -> None:
+        operator, resources, loop = stream_resources
+        resources.fail_at = stage
+
+        with pytest.raises(OSError, match=f"stream fault: {stage}"):
+            list(operator.stream_chunks("file", 1024))
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
+    @pytest.mark.parametrize(
+        "stage",
+        ["reader_close", "client_close", "connection_close"],
+        ids=str,
+    )
+    def test_finishes_remaining_cleanup_after_a_close_failure(
+        self,
+        stream_resources,
+        stage: str,
+    ) -> None:
+        operator, resources, loop = stream_resources
+        resources.fail_at = stage
+
+        with pytest.raises(OSError, match=f"stream fault: {stage}"):
+            list(operator.stream_chunks("file", 1024))
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()


### PR DESCRIPTION
## Summary

SFTP streaming could leak its private event loop or connection when connection/client/reader acquisition failed. A cleanup exception could also prevent outer resources from closing. Register each acquired resource immediately and run every remaining cleanup when reads end, consumers stop, or a cleanup raises.

## Testing

- [x] Full backend coverage, Ruff, Pyright, frontend, browser and image gates passed in CI at `4dba7ea` after rebasing onto main.
- [x] Frontend checks not needed
- [x] Real loopback SFTP/WebDAV contracts: 16 passed
- Focused SFTP unit tests: 38 passed. New regressions initially produced 6 failures and 3 passes before the fix. Ruff and Pyright passed locally.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | closes acquired resources after transport failure | Error | connect/client/open/read fault | Acquired resources and loop closed | Unit | ✅ unit/services/storage_opendal/test_stream_cleanup.py::TestStreamChunks::test_closes_acquired_resources_after_transport_failure |
| 2 | finishes remaining cleanup after a close failure | Error | reader/client/connection cleanup raises | Outer resources still close | Unit | ✅ unit/services/storage_opendal/test_stream_cleanup.py::TestStreamChunks::test_finishes_remaining_cleanup_after_a_close_failure |
| 3 | closes resources after early consumer exit | Edge | Generator closed after first chunk | All acquired resources close | Unit | ✅ unit/services/storage_opendal/test_stream_cleanup.py::TestStreamChunks::test_closes_resources_after_early_consumer_exit |
| 4 | closes resources after cancellation | Edge | Consumer raises cancellation | All acquired resources close | Unit | ✅ unit/services/storage_opendal/test_stream_cleanup.py::TestStreamChunks::test_closes_resources_after_cancellation |
| 5 | closes an abandoned SFTP stream | Edge | Real loopback reader closed early | Server observes disconnect | Contract | ✅ contract/services/test_storage_opendal.py::TestOpenDALStorageBackend::test_sftp_closes_an_abandoned_stream |
| 6 | streams complete SFTP content | Happy | Password-authenticated server | Full round trip matches payload | Contract | ✅ contract/services/test_storage_opendal.py::TestOpenDALStorageBackend::test_sftp_password_stream_round_trip |

## Notes

The protocol fake adds optional connection event recording so the contract observes server-side resource release without patching the client.
