### PR TITLE
fix: preserve backups when exact deletion is unsupported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Backup deletion refuses destinations without an exact owned-object deletion operation, including manually confirmed requests. Unsupported retention keeps replicas and ownership evidence intact without repeated provider-error warnings. Mutable S3 null versions use conditional ETags.
+
 - SFTP backup profiles can probe, list, verify and restore remote-only archives.
   Manifest reads stream through bounded buffers and close their remote handles
   on early exit; failed downloads remove their temporary bytes.

--- a/backend/app/api/v1/backup.py
+++ b/backend/app/api/v1/backup.py
@@ -419,14 +419,15 @@ def download_backup(
 def delete_backup(backup_id: str, source_ref: str | None = None) -> dict:
     try:
         deleted = (
-            backup.delete_backup(backup_id, allow_unversioned=True)
+            backup.delete_backup(backup_id)
             if source_ref is None
             else backup.delete_backup(
                 backup_id,
                 source_ref=source_ref,
-                allow_unversioned=True,
             )
         )
+    except backup.BackupDeleteUnsupportedError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     except backup.BackupOwnershipError as exc:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/backend/app/services/backup.py
+++ b/backend/app/services/backup.py
@@ -103,6 +103,13 @@ class BackupOwnershipError(RuntimeError):
     """A backup target lacks current operation-level ownership proof."""
 
 
+class BackupDeleteUnsupportedError(BackupOwnershipError):
+    """The destination has no safe deletion operation for this owned copy."""
+
+    def __init__(self) -> None:
+        super().__init__("backup_exact_delete_unsupported")
+
+
 class _BackupConfigUnstableError(RuntimeError):
     """Settings changed during a target snapshot; retry the next operation."""
 
@@ -612,7 +619,7 @@ def _s3_object_kwargs(
     unconditional delete after a check-then-delete race.
     """
     kwargs: dict[str, str] = {"Bucket": bucket, "Key": key}
-    if row.version_id:
+    if row.version_id and row.version_id != "null":
         kwargs["VersionId"] = row.version_id
     elif row.etag:
         kwargs["IfMatch"] = row.etag
@@ -653,7 +660,7 @@ def _s3_identity_kwargs(*, bucket: str, key: str, response: dict) -> dict[str, s
     """Build a conditional locator from a just-captured S3 identity."""
     version_id = response.get("VersionId")
     etag = response.get("ETag")
-    if version_id:
+    if version_id and version_id != "null":
         return {"Bucket": bucket, "Key": key, "VersionId": str(version_id)}
     if etag:
         return {"Bucket": bucket, "Key": key, "IfMatch": str(etag)}
@@ -2639,11 +2646,7 @@ def _require_backup_archive_owned(
                 try:
                     if backend.creation_matches(receipt):
                         return row
-                    if (
-                        row.sha256 is None
-                        or row.device is None
-                        or row.inode is None
-                    ):
+                    if row.sha256 is None or row.device is None or row.inode is None:
                         continue
                     refreshed = backend.adopt_existing(
                         row.key,
@@ -3119,7 +3122,6 @@ def delete_backup(
     backup_id: str,
     *,
     source_ref: str | None = None,
-    allow_unversioned: bool = False,
 ) -> bool:
     """Delete exactly the source authorized by ``source_ref``."""
     meta = get_backup(backup_id, source_ref=source_ref)
@@ -3141,10 +3143,10 @@ def delete_backup(
         elif meta.location.startswith("opendal:"):
             owned = _require_backup_archive_owned(meta)
             destination = destination_for_ownership(owned)
-            if destination is None or not destination.delete_owned(
-                owned, allow_unversioned=allow_unversioned
-            ):
-                raise BackupOwnershipError("backup_remote_delete_unverified")
+            if destination is None:
+                raise BackupOwnershipError("backup_storage_ownership_unverified")
+            if not destination.delete_owned(owned):
+                raise BackupDeleteUnsupportedError()
             session.delete(owned)
             deleted = True
         else:
@@ -5114,6 +5116,10 @@ def purge_old_backups(retain_days: int | None = None) -> int:
             if created < cutoff:
                 if delete_backup(meta.id, source_ref=meta.source_ref):
                     removed += 1
+        except BackupDeleteUnsupportedError:
+            # Unsupported retention is a stable capability result shown with
+            # the source. It is not a recurring provider failure.
+            continue
         except Exception as exc:
             # Retention is best effort per exact source.  A stale credential,
             # provider outage, or ownership conflict must never make us probe

--- a/backend/app/services/backup_destination.py
+++ b/backend/app/services/backup_destination.py
@@ -152,26 +152,16 @@ class RemoteBackupDestination:
                 raise
             raise BackupDestinationError("backup_remote_read_failed") from exc
 
-    def delete_owned(
-        self, row: OwnedStorageObject, *, allow_unversioned: bool = False
-    ) -> bool:
+    def delete_owned(self, row: OwnedStorageObject) -> bool:
         """Delete only through an immutable version identity.
 
         Consumer-cloud and WebDAV transports deliberately return ``False``;
         their path-only delete can race a replacement and is therefore never
         used by automatic retention.
         """
+        if not row.version_id or row.version_id == "null":
+            return False
         self.require_owned(row)
-        if not row.version_id:
-            if not allow_unversioned:
-                return False
-            assert row.size_bytes is not None
-            self.backend.delete_owned_unversioned(
-                row.key,
-                expected_size=row.size_bytes,
-                expected_etag=row.etag,
-            )
-            return True
         try:
             self.backend.delete_versioned(row.key, row.version_id)
         except StorageConfigurationError:

--- a/backend/app/services/storage_opendal.py
+++ b/backend/app/services/storage_opendal.py
@@ -420,29 +420,13 @@ class OpenDALStorageBackend(StorageBackend):
         return self._operator.open(self._relative(key), "rb")
 
     def delete_versioned(self, key: str, version_id: str) -> None:
-        if not getattr(self.operator_capabilities, "delete_with_version", False):
+        if (
+            not version_id
+            or version_id == "null"
+            or not getattr(self.operator_capabilities, "delete_with_version", False)
+        ):
             raise StorageConfigurationError("conditional_delete_unavailable")
         self._operator.delete(self._relative(key), version=version_id)
-
-    def delete_owned_unversioned(
-        self,
-        key: str,
-        *,
-        expected_size: int,
-        expected_etag: str | None,
-    ) -> None:
-        """Delete one explicitly confirmed object after a last identity check."""
-        relative = self._relative(key)
-        info = self.object_info(key)
-        if (
-            info is None
-            or info.size != expected_size
-            or (expected_etag is not None and info.etag != expected_etag)
-        ):
-            raise StorageConfigurationError("remote_object_identity_changed")
-        self._operator.delete(relative)
-        if self._operator.exists(relative):
-            raise StorageConfigurationError("remote_object_delete_failed")
 
     def stream_chunks(
         self,

--- a/backend/tests/contract/services/test_storage_opendal.py
+++ b/backend/tests/contract/services/test_storage_opendal.py
@@ -7,6 +7,7 @@ protocol servers rather than mocks.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import shutil
 import socket
@@ -20,7 +21,13 @@ import asyncssh
 import opendal
 import pytest
 
-from app.db.models import LibrarySourceKind, StorageConnection, StorageConnectionPurpose
+from app.db.models import (
+    LibrarySourceKind,
+    OwnedStorageObject,
+    StorageConnection,
+    StorageConnectionPurpose,
+    StorageObjectState,
+)
 from app.services.backup_destination import (
     BackupDestinationError,
     destination_from_connection,
@@ -285,6 +292,79 @@ class _RenameFailure:
 
 
 class TestOpenDALStorageBackend:
+    @pytest.mark.parametrize("provider", ["sftp", "webdav"])
+    @pytest.mark.parametrize("replacement", [False, True])
+    def test_unversioned_replica_deletion_preserves_real_server_bytes(
+        self, request, tmp_path: Path, provider: str, replacement: bool
+    ) -> None:
+        if provider == "sftp":
+            port, known_hosts = request.getfixturevalue("sftp_password_endpoint")
+            config = {
+                "provider": "sftp",
+                "host": "127.0.0.1",
+                "port": port,
+                "username": "printstash",
+                "host_key": str(known_hosts),
+                "root": "vault-data",
+            }
+            secrets = {"password": "contract-secret"}
+            remote_file = (
+                tmp_path
+                / "password-server/vault-data/printstash-backups/archive.tar.gz"
+            )
+        else:
+            endpoint = request.getfixturevalue("webdav_endpoint")
+            config = {
+                "provider": "webdav",
+                "endpoint_url": endpoint,
+                "username": "webdav-user",
+                "root": "vault-data",
+            }
+            secrets = {"password": "webdav-password"}
+            remote_file = (
+                tmp_path / "storage/vault-data/printstash-backups/archive.tar.gz"
+            )
+        profile = StorageConnection(
+            id=7,
+            name="Archive",
+            kind=LibrarySourceKind(provider),
+            purpose=StorageConnectionPurpose.BACKUP,
+            config_json=json.dumps(config),
+            secret_json=json.dumps(secrets),
+        )
+        destination = destination_from_connection(profile)
+        if provider == "sftp":
+            destination.backend.provision_root()
+        key = destination.key("archive.tar.gz")
+        payload = b"original-archive"
+        receipt = destination.backend.create_bytes(payload, key)
+        info = destination.backend.object_info(key)
+        assert info is not None
+        row = OwnedStorageObject(
+            backend=destination.backend.backend_name,
+            namespace=destination.namespace,
+            key=key,
+            provider_ref=destination.provider_ref,
+            token=receipt.token,
+            object_kind="backup",
+            state=StorageObjectState.COMMITTED,
+            size_bytes=len(payload),
+            sha256=hashlib.sha256(payload).hexdigest(),
+            etag=info.etag,
+            version_id=info.version_id,
+        )
+        expected = b"replaced-archive" if replacement else payload
+        assert len(expected) == len(payload)
+        if replacement:
+            remote_file.write_bytes(expected)
+
+        assert destination.delete_owned(row) is False
+
+        assert remote_file.read_bytes() == expected
+        assert destination.backend.read_bytes(key) == expected
+        assert row.token == receipt.token
+        assert row.state == StorageObjectState.COMMITTED
+
     @pytest.mark.parametrize("password", ["contract-secret", "incorrect-secret"])
     def test_sftp_backup_probe_uses_the_production_factory(
         self, sftp_password_endpoint, password: str

--- a/backend/tests/integration/api/v1/test_backup.py
+++ b/backend/tests/integration/api/v1/test_backup.py
@@ -15,9 +15,11 @@ restore actually recovers live in `integration/services/backup/test_core.py`.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from fastapi import BackgroundTasks, HTTPException
@@ -26,6 +28,10 @@ from fastapi.testclient import TestClient
 import app.services.backup as backup
 import app.services.storage_backend as storage_backend
 from app.api.v1 import backup as backup_api
+from app.db.models import OwnedStorageObject
+from app.services.backup_destination import RemoteBackupDestination
+from app.services.storage_backend import StorageObjectInfo
+from tests.factories import build_owned_storage_object
 from tests.integration._backup_harness import (
     BackupEnv,
     backup_admin_headers,
@@ -789,6 +795,84 @@ class TestVerifyBackup:
 
 
 class TestDeleteBackup:
+    @pytest.mark.parametrize("replacement", [False, True])
+    def test_manual_confirmation_cannot_delete_an_unversioned_replica(
+        self,
+        client: TestClient,
+        backup_env: BackupEnv,
+        admin_headers,
+        monkeypatch,
+        tmp_path: Path,
+        replacement: bool,
+    ) -> None:
+        remote_bytes = tmp_path / "remote-archive"
+        original = b"backup1"
+        remote_bytes.write_bytes(b"backup2" if replacement else original)
+        key = "sftp/root/printstash-backups/archive.tar.gz"
+
+        class UnversionedStorage:
+            backend_name = "backup-opendal-sftp"
+            source_namespace = "sftp/root"
+            operator_capabilities = SimpleNamespace(delete_with_version=False)
+
+            def object_info(self, requested):
+                assert requested == key
+                return StorageObjectInfo(size=remote_bytes.stat().st_size)
+
+            def delete_owned_unversioned(self, requested, **_kwargs):
+                assert requested == key
+                remote_bytes.unlink()
+
+        destination = RemoteBackupDestination(
+            1, "SFTP backup", "sftp", UnversionedStorage(), "provider"
+        )  # type: ignore[arg-type]
+        with backup_env.new_session() as session:
+            row = build_owned_storage_object(
+                session,
+                backend="backup-opendal-sftp",
+                namespace="sftp/root",
+                key=key,
+                object_kind="backup",
+                provider_ref="provider",
+                sha256=hashlib.sha256(original).hexdigest(),
+                size_bytes=len(original),
+            )
+            row_id, token = row.id, row.token
+        meta = backup.BackupMeta(
+            id="archive",
+            created_at="2026-01-01T00:00:00+00:00",
+            size_bytes=len(original),
+            storage_backend="local",
+            file_count=0,
+            app_version="0.13.0",
+            path=key,
+            location="opendal:sftp",
+            provider_ref="provider",
+            namespace="sftp/root",
+            source_ref="exact-source",
+        )
+        monkeypatch.setattr(backup, "get_backup", lambda *_a, **_k: meta)
+        monkeypatch.setattr(backup, "destination_for_ownership", lambda _: destination)
+
+        response = client.delete(
+            "/api/v1/backups/archive",
+            headers=admin_headers,
+            params={
+                "source_ref": "exact-source",
+                "confirm_storage_risk": "true",
+                "allow_unversioned": "true",
+            },
+        )
+
+        assert response.status_code == 409, response.text
+        assert response.json()["detail"] == "backup_exact_delete_unsupported"
+        assert remote_bytes.read_bytes() == (b"backup2" if replacement else original)
+        with backup_env.new_session() as session:
+            retained = session.get(OwnedStorageObject, row_id)
+            assert retained is not None and retained.token == token
+            assert retained.provider_ref == "provider"
+            assert retained.sha256 == hashlib.sha256(original).hexdigest()
+
     def test_reports_the_deletion(
         self, client: TestClient, admin_headers: dict[str, str], a_backup
     ) -> None:
@@ -872,7 +956,7 @@ class TestDeleteBackup:
         assert response.status_code == 200, response.text
         assert observed == {
             "source_ref": "exact-source",
-            "allow_unversioned": True,
+            "allow_unversioned": False,
         }
 
     def test_maps_source_identity_conflict_to_http_conflict(

--- a/backend/tests/integration/services/backup/test_core.py
+++ b/backend/tests/integration/services/backup/test_core.py
@@ -1977,7 +1977,7 @@ class TestDeleteBackup:
         )
 
         with pytest.raises(
-            backup.BackupOwnershipError, match="backup_remote_delete_unverified"
+            backup.BackupDeleteUnsupportedError, match="backup_exact_delete_unsupported"
         ):
             backup.delete_backup(meta.id)
 
@@ -4865,6 +4865,37 @@ class TestRestoreDatabase:
 
 
 class TestPurgeOldBackups:
+    def test_retention_treats_unsupported_deletion_as_steady_state(
+        self, backup_env: BackupEnv, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        sources = [
+            backup.BackupMeta(
+                id=identity,
+                created_at="2020-01-01T00:00:00+00:00",
+                size_bytes=1,
+                storage_backend="local",
+                file_count=0,
+                app_version="0.13.0",
+                path=identity,
+                source_ref=identity,
+            )
+            for identity in ("unsupported", "deletable")
+        ]
+        attempted = []
+
+        def delete(identity, *, source_ref):
+            attempted.append(source_ref)
+            if identity == "unsupported":
+                raise backup.BackupDeleteUnsupportedError()
+            return True
+
+        monkeypatch.setattr(backup, "list_backup_sources", lambda: sources)
+        monkeypatch.setattr(backup, "delete_backup", delete)
+        assert backup.purge_old_backups(30) == 1
+        assert backup.purge_old_backups(30) == 1
+        assert attempted == ["unsupported", "deletable", "unsupported", "deletable"]
+        assert "could not be removed" not in caplog.text
+
     def test_purge_old_backups_noop_when_retention_non_positive(
         self, backup_env: BackupEnv
     ):

--- a/backend/tests/unit/services/storage_opendal/test_backend.py
+++ b/backend/tests/unit/services/storage_opendal/test_backend.py
@@ -399,37 +399,38 @@ class TestOpenDALStorageBackend:
         assert operator.objects["thumbs/45.webp"] == b""
         assert receipt.size == 0
 
-    def test_explicitly_deletes_an_unversioned_owned_object(self) -> None:
+    @pytest.mark.parametrize("version", ["", "null"])
+    def test_mutable_version_cannot_delete_a_replacement(self, version: str) -> None:
         operator = _MemoryOperator()
-        backend = storage_opendal.OpenDALStorageBackend(
-            _spec(TransportKind.GDRIVE), operator=operator
-        )
-        key = backend.thumbnail_key(43)
-        operator.objects["thumbs/43.webp"] = b"owned"
-
-        backend.delete_owned_unversioned(
-            key,
-            expected_size=5,
-            expected_etag="etag:thumbs/43.webp",
-        )
-
-        assert not backend.exists(key)
-
-    def test_refuses_to_delete_a_changed_unversioned_object(self) -> None:
-        operator = _MemoryOperator()
-        backend = storage_opendal.OpenDALStorageBackend(
-            _spec(TransportKind.GDRIVE), operator=operator
-        )
+        backend = storage_opendal.OpenDALStorageBackend(_spec(), operator=operator)
         key = backend.thumbnail_key(44)
         operator.objects["thumbs/44.webp"] = b"replacement"
 
-        with pytest.raises(StorageConfigurationError, match="identity_changed"):
-            backend.delete_owned_unversioned(
-                key,
-                expected_size=5,
-                expected_etag="old-etag",
-            )
+        with pytest.raises(
+            StorageConfigurationError, match="conditional_delete_unavailable"
+        ):
+            backend.delete_versioned(key, version)
 
+        assert backend.read_bytes(key) == b"replacement"
+
+    def test_delete_targets_only_the_owned_immutable_version(self) -> None:
+        class VersionedOperator(_MemoryOperator):
+            calls = []
+
+            def capability(self):
+                return SimpleNamespace(delete_with_version=True)
+
+            def delete(self, key, *, version):
+                self.calls.append((key, version))
+
+        operator = VersionedOperator()
+        backend = storage_opendal.OpenDALStorageBackend(_spec(), operator=operator)
+        key = backend.thumbnail_key(44)
+        operator.objects["thumbs/44.webp"] = b"replacement"
+
+        backend.delete_versioned(key, "owned-version")
+
+        assert operator.calls == [("thumbs/44.webp", "owned-version")]
         assert backend.read_bytes(key) == b"replacement"
 
     def test_uses_a_stream_writer_when_the_operator_exposes_one(self) -> None:

--- a/backend/tests/unit/services/test_backup.py
+++ b/backend/tests/unit/services/test_backup.py
@@ -1846,6 +1846,7 @@ class TestBackupStorageHelpers:
         [
             ("version-7", '"etag-7"', {"VersionId": "version-7"}),
             (None, '"etag-7"', {"IfMatch": '"etag-7"'}),
+            ("null", '"etag-7"', {"IfMatch": '"etag-7"'}),
         ],
     )
     def test_remote_operations_use_exact_version_or_conditional_etag(
@@ -1869,6 +1870,28 @@ class TestBackupStorageHelpers:
             "Key": row.key,
             **expected,
         }
+
+    @pytest.mark.parametrize("version_id", [None, "null"])
+    def test_captured_mutable_s3_identity_uses_conditional_etag(
+        self, version_id: str | None
+    ) -> None:
+        response = {"VersionId": version_id, "ETag": '"original"'}
+        assert backup._s3_identity_kwargs(
+            bucket="bucket-a", key="archive.tar.gz", response=response
+        ) == {"Bucket": "bucket-a", "Key": "archive.tar.gz", "IfMatch": '"original"'}
+
+    @pytest.mark.parametrize("version_id", [None, "null"])
+    def test_captured_mutable_s3_identity_without_etag_is_rejected(
+        self, version_id: str | None
+    ) -> None:
+        with pytest.raises(
+            backup.BackupOwnershipError, match="remote_identity_unavailable"
+        ):
+            backup._s3_identity_kwargs(
+                bucket="bucket-a",
+                key="archive.tar.gz",
+                response={"VersionId": version_id},
+            )
 
     def test_remote_operation_without_stable_identity_fails_closed(self) -> None:
         row = backup.OwnedStorageObject(

--- a/backend/tests/unit/services/test_backup_destination.py
+++ b/backend/tests/unit/services/test_backup_destination.py
@@ -174,6 +174,21 @@ class TestDownloadOwned:
 
 
 class TestDeleteOwned:
+    def test_null_version_is_not_an_immutable_delete_identity(self) -> None:
+        row = _row()
+        row.version_id = "null"
+
+        class MutableVersionBackend(_Backend):
+            def delete_versioned(self, key, version):
+                assert version == "null"
+                self.deleted_keys.append(key)
+
+        backend = MutableVersionBackend()
+        backend.info = StorageObjectInfo(size=7, etag="etag", version_id="null")
+
+        assert _destination(backend).delete_owned(row) is False
+        assert backend.deleted_keys == []
+
     def test_retention_refuses_an_unversioned_backup(self) -> None:
         row = _row()
         backend = _Backend()
@@ -189,14 +204,12 @@ class TestDeleteOwned:
 
         assert _destination(backend).delete_owned(row) is False
 
-    def test_explicitly_deletes_an_owned_unversioned_backup(self) -> None:
-        row = _row()
-        backend = _Backend()
+    def test_unversioned_deletion_does_not_contact_the_provider(self) -> None:
+        class UnreachableBackend(_Backend):
+            def object_info(self, _key):
+                pytest.fail("unsupported deletion must not issue metadata requests")
 
-        deleted = _destination(backend).delete_owned(row, allow_unversioned=True)
-
-        assert deleted is True
-        assert backend.deleted_keys == [row.key]
+        assert _destination(UnreachableBackend()).delete_owned(_row()) is False
 
 
 class TestProbe:

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -302,3 +302,10 @@ filesystem, protocol, auth mode and the release-validation checklist result.
 | Nextcloud contract container | Pinned CI image | WebDAV | 2026-08-31 | Automated contract | Pass | Production OpenDAL adapter, including discovery cursor |
 | OpenSSH contract container | Pinned CI image | SFTP | 2026-08-31 | Automated contract | Pass | Production adapter and pinned-host-key rejection |
 | _(no physical NAS validation yet)_ | | | | | | |
+
+
+### Backup deletion and retention
+
+Backup recovery and backup deletion have separate requirements. An archive can remain listable and recoverable while its destination cannot safely delete its exact owned object. Such deletion requests return `409 backup_exact_delete_unsupported`, even when the administrator confirms storage risk. Bytes and ownership evidence remain intact.
+
+OpenDAL backup destinations require an immutable object version and compiled version-deletion support. Empty and S3 `null` versions are mutable and do not qualify. Native S3 backups continue to use an immutable version or a conditional ETag; they never substitute an unconditional delete. Automatic retention leaves unsupported replicas in place without repeating provider-error warnings. The backup operation explanation remains visible until the destination supports safe deletion.


### PR DESCRIPTION
## Summary

Manually confirmed deletion could remove an unversioned remote backup after a metadata check, including an equal-size replacement. Remove that override and return `409 backup_exact_delete_unsupported` when the exact owned object cannot be deleted safely. Preserve bytes and ownership records; automatic retention treats unsupported deletion as a steady state instead of emitting repeated provider-error warnings.

Empty and S3 `null` versions are mutable. OpenDAL requires a real immutable version plus version-deletion support. Native S3 uses a conditional ETag when an immutable version is absent.

## Validation

- The two manual-confirmation API regressions, null-version deletion case and native null-version locator case failed before their fixes.
- 2,402 focused ownership, backup, retention, real S3/SFTP/WebDAV and test-hygiene checks passed. The full backup API suite passed (64 cases). Ruff and Pyright passed.
- All CI gates passed on the final rebased commit, including backend full/coverage, both image architectures, frontend and real-backend E2E. Another 178 focused checks passed after rebasing onto main.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | refuses unsafe manual deletion | Error | Confirmed original or equal-size replacement, legacy override parameter | Stable 409, unchanged bytes and ownership | Integration | ✅ test_manual_confirmation_cannot_delete_an_unversioned_replica |
| 2 | avoids unsupported provider deletion | Edge | No immutable version | No provider call | Unit | ✅ test_unversioned_deletion_does_not_contact_the_provider |
| 3 | rejects mutable version identity | Error | Null or empty version | Replacement remains | Unit | ✅ test_mutable_version_cannot_delete_a_replacement; test_null_version_is_not_an_immutable_delete_identity |
| 4 | deletes only the owned version | Happy | Immutable original and current replacement | Original version removed, replacement remains | Unit | ✅ test_delete_targets_only_the_owned_immutable_version |
| 5 | preserves real remote replicas | Error | SFTP/WebDAV original or equal-size replacement | Real server bytes unchanged | Contract | ✅ test_unversioned_replica_deletion_preserves_real_server_bytes |
| 6 | keeps unsupported retention quiet | Edge | Repeated retention runs | Unsupported replica retained, supported work continues, no recurring warning | Integration | ✅ test_retention_treats_unsupported_deletion_as_steady_state |
| 7 | binds native S3 operations | Edge | Immutable, absent or null version | Version or conditional ETag is used | Unit | ✅ test_remote_operations_use_exact_version_or_conditional_etag; test_captured_mutable_s3_identity_uses_conditional_etag |
| 8 | refuses unprovable native identity | Error | Mutable version without ETag | Ownership conflict before remote operation | Unit | ✅ test_captured_mutable_s3_identity_without_etag_is_rejected |
