### PR TITLE
fix(backup): support streaming SFTP backup recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- SFTP backup profiles can probe, list, verify and restore remote-only archives.
+  Manifest reads stream through bounded buffers and close their remote handles
+  on early exit; failed downloads remove their temporary bytes.
+
 - The full container image includes the S3 transport used by remote Library
   sources and backup connections. Image checks now exercise remote-only S3
   recovery on both supported architectures.

--- a/backend/app/services/backup_destination.py
+++ b/backend/app/services/backup_destination.py
@@ -102,7 +102,10 @@ class RemoteBackupDestination:
             or row.sha256 is None
         ):
             raise BackupDestinationError("backup_storage_ownership_unverified")
-        info = self.backend.object_info(row.key)
+        try:
+            info = self.backend.object_info(row.key)
+        except Exception as exc:
+            raise BackupDestinationError("backup_remote_metadata_failed") from exc
         if info is None or info.size != row.size_bytes:
             raise BackupDestinationError("backup_remote_identity_mismatch")
         if row.etag and info.etag != row.etag:
@@ -119,19 +122,30 @@ class RemoteBackupDestination:
 
     def download_owned(self, row: OwnedStorageObject, destination: Path) -> None:
         self.require_owned(row)
+        assert row.size_bytes is not None
         digest = hashlib.sha256()
         written = 0
-        with destination.open("xb") as output:
-            for chunk in self.backend.stream_chunks(row.key):
-                output.write(chunk)
-                digest.update(chunk)
-                written += len(chunk)
-        self.require_owned(row)
-        if written != row.size_bytes or (
-            row.sha256 and digest.hexdigest() != row.sha256
-        ):
-            destination.unlink(missing_ok=True)
-            raise BackupDestinationError("backup_download_digest_mismatch")
+        created = False
+        try:
+            with destination.open("xb") as output:
+                created = True
+                for chunk in self.backend.stream_chunks(row.key):
+                    written += len(chunk)
+                    if written > row.size_bytes:
+                        raise BackupDestinationError("backup_download_digest_mismatch")
+                    output.write(chunk)
+                    digest.update(chunk)
+            self.require_owned(row)
+            if written != row.size_bytes or digest.hexdigest() != row.sha256:
+                raise BackupDestinationError("backup_download_digest_mismatch")
+        except BaseException as exc:
+            if created:
+                destination.unlink(missing_ok=True)
+            if isinstance(exc, BackupDestinationError) or not isinstance(
+                exc, Exception
+            ):
+                raise
+            raise BackupDestinationError("backup_remote_read_failed") from exc
 
     def delete_owned(
         self, row: OwnedStorageObject, *, allow_unversioned: bool = False

--- a/backend/app/services/storage_opendal.py
+++ b/backend/app/services/storage_opendal.py
@@ -11,6 +11,7 @@ import tempfile
 import uuid
 from contextlib import ExitStack
 from dataclasses import dataclass
+from io import BufferedReader, RawIOBase
 from itertools import islice
 from pathlib import Path
 from types import SimpleNamespace
@@ -402,7 +403,7 @@ class OpenDALStorageBackend(StorageBackend):
 
     @property
     def operator_capabilities(self):
-        """Expose OpenDAL's measured operation surface to role-specific adapters."""
+        """Supported transport operations; endpoint guarantees require a probe."""
         return self._operator.capability()
 
     def check(self) -> None:
@@ -792,6 +793,61 @@ class _AsyncSSHMetadata:
 
 
 @dataclass(frozen=True)
+class _SFTPCapabilities:
+    """Supported operations; root access is probed separately.
+
+    Exclusive creation prevents overwrite but does not promise atomic visible
+    publication or an immutable version identity for deletion.
+    """
+
+    read: bool = True
+    write: bool = True
+    list: bool = True
+    write_with_if_not_exists: bool = True
+    delete_with_version: bool = False
+
+
+class _ChunkReader(RawIOBase):
+    """Adapt a bounded transport iterator to Python's streaming file contract."""
+
+    def __init__(self, chunks: Iterator[bytes]) -> None:
+        super().__init__()
+        self._chunks = chunks
+        self._pending = memoryview(b"")
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer) -> int:
+        if self.closed:
+            raise ValueError("read of closed remote stream")
+        if not buffer:
+            return 0
+        if not self._pending:
+            try:
+                self._pending = memoryview(next(self._chunks))
+            except StopIteration:
+                return 0
+            except Exception as exc:
+                raise StorageConfigurationError("remote_storage_read_failed") from exc
+        count = min(len(buffer), len(self._pending))
+        buffer[:count] = self._pending[:count]
+        self._pending = self._pending[count:]
+        return count
+
+    def close(self) -> None:
+        try:
+            close = getattr(self._chunks, "close", None)
+            if close is not None:
+                close()
+        except Exception as exc:
+            raise StorageConfigurationError("remote_storage_read_failed") from exc
+        finally:
+            self._pending = memoryview(b"")
+            super().close()
+
+
+@dataclass(frozen=True)
 class SourceDirectoryEntry:
     """One immediate child below a read-only library source directory."""
 
