### PR TITLE
fix(storage): reject incomplete remote source downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
   domains. Different profiles, credentials, or prefixes cannot authorize
   deletion using a backup on the same storage. Custom targets require an
   administrator declaration; changes invalidate an approved plan.
+- Remote Library sources reject incomplete or oversized downloads before
+  indexing, so a truncated first read cannot create an Artifact from partial bytes.
 
 ## 0.13.0
 

--- a/backend/app/services/library_source.py
+++ b/backend/app/services/library_source.py
@@ -322,13 +322,17 @@ class OpenDalLibrarySource:
         try:
             with open(fd, "wb", closefd=True) as output:
                 for chunk in self.backend.stream_chunks(provider_key):
-                    output.write(chunk)
                     written += len(chunk)
+                    if written > before.size:
+                        raise LibrarySourceError("library_source_size_mismatch")
+                    output.write(chunk)
                     if self.max_bytes_per_second:
                         target_elapsed = written / self.max_bytes_per_second
                         remaining = target_elapsed - (time.monotonic() - started)
                         if remaining > 0:
                             time.sleep(remaining)
+            if written != before.size:
+                raise LibrarySourceError("library_source_size_mismatch")
             after = self.backend.object_info(provider_key)
             if (
                 after is None

--- a/backend/tests/integration/services/external_library/test_remote_materialization.py
+++ b/backend/tests/integration/services/external_library/test_remote_materialization.py
@@ -1,0 +1,75 @@
+"""A truncated first read must fail before remote indexing publishes any catalog data."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from sqlmodel import Session, select
+
+from app.db.models import File, LibrarySourceKind, Model, OwnedStorageObject
+from app.services import external_library
+from app.services.library_source import (
+    LibrarySourceError,
+    OpenDalLibrarySource,
+    SourceEntry,
+)
+from app.services.storage_opendal import OpenDALStorageBackend
+from app.services.storage_providers import TransportKind, TransportSpec
+from tests.paths import FIXTURES_DIR
+
+
+class TruncatedOperator:
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+
+    def exists(self, key: str) -> bool:
+        return True
+
+    def stat(self, key: str) -> SimpleNamespace:
+        return SimpleNamespace(content_length=len(self.payload) + 1, etag="stable")
+
+    def open(self, key: str, mode: str) -> BytesIO:
+        return BytesIO(self.payload)
+
+
+class TestIndexRemoteFile:
+    def test_rejects_truncated_content_before_catalog_publication(
+        self,
+        db_session: Session,
+        make_external_library,
+    ) -> None:
+        library = make_external_library(
+            "",
+            source_kind=LibrarySourceKind.WEBDAV,
+            source_prefix="models",
+            root_identity=None,
+        )
+        payload = (FIXTURES_DIR / "sample.gcode").read_bytes()
+        source = OpenDalLibrarySource(
+            OpenDALStorageBackend(
+                TransportSpec(
+                    kind=TransportKind.WEBDAV,
+                    provider="webdav",
+                    namespace="root",
+                    options={"root": "root"},
+                ),
+                operator=TruncatedOperator(payload),
+            )
+        )
+        initial_model_ids = db_session.exec(select(Model.id)).all()
+        initial_file_ids = db_session.exec(select(File.id)).all()
+        initial_owned_ids = db_session.exec(select(OwnedStorageObject.id)).all()
+
+        with pytest.raises(LibrarySourceError, match="library_source_size_mismatch"):
+            external_library._index_remote_file(
+                db_session,
+                library,
+                source,
+                SourceEntry("models/sample.gcode", len(payload) + 1),
+            )
+
+        assert db_session.exec(select(Model.id)).all() == initial_model_ids
+        assert db_session.exec(select(File.id)).all() == initial_file_ids
+        assert db_session.exec(select(OwnedStorageObject.id)).all() == initial_owned_ids

--- a/backend/tests/unit/services/test_library_source.py
+++ b/backend/tests/unit/services/test_library_source.py
@@ -6,6 +6,7 @@ import io
 import json
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -326,6 +327,98 @@ class TestS3LibrarySourceAdapter:
 
 
 class TestOpenDalLibrarySourceAdapter:
+    @pytest.mark.parametrize(
+        "after",
+        [
+            None,
+            StorageObjectInfo(size=4, etag="before"),
+            StorageObjectInfo(size=3, etag="changed"),
+            StorageObjectInfo(size=3, etag="before", version_id="replacement"),
+        ],
+        ids=["disappeared", "size-changed", "etag-changed", "version-changed"],
+    )
+    def test_rejects_changed_metadata_before_exposing_downloaded_content(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        after: StorageObjectInfo | None,
+    ) -> None:
+        backend = _StableDirectoryBackend()
+        observations = iter([StorageObjectInfo(size=3, etag="before"), after])
+        monkeypatch.setattr(backend, "object_info", lambda _key: next(observations))
+        monkeypatch.setattr(library_source.tempfile, "tempdir", str(tmp_path))
+        source = OpenDalLibrarySource(backend)  # type: ignore[arg-type]
+
+        with pytest.raises(LibrarySourceError, match="library_source_changed"):
+            with source.materialize("models/a.stl"):
+                pytest.fail("changed source content was exposed to indexing")
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_cleans_the_temporary_download_after_a_read_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        backend = _StableDirectoryBackend()
+
+        def broken_stream(_key: str):
+            yield b"a"
+            raise OSError("remote read failed")
+
+        monkeypatch.setattr(backend, "stream_chunks", broken_stream)
+        monkeypatch.setattr(library_source.tempfile, "tempdir", str(tmp_path))
+        source = OpenDalLibrarySource(backend)  # type: ignore[arg-type]
+
+        with pytest.raises(OSError, match="remote read failed"):
+            with source.materialize("models/a.stl"):
+                pytest.fail("failed remote content was exposed to indexing")
+
+        assert list(tmp_path.iterdir()) == []
+
+    @pytest.mark.parametrize(
+        "payload",
+        [b"", b"ab", b"abcd"],
+        ids=["empty", "short", "oversized"],
+    )
+    def test_rejects_a_stream_with_the_wrong_length(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        payload: bytes,
+    ) -> None:
+        backend = _StableDirectoryBackend()
+        monkeypatch.setattr(backend, "stream_chunks", lambda _key: iter([payload]))
+        monkeypatch.setattr(library_source.tempfile, "tempdir", str(tmp_path))
+        source = OpenDalLibrarySource(backend)  # type: ignore[arg-type]
+
+        with pytest.raises(LibrarySourceError, match="library_source_size_mismatch"):
+            with source.materialize("models/a.stl"):
+                pytest.fail("an incomplete source was exposed to indexing")
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_stops_reading_when_the_advertised_length_is_exceeded(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        backend = _StableDirectoryBackend()
+
+        def oversized_stream(_key: str):
+            yield b"abcd"
+            pytest.fail("continued reading an oversized source")
+
+        monkeypatch.setattr(backend, "stream_chunks", oversized_stream)
+        monkeypatch.setattr(library_source.tempfile, "tempdir", str(tmp_path))
+        source = OpenDalLibrarySource(backend)  # type: ignore[arg-type]
+
+        with pytest.raises(LibrarySourceError, match="library_source_size_mismatch"):
+            with source.materialize("models/a.stl"):
+                pytest.fail("an oversized source was exposed to indexing")
+
+        assert list(tmp_path.iterdir()) == []
+
     def test_depth_first_cursor_pages_without_a_recursive_full_listing(self) -> None:
         source = OpenDalLibrarySource(_DirectoryBackend())  # type: ignore[arg-type]
 


### PR DESCRIPTION
## Summary

Remote Library sources could expose truncated downloads to indexing when a server returned fewer bytes than advertised. Require the exact expected size before yielding a temporary file, stop oversized streams immediately, and retain metadata and cleanup guards.

## Testing

- 51 focused source and indexing tests passed; Ruff and Pyright passed.
- New length regressions failed before the fix, including the integration case that previously accepted truncated content.
- All CI gates passed on the rebased commit, including backend full coverage/regressions, real-backend E2E and both image architectures. No frontend changes.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | rejects incorrect download lengths | Error | Empty, short, or oversized stream | No yielded path or temporary residue | Unit | ✅ TestOpenDalLibrarySourceAdapter.test_rejects_a_stream_with_the_wrong_length |
| 2 | stops oversized downloads immediately | Edge | Stream exceeds advertised length | No further remote chunks consumed | Unit | ✅ TestOpenDalLibrarySourceAdapter.test_stops_reading_when_the_advertised_length_is_exceeded |
| 3 | rejects changed remote identity | Error | Disappearance or size/ETag/version change | No yielded path or temporary residue | Unit | ✅ TestOpenDalLibrarySourceAdapter.test_rejects_changed_metadata_before_exposing_downloaded_content |
| 4 | cleans failed reads | Error | Transport read raises | Temporary download removed | Unit | ✅ TestOpenDalLibrarySourceAdapter.test_cleans_the_temporary_download_after_a_read_failure |
| 5 | rejects content before indexing | Error | Valid G-code bytes with a larger advertised length | Model, Artifact and owned-object rows unchanged | Integration | ✅ test_rejects_truncated_content_before_catalog_publication |
| 6 | materializes stable content | Happy | Complete unchanged object | Original bytes available inside context and removed afterward | Unit | ✅ TestOpenDalLibrarySourceAdapter.test_stable_materialization_cleans_the_temporary_copy |

Modification-time propagation is a separate source-metadata change; existing size, ETag and version checks remain in place here.