@@ -872,6 +928,14 @@ class _AsyncSSHSFTPOperator:
             await client.stat(self._root)
 
         self._run(operation)
+
+    def capability(self) -> _SFTPCapabilities:
+        return _SFTPCapabilities()
+
+    def open(self, relative: str, mode: str = "rb") -> BufferedReader:
+        if mode != "rb":
+            raise StorageConfigurationError("sftp_stream_mode_unsupported")
+        return BufferedReader(_ChunkReader(self.stream_chunks(relative, 64 * 1024)))
 
     def provision_root(self) -> None:
         async def operation(client) -> None:

--- a/backend/tests/contract/services/test_storage_opendal.py
+++ b/backend/tests/contract/services/test_storage_opendal.py
@@ -20,6 +20,11 @@ import asyncssh
 import opendal
 import pytest
 
+from app.db.models import LibrarySourceKind, StorageConnection, StorageConnectionPurpose
+from app.services.backup_destination import (
+    BackupDestinationError,
+    destination_from_connection,
+)
 from app.services.storage_backend import (
     StorageCollisionError,
     StorageConfigurationError,
@@ -280,6 +285,47 @@ class _RenameFailure:
 
 
 class TestOpenDALStorageBackend:
+    @pytest.mark.parametrize("password", ["contract-secret", "incorrect-secret"])
+    def test_sftp_backup_probe_uses_the_production_factory(
+        self, sftp_password_endpoint, password: str
+    ) -> None:
+        port, known_hosts = sftp_password_endpoint
+        profile = StorageConnection(
+            id=7,
+            name="SFTP archive",
+            kind=LibrarySourceKind.SFTP,
+            purpose=StorageConnectionPurpose.BACKUP,
+            config_json=json.dumps(
+                {
+                    "provider": "sftp",
+                    "host": "127.0.0.1",
+                    "port": port,
+                    "username": "printstash",
+                    "host_key": str(known_hosts),
+                    "root": "vault-data",
+                }
+            ),
+            secret_json=json.dumps({"password": "contract-secret"}),
+        )
+        destination_from_connection(profile).backend.provision_root()
+        profile.secret_json = json.dumps({"password": password})
+        destination = destination_from_connection(profile)
+
+        if password != "contract-secret":
+            with pytest.raises(
+                BackupDestinationError, match="^storage_connection_probe_failed$"
+            ) as failure:
+                destination.probe()
+            assert password not in str(failure.value)
+            return
+        result = destination.probe()
+
+        assert result["ok"] is True
+        assert result["read"] is True
+        assert result["write"] is True
+        assert result["conditional_create"] is True
+        assert result["versioned_delete"] is False
+
     def test_webdav_rejects_invalid_credentials(self, webdav_endpoint: str) -> None:
         spec = _spec(webdav_endpoint)
         spec.options["password"] = "not-the-contract-password"

--- a/backend/tests/e2e/test_remote_backup.py
+++ b/backend/tests/e2e/test_remote_backup.py
@@ -1,6 +1,6 @@
 """A remote-only backup remains recoverable through the public HTTP API.
 
-The archive lives in a real S3-compatible service and no local copy is retained;
+The archive lives in a real S3-compatible or SFTP service and no local copy is retained;
 the test then destroys the catalog row and Artifact bytes before restoring them
 through the same operator-facing endpoints.
 """
@@ -18,7 +18,9 @@ from botocore.config import Config as BotoConfig
 from app.core.config import settings
 from app.services.setup_token import current_setup_token
 from app.services.storage_backend import init_backend
-from tests.containers import S3_ACCESS_KEY, S3_SECRET_KEY, s3_endpoint
+from app.services.storage_opendal import OpenDALStorageBackend
+from app.services.storage_providers import SFTPProviderConfig, resolve_transport
+from tests.containers import S3_ACCESS_KEY, S3_SECRET_KEY, openssh_endpoint, s3_endpoint
 from tests.paths import FIXTURES_DIR
 
 FIXTURE = FIXTURES_DIR / "sample.gcode"
@@ -46,14 +48,55 @@ def remote_backup_bucket():
         client.delete_bucket(Bucket=bucket)
 
 
+@pytest.fixture(
+    params=[
+        pytest.param("s3", marks=pytest.mark.s3),
+        pytest.param("sftp", marks=pytest.mark.remote_storage),
+    ]
+)
+def remote_backup_profile(request):
+    if request.param == "s3":
+        endpoint, bucket = request.getfixturevalue("remote_backup_bucket")
+        return {
+            "kind": "s3",
+            "configuration": {
+                "provider": "s3_self_hosted",
+                "bucket": bucket,
+                "endpoint_url": endpoint,
+                "region": "us-east-1",
+                "root": "off-site",
+                "addressing_style": "path",
+            },
+            "secrets": {"access_key": S3_ACCESS_KEY, "secret_key": S3_SECRET_KEY},
+        }
+    host, port, host_key = openssh_endpoint()
+    configuration = {
+        "provider": "sftp",
+        "host": host,
+        "port": port,
+        "username": "contract",
+        "host_key": host_key,
+        "root": f"api-backup-{uuid4().hex}",
+    }
+    # Provision only this disposable test directory before enrolling the
+    # profile. Runtime probes and reads must never create an absent root.
+    backend = OpenDALStorageBackend(
+        resolve_transport(SFTPProviderConfig(**configuration, password="contract-only"))
+    )
+    backend.provision_root()
+    return {
+        "kind": "sftp",
+        "configuration": configuration,
+        "secrets": {"password": "contract-only"},
+    }
+
+
 class TestRemoteBackup:
     @pytest.mark.critical
-    @pytest.mark.s3
     @pytest.mark.asyncio
     async def test_remote_only_backup_restores_through_the_public_api(
-        self, api, tmp_path, remote_backup_bucket
+        self, api, tmp_path, remote_backup_profile
     ) -> None:
-        endpoint, bucket = remote_backup_bucket
         setup = await api.post(
             "/api/v1/setup",
             json={
@@ -79,23 +122,17 @@ class TestRemoteBackup:
             headers=headers,
             json={
                 "name": f"critical backup {uuid4().hex}",
-                "kind": "s3",
                 "purpose": "backup",
-                "configuration": {
-                    "provider": "s3_self_hosted",
-                    "bucket": bucket,
-                    "endpoint_url": endpoint,
-                    "region": "us-east-1",
-                    "root": "off-site",
-                    "addressing_style": "path",
-                },
-                "secrets": {
-                    "access_key": S3_ACCESS_KEY,
-                    "secret_key": S3_SECRET_KEY,
-                },
+                **remote_backup_profile,
             },
         )
         assert connection.status_code == 201, connection.text
+        probe = await api.post(
+            f"/api/v1/storage-connections/{connection.json()['id']}/probe",
+            headers=headers,
+        )
+        assert probe.status_code == 200, probe.text
+        assert probe.json()["read"] is True
 
         uploaded = await api.post(
             "/api/v1/ingest/orca",
@@ -126,8 +163,20 @@ class TestRemoteBackup:
 
         assert created.status_code == 202, created.text
         metadata = created.json()
-        assert metadata["location"] == "opendal:s3"
+        assert metadata["location"] == f"opendal:{remote_backup_profile['kind']}"
         assert not list(Path(settings.backup_dir).glob("*.tar.gz"))
+        listed = await api.get("/api/v1/backups/sources", headers=headers)
+        assert listed.status_code == 200, listed.text
+        assert any(
+            item["source_ref"] == metadata["source_ref"] for item in listed.json()
+        )
+        verified = await api.post(
+            f"/api/v1/backups/{metadata['backup_id']}/verify",
+            headers=headers,
+            params={"source_ref": metadata["source_ref"]},
+        )
+        assert verified.status_code == 200, verified.text
+        assert verified.json()["valid"] is True
         trashed = await api.delete(f"/api/v1/models/{model['id']}", headers=headers)
         assert trashed.status_code == 204, trashed.text
         purged = await api.delete(

--- a/backend/tests/unit/services/storage_opendal/test_stream_cleanup.py
+++ b/backend/tests/unit/services/storage_opendal/test_stream_cleanup.py
@@ -102,6 +102,74 @@ def stream_resources(monkeypatch: pytest.MonkeyPatch):
 
 
 class TestStreamChunks:
+    def test_reader_reaches_eof_without_losing_chunk_boundaries(
+        self, stream_resources
+    ) -> None:
+        operator, resources, loop = stream_resources
+
+        with operator.open("archive.tar.gz", "rb") as reader:
+            assert reader.read(7) == b"firstla"
+            assert reader.read() == b"st"
+            assert reader.read(1) == b""
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
+    def test_reader_rejects_a_write_mode_without_connecting(
+        self, stream_resources
+    ) -> None:
+        from app.services.storage_backend import StorageConfigurationError
+
+        operator, resources, _ = stream_resources
+        with pytest.raises(
+            StorageConfigurationError, match="sftp_stream_mode_unsupported"
+        ):
+            operator.open("archive.tar.gz", "wb")
+
+        assert not resources.acquired
+
+    def test_reader_normalizes_cleanup_failures(self, stream_resources) -> None:
+        from app.services.storage_backend import StorageConfigurationError
+
+        operator, resources, loop = stream_resources
+        with pytest.raises(
+            StorageConfigurationError, match="remote_storage_read_failed"
+        ):
+            with operator.open("archive.tar.gz", "rb") as reader:
+                reader.read(1)
+                resources.fail_at = "reader_close"
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
+    def test_reader_leaves_unconsumed_archive_bytes_remote(
+        self, stream_resources
+    ) -> None:
+        operator, resources, loop = stream_resources
+        resources.chunks = [b"x" * 65536, b"unconsumed", b""]
+
+        with operator.open("archive.tar.gz", "rb") as reader:
+            assert reader.read(10) == b"x" * 10
+            assert resources.chunks == [b"unconsumed", b""]
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
+    def test_reader_normalizes_transport_failures(self, stream_resources) -> None:
+        from app.services.storage_backend import StorageConfigurationError
+
+        operator, resources, loop = stream_resources
+        resources.fail_at = "read"
+
+        with pytest.raises(
+            StorageConfigurationError, match="remote_storage_read_failed"
+        ):
+            with operator.open("archive.tar.gz", "rb") as reader:
+                reader.read(10)
+
+        assert resources.closed == resources.acquired
+        assert loop.is_closed()
+
     def test_closes_resources_after_early_consumer_exit(self, stream_resources) -> None:
         operator, resources, loop = stream_resources
         stream = operator.stream_chunks("file", 1024)

--- a/backend/tests/unit/services/test_backup_destination.py
+++ b/backend/tests/unit/services/test_backup_destination.py
@@ -94,6 +94,62 @@ def _row(payload: bytes = b"archive") -> OwnedStorageObject:
 
 
 class TestDownloadOwned:
+    def test_normalizes_remote_metadata_failures(self, tmp_path: Path) -> None:
+        class FailingBackend(_Backend):
+            def object_info(self, _key: str):
+                raise OSError("example-secret")
+
+        with pytest.raises(
+            BackupDestinationError, match="^backup_remote_metadata_failed$"
+        ):
+            _destination(FailingBackend()).download_owned(
+                _row(), tmp_path / "backup.tar.gz"
+            )
+
+        assert not list(tmp_path.iterdir())
+
+    def test_normalizes_failed_downloads_without_retaining_partial_bytes(
+        self, tmp_path: Path
+    ) -> None:
+        class FailingBackend(_Backend):
+            def stream_chunks(self, _key: str):
+                yield b"arc"
+                raise OSError("endpoint included example-secret")
+
+        path = tmp_path / "backup.tar.gz"
+        with pytest.raises(
+            BackupDestinationError, match="^backup_remote_read_failed$"
+        ) as failure:
+            _destination(FailingBackend()).download_owned(_row(), path)
+
+        assert "example-secret" not in str(failure.value)
+        assert not path.exists()
+
+    def test_never_removes_a_preexisting_download_destination(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "backup.tar.gz"
+        path.write_bytes(b"existing")
+
+        with pytest.raises(BackupDestinationError, match="backup_remote_read_failed"):
+            _destination(_Backend()).download_owned(_row(), path)
+
+        assert path.read_bytes() == b"existing"
+
+    def test_stops_an_oversized_archive_download(self, tmp_path: Path) -> None:
+        class OversizedBackend(_Backend):
+            def stream_chunks(self, _key: str):
+                yield b"too many bytes"
+                pytest.fail("oversized stream must not be drained")
+
+        path = tmp_path / "backup.tar.gz"
+        with pytest.raises(
+            BackupDestinationError, match="backup_download_digest_mismatch"
+        ):
+            _destination(OversizedBackend()).download_owned(_row(), path)
+
+        assert not path.exists()
+
     def test_requires_verified_ownership(self, tmp_path: Path) -> None:
         destination = _destination(_Backend())
         output = tmp_path / "backup.tar.gz"
@@ -154,8 +210,16 @@ class TestProbe:
             "versioned_delete": False,
         }
 
-    def test_reports_a_remote_connection_failure(self) -> None:
-        destination = _destination(_Backend(check_error=RuntimeError("oauth rejected")))
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RuntimeError("oauth rejected"),
+            TimeoutError("example-secret"),
+            ConnectionError("example-secret"),
+        ],
+    )
+    def test_reports_a_remote_connection_failure(self, error: Exception) -> None:
+        destination = _destination(_Backend(check_error=error))
 
         with pytest.raises(
             BackupDestinationError, match="storage_connection_probe_failed"

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -242,8 +242,8 @@ same release has been exercised on the named public service or appliance.
 | Other S3-compatible services (MinIO, R2, B2, Wasabi, NAS object stores) | Managed, read-only source and backup destination | Native managed-storage contract plus OpenDAL source/replica tests; separate MinIO migration test | No complete public-service matrix | Beta compatibility; configure exact region, endpoint and address style |
 | Nextcloud WebDAV | Managed and read-only source | Real Nextcloud contract through the production OpenDAL adapter, including paged source discovery | Containerized contract service | Protocol-contract validated; appliance deployment remains beta |
 | Generic WebDAV | Managed and read-only source | Nextcloud contract plus adapter edge cases | No server matrix | Beta protocol compatibility |
-| OpenSSH SFTP | Managed and read-only source | Real OpenSSH contract through the production adapter, including host-key rejection and paged source discovery | Containerized contract service | Protocol-contract validated |
-| NAS SFTP | Managed and read-only source | OpenSSH protocol contract | No model/firmware matrix | Beta protocol compatibility; pinned host key required |
+| OpenSSH SFTP | Managed, read-only source and backup destination | Real OpenSSH contract through the production adapter; remote-only API backup probe, listing, verification and byte-matching restore | Containerized contract service | Protocol-contract validated |
+| NAS SFTP | Managed, read-only source and backup destination | OpenSSH protocol contract | No model/firmware matrix | Beta protocol compatibility; pinned host key required |
 | Google Drive | Read-only source and backup destination | OpenDAL configuration, discovery, hash-verified restore and fail-closed retention tests | No live Google account validation | Beta; automatic remote retention and Vault-GC witness are disabled |
 | Unraid, Synology DSM, TrueNAS SCALE, OpenMediaVault, QNAP QTS/QuTS, CasaOS/ZimaOS, Proxmox VE | Mounted source or host for a remote profile | The interface contracts above | No complete appliance validation rows | Installation recipes, not certification |
 


### PR DESCRIPTION
## Summary

SFTP backup profiles failed capability probing and could not reopen a published archive for manifest listing. Supply the adapter's supported operations and a context-managed streaming reader backed by bounded chunks. Listing releases the reader after the manifest instead of draining the archive.

Remote metadata and download failures now produce stable application errors. Failed or oversized downloads remove only their newly created temporary file; an existing destination remains untouched.

## Validation

- 173 focused remote-storage and backup tests passed; Ruff and Pyright passed.
- Real loopback WebDAV/SFTP contracts: 18 passed.
- Real S3/OpenSSH API recovery flows: 2 passed. Each probes, creates, lists, verifies, deletes the original Artifact, restores the remote-only archive and compares bytes.
- Reader regressions initially failed with the missing `open` method; the successful-auth probe contract initially failed with the missing capability method.
- All CI gates pass, including the full backend regression/coverage, Ruff/Pyright, real-backend browser tests, and final full/lite images on amd64 and arm64. No schema changes. The first backend attempt encountered a registry rate limit while pulling the pinned OpenSSH image; the rerun passed.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | probes an SFTP backup through the production factory | Happy | Pinned host, valid password | Supported read/write/exclusive-create; versioned deletion unavailable | Contract | ✅ TestOpenDALStorageBackend.test_sftp_backup_probe_uses_the_production_factory[contract-secret] |
| 2 | normalizes rejected SFTP authentication | Error | Incorrect password | Stable probe error without credential | Contract | ✅ TestOpenDALStorageBackend.test_sftp_backup_probe_uses_the_production_factory[incorrect-secret] |
| 3 | reads manifests without draining archives | Edge | Consumer stops after a short prefix | Remaining chunks untouched; connection and loop closed | Unit | ✅ TestStreamChunks.test_reader_leaves_unconsumed_archive_bytes_remote |
| 4 | preserves bytes across streaming boundaries | Happy | Partial reads followed by EOF | Complete bytes in order; resources closed | Unit | ✅ TestStreamChunks.test_reader_reaches_eof_without_losing_chunk_boundaries |
| 5 | normalizes reader failures | Error | Read or cleanup fails | Stable read error; acquired resources close | Unit | ✅ TestStreamChunks.test_reader_normalizes_transport_failures; TestStreamChunks.test_reader_normalizes_cleanup_failures |
| 6 | refuses unsupported reader modes | Error | Write mode requested | Refused before connecting | Unit | ✅ TestStreamChunks.test_reader_rejects_a_write_mode_without_connecting |
| 7 | removes partial failed downloads | Error | Transport raises after bytes arrive | Stable error; temporary file removed | Unit | ✅ TestDownloadOwned.test_normalizes_failed_downloads_without_retaining_partial_bytes |
| 8 | preserves existing download destinations | Edge | Destination already exists | Existing bytes unchanged | Unit | ✅ TestDownloadOwned.test_never_removes_a_preexisting_download_destination |
| 9 | bounds oversized archive downloads | Error | Stream exceeds owned size | Stops reading; temporary file removed | Unit | ✅ TestDownloadOwned.test_stops_an_oversized_archive_download |
| 10 | normalizes metadata failures | Error | Remote stat fails | Stable error; no temporary file | Unit | ✅ TestDownloadOwned.test_normalizes_remote_metadata_failures |
| 11 | normalizes unavailable or timed-out probes | Error | Timeout/connection error | Stable application error | Unit | ✅ TestProbe.test_reports_a_remote_connection_failure |
| 12 | recovers an SFTP-only backup through the API | Happy | Real OpenSSH service; no local archive | Listed and verified source restores identical Artifact bytes | E2E | ✅ TestRemoteBackup.test_remote_only_backup_restores_through_the_public_api[sftp] |
| 13 | preserves S3-only recovery | Happy | Real S3-compatible service | Identical API recovery flow succeeds | E2E | ✅ TestRemoteBackup.test_remote_only_backup_restores_through_the_public_api[s3] |

Exclusive SFTP creation prevents overwrite; this change does not claim immutable-version deletion or atomic visible publication. Provider maturity remains unchanged.
