### PR TITLE
feat: support independent OpenDAL S3 GC witnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Backup deletion refuses destinations without an exact owned-object deletion operation, including manually confirmed requests. Unsupported retention keeps replicas and ownership evidence intact without repeated provider-error warnings. Mutable S3 null versions use conditional ETags.
+- Verified OpenDAL S3 backup replicas can now witness GC when current target and failure-domain evidence proves independence. Approval and finalization remain bound to the exact owned archive and quarantine deadline.
 
 - SFTP backup profiles can probe, list, verify and restore remote-only archives.
   Manifest reads stream through bounded buffers and close their remote handles

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,6 +119,8 @@ restore generation, target identity and failure-domain evidence, backup and quar
 The exact archive id, source reference, provider identity and digest of a fully
 verified, application-compatible S3 backup created in the previous 24 hours,
 with current evidence of a failure domain independent of active Vault storage.
+Native S3 and OpenDAL S3 replicas can supply the witness; the source is resolved
+against current configuration and committed ownership before full verification.
 
 ### Storage
 

--- a/backend/app/services/backup_capabilities.py
+++ b/backend/app/services/backup_capabilities.py
@@ -47,7 +47,7 @@ def backup_operations(meta: BackupMeta) -> dict[str, dict]:
                     )
                 )
     gc_reason = "storage_gc_witness_unsupported"
-    if meta.location == "s3":
+    if meta.location in {"s3", "opendal:s3"}:
         from app.services.gc_planner import _source_identity_evidence
 
         gc_reason = (

--- a/backend/app/services/gc_planner.py
+++ b/backend/app/services/gc_planner.py
@@ -31,7 +31,9 @@ from app.db.models import (
     Model,
     ModelProvenanceSource,
     ModelSourceCover,
+    OwnedStorageObject,
     RestoreMarker,
+    StorageObjectState,
 )
 from app.db.scopes import trashed
 from app.db.session import get_session_factory
@@ -336,7 +338,7 @@ def find_backup_witness() -> BackupWitness | None:
         if (
             created_at is None
             or now - created_at > _BACKUP_MAX_AGE
-            or meta.location != "s3"
+            or meta.location not in {"s3", "opendal:s3"}
             or not meta.source_ref
             or not meta.provider_ref
             or meta.provider_ref == active
@@ -366,14 +368,47 @@ def find_backup_witness() -> BackupWitness | None:
 def _source_identity_evidence(meta) -> tuple[dict, dict] | None:
     from app.services import backup
 
-    target = backup._get_backup_s3_target()
-    if (
-        target is None
-        or meta.location != "s3"
-        or target.provider_ref != meta.provider_ref
-    ):
+    if meta.location == "s3":
+        target = backup._get_backup_s3_target()
+        if target is None or target.provider_ref != meta.provider_ref:
+            return None
+        storage_target = target.storage_target
+    elif meta.location == "opendal:s3":
+        from app.services.backup_destination import destination_for_ownership
+
+        if meta.source_ref != backup._source_ref(
+            location=meta.location,
+            namespace=meta.namespace,
+            path=meta.path,
+            provider_ref=meta.provider_ref,
+        ):
+            return None
+        with get_session_factory().scoped_session() as session:
+            row = session.exec(
+                select(OwnedStorageObject).where(
+                    OwnedStorageObject.provider_ref == meta.provider_ref,
+                    OwnedStorageObject.namespace == meta.namespace,
+                    OwnedStorageObject.key == meta.path,
+                    OwnedStorageObject.object_kind.in_(("backup", "backup-legacy")),
+                    OwnedStorageObject.state == StorageObjectState.COMMITTED,
+                )
+            ).first()
+            if (
+                row is None
+                or not row.token
+                or not row.sha256
+                or row.sha256 != meta.archive_sha256
+            ):
+                return None
+            destination = destination_for_ownership(row)
+            if destination is None:
+                return None
+            storage_target = destination.backend.storage_target
+        if storage_target is None or storage_target.transport != "s3":
+            return None
+    else:
         return None
-    return independent_evidence(get_backend().storage_target, target.storage_target)
+    return independent_evidence(get_backend().storage_target, storage_target)
 
 
 def _serialize_evidence(evidence: dict) -> str:
@@ -481,7 +516,7 @@ def _reverify_backup(run: GcRun) -> None:
             and item.source_ref == run.backup_source_ref
             and item.provider_ref == run.backup_provider_ref
             and item.archive_sha256 == run.backup_archive_sha256
-            and item.location == "s3"
+            and item.location in {"s3", "opendal:s3"}
         ),
         None,
     )

--- a/backend/tests/containers.py
+++ b/backend/tests/containers.py
@@ -215,6 +215,14 @@ def _start_seaweedfs() -> str:
         )
     )
     _started.append(container)
+    # GC tests need the container's distinct network endpoint: a loopback
+    # backup is correctly considered shared with a local Vault. The test
+    # administrator still has to declare this simulated failure domain.
+    networks = container.get_wrapped_container().attrs["NetworkSettings"]["Networks"]
+    private_ip = next(
+        info["IPAddress"] for info in networks.values() if info["IPAddress"]
+    )
+    _resolved["s3_private"] = f"http://{private_ip}:{SEAWEEDFS_S3_PORT}"
     host = container.get_container_host_ip()
     port = container.get_exposed_port(SEAWEEDFS_S3_PORT)
     return f"http://{host}:{port}"
@@ -228,6 +236,14 @@ def postgres_url() -> str:
 def s3_endpoint() -> str:
     """A real S3-compatible endpoint URL. Raises when Docker is not running."""
     return _resolve("s3", S3_RESOURCE, _start_seaweedfs)
+
+
+def s3_private_endpoint() -> str:
+    """Direct Linux Docker bridge endpoint for declared-domain GC scenarios."""
+    s3_endpoint()
+    endpoint = _resolved["s3_private"]
+    assert endpoint is not None
+    return endpoint
 
 
 def _start_nextcloud() -> str:

--- a/backend/tests/e2e/test_opendal_gc.py
+++ b/backend/tests/e2e/test_opendal_gc.py
@@ -1,0 +1,177 @@
+"""An administrator-declared OpenDAL S3 replica witnesses the real GC API flow.
+
+The Docker network is a simulation of separately administered storage; the
+application resolves its real endpoint and requires the same explicit domain
+declaration used for custom production S3. No identity or backup verifier is stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import boto3
+import pytest
+from botocore.config import Config as BotoConfig
+from sqlmodel import select
+
+from app.core.config import settings
+from app.core.time import utcnow
+from app.db.models import File, GcRun, Model
+from tests.containers import S3_ACCESS_KEY, S3_SECRET_KEY, s3_private_endpoint
+from tests.paths import FIXTURES_DIR
+
+
+@pytest.fixture
+def independent_s3_bucket():
+    endpoint = s3_private_endpoint()
+    bucket = f"gc-witness-{uuid4().hex[:12]}"
+    client = boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        region_name="us-east-1",
+        aws_access_key_id=S3_ACCESS_KEY,
+        aws_secret_access_key=S3_SECRET_KEY,
+        config=BotoConfig(s3={"addressing_style": "path"}),
+    )
+    client.create_bucket(Bucket=bucket)
+    try:
+        yield endpoint, bucket, client
+    finally:
+        for page in client.get_paginator("list_objects_v2").paginate(Bucket=bucket):
+            for item in page.get("Contents", []):
+                client.delete_object(Bucket=bucket, Key=item["Key"])
+        client.delete_bucket(Bucket=bucket)
+
+
+class TestOpenDalGc:
+    @pytest.mark.s3
+    @pytest.mark.critical
+    @pytest.mark.asyncio
+    async def test_independent_s3_replica_authorizes_only_quarantined_gc_candidates(
+        self, api, superuser_headers, e2e_db, independent_s3_bucket
+    ) -> None:
+        endpoint, bucket, remote = independent_s3_bucket
+        headers = superuser_headers
+        configured = await api.put(
+            "/api/v1/config",
+            headers=headers,
+            json={"manual_local_backup_enabled": False, "trash_retention_days": 30},
+        )
+        assert configured.status_code == 200, configured.text
+        connection = await api.post(
+            "/api/v1/storage-connections",
+            headers=headers,
+            json={
+                "name": "GC remote backup",
+                "kind": "s3",
+                "purpose": "backup",
+                "configuration": {
+                    "provider": "s3_self_hosted",
+                    "bucket": bucket,
+                    "endpoint_url": endpoint,
+                    "region": "us-east-1",
+                    "root": "offsite",
+                    "addressing_style": "path",
+                },
+                "secrets": {"access_key": S3_ACCESS_KEY, "secret_key": S3_SECRET_KEY},
+            },
+        )
+        assert connection.status_code == 201, connection.text
+        payload = (FIXTURES_DIR / "sample.gcode").read_bytes()
+        uploaded = await api.post(
+            "/api/v1/ingest/orca",
+            headers=headers,
+            files={"file": ("sample.gcode", payload, "text/plain")},
+            data={"model_name": "GC candidate"},
+        )
+        assert uploaded.status_code == 202, uploaded.text
+        for _ in range(50):
+            job = (
+                await api.get(
+                    f"/api/v1/ingest/jobs/{uploaded.json()['job_id']}", headers=headers
+                )
+            ).json()
+            if job["state"] in {"completed", "failed", "duplicate"}:
+                break
+            await asyncio.sleep(0.05)
+        assert job["state"] == "completed", job
+        e2e_db.expire_all()
+        candidate = e2e_db.exec(select(Model).where(Model.name == "GC candidate")).one()
+        artifact = e2e_db.exec(select(File).where(File.model_id == candidate.id)).one()
+        candidate_id, artifact_id = candidate.id, artifact.id
+        untouched = Path(settings.data_dir) / "external-original.stl"
+        untouched.write_bytes(b"not owned by PrintStash")
+        created = await api.post("/api/v1/backups", headers=headers)
+        assert created.status_code == 202, created.text
+        archive = created.json()
+        assert archive["location"] == "opendal:s3"
+        assert not list(Path(settings.backup_dir).glob("*.tar.gz"))
+        assert (
+            await api.delete(f"/api/v1/models/{candidate_id}", headers=headers)
+        ).status_code == 204
+        e2e_db.expire_all()
+        candidate = e2e_db.get(Model, candidate_id)
+        candidate.deleted_at = utcnow() - timedelta(days=31)
+        e2e_db.add(candidate)
+        e2e_db.commit()
+        preview = await api.post("/api/v1/admin/gc", headers=headers)
+        assert preview.status_code == 200, preview.text
+        plan = preview.json()
+        assert plan["resource_count"] == 1
+        refused = await api.post(
+            f"/api/v1/admin/gc/{plan['id']}/approve",
+            headers=headers,
+            json={"digest": plan["digest"]},
+        )
+        assert refused.status_code == 409
+        assert refused.json()["detail"] == "gc_backup_required"
+        targets = (await api.get("/api/v1/storage/targets", headers=headers)).json()
+        target = next(item for item in targets if item["role"] == "backup")
+        declared = await api.put(
+            f"/api/v1/storage/targets/{target['target_ref']}/failure-domain",
+            headers=headers,
+            json={"failure_domain": "offsite-gc-test"},
+        )
+        assert declared.status_code == 200, declared.text
+        approved = await api.post(
+            f"/api/v1/admin/gc/{plan['id']}/approve",
+            headers=headers,
+            json={"digest": plan["digest"]},
+        )
+        assert approved.status_code == 200, approved.text
+        assert approved.json()["state"] == "quarantined"
+        assert approved.json()["backup_source_ref"] == archive["source_ref"]
+        assert approved.json()["backup_archive_sha256"] == archive["archive_sha256"]
+        premature = await api.post(
+            f"/api/v1/admin/gc/{plan['id']}/finalize", headers=headers
+        )
+        assert premature.status_code == 409
+        assert premature.json()["detail"] == "gc_quarantine_active"
+        e2e_db.expire_all()
+        assert e2e_db.get(File, artifact_id) is not None
+        # Advance the persisted quarantine deadline without changing the
+        # approved digest, identity evidence or any deletion implementation.
+        run = e2e_db.get(GcRun, plan["id"])
+        run.quarantine_until = utcnow() - timedelta(seconds=1)
+        e2e_db.add(run)
+        e2e_db.commit()
+        finalized = await api.post(
+            f"/api/v1/admin/gc/{plan['id']}/finalize", headers=headers
+        )
+        assert finalized.status_code == 200, finalized.text
+        assert finalized.json()["state"] == "completed"
+        e2e_db.expire_all()
+        assert e2e_db.get(Model, candidate_id) is None
+        assert e2e_db.get(File, artifact_id) is None
+        assert untouched.read_bytes() == b"not owned by PrintStash"
+        assert remote.list_objects_v2(Bucket=bucket)["KeyCount"] == 1
+        verified = await api.post(
+            f"/api/v1/backups/{archive['backup_id']}/verify",
+            headers=headers,
+            params={"source_ref": archive["source_ref"]},
+        )
+        assert verified.status_code == 200, verified.text
+        assert verified.json()["valid"] is True

--- a/backend/tests/integration/services/test_backup_capabilities.py
+++ b/backend/tests/integration/services/test_backup_capabilities.py
@@ -64,7 +64,7 @@ class TestBackupOperations:
         assert result["physical_delete"]["allowed"] is allowed
         assert result["automatic_retention"]["allowed"] is allowed
         assert not result["catalog_purge"]["allowed"]
-        assert result["gc_witness"]["reason"] == "storage_gc_witness_unsupported"
+        assert result["gc_witness"]["reason"] == "storage_independent_backup_required"
 
     @pytest.mark.parametrize(
         "missing", ["row", "token", "digest", "destination", "committed"]
@@ -128,13 +128,14 @@ class TestBackupOperations:
 
         assert result["physical_delete"]["allowed"] is allowed
 
-    def test_independent_native_backup_still_requires_gc_reverification(
-        self, db_session, monkeypatch
+    @pytest.mark.parametrize("location", ["s3", "opendal:s3"])
+    def test_independent_backup_still_requires_gc_reverification(
+        self, db_session, monkeypatch, location
     ):
         monkeypatch.setattr(
             "app.services.gc_planner._source_identity_evidence", lambda _: ({}, {})
         )
-        result = backup_capabilities.backup_operations(_meta("s3"))
+        result = backup_capabilities.backup_operations(_meta(location))
         assert result["gc_witness"] == {
             "allowed": False,
             "reason": "storage_gc_verification_required",

--- a/backend/tests/integration/services/test_gc_planner.py
+++ b/backend/tests/integration/services/test_gc_planner.py
@@ -1211,3 +1211,203 @@ class TestScheduledGc:
 
         assert result["gc_plan_id"] == run.id
         assert result["rows"] == (0 if finalize_fails else run.resource_count)
+
+
+class TestOpenDalS3Witness:
+    def _source(self, session, monkeypatch):
+        from app.services import backup_destination
+        from tests.factories import build_owned_storage_object
+
+        target = s3_target(endpoint="https://offsite.example.test", bucket="backups")
+        declaration = build_failure_domain_declaration(session, target)
+        row = build_owned_storage_object(
+            session,
+            backend="s3_self_hosted",
+            namespace="backups",
+            key="backups/archive.tar.gz",
+            object_kind="backup",
+            provider_ref="e" * 64,
+            sha256="b" * 64,
+            token="publication-token",
+        )
+        meta = backup.BackupMeta(
+            id="archive",
+            created_at=utcnow().isoformat(),
+            size_bytes=3,
+            storage_backend="local",
+            file_count=1,
+            app_version="0.13.0",
+            path=row.key,
+            location="opendal:s3",
+            archive_sha256=row.sha256,
+            provider_ref=row.provider_ref,
+            source_ref=backup._source_ref(
+                location="opendal:s3",
+                namespace=row.namespace,
+                path=row.key,
+                provider_ref=row.provider_ref,
+            ),
+            namespace=row.namespace,
+        )
+        destination = SimpleNamespace(backend=SimpleNamespace(storage_target=target))
+        monkeypatch.setattr(
+            backup_destination, "destination_for_ownership", lambda _: destination
+        )
+        monkeypatch.setattr(backup, "list_backup_sources", lambda: [meta])
+        verification = backup.BackupVerification("archive", True, True, "3", 1, [])
+        calls = []
+
+        def verify(backup_id, *, source_ref):
+            calls.append((backup_id, source_ref))
+            return verification
+
+        monkeypatch.setattr(backup, "verify_backup", verify)
+        return row, meta, declaration, destination, verification, calls
+
+    def test_independent_opendal_s3_archive_can_witness_gc(
+        self, db_session, monkeypatch
+    ):
+        _, meta, _, _, _, calls = self._source(db_session, monkeypatch)
+
+        witness = gc_planner.find_backup_witness()
+
+        assert witness is not None
+        assert witness.source_ref == meta.source_ref
+        assert witness.archive_sha256 == meta.archive_sha256
+        assert witness.backup_identity_evidence["target"]["container"] == "backups"
+        assert calls == [(meta.id, meta.source_ref)]
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            "domain",
+            "target",
+            "digest",
+            "token",
+            "destination",
+            "uncommitted",
+            "missing-row",
+            "missing-digest",
+            "missing-target",
+            "wrong-transport",
+            "source",
+            "transport",
+        ],
+    )
+    def test_unprovable_opendal_source_never_authorizes_gc(
+        self, db_session, monkeypatch, mutation
+    ):
+        from app.db.models import StorageObjectState
+        from app.services import backup_destination
+
+        row, meta, declaration, destination, _, calls = self._source(
+            db_session, monkeypatch
+        )
+        if mutation == "domain":
+            db_session.delete(declaration)
+        elif mutation == "target":
+            destination.backend.storage_target = s3_target(
+                endpoint="http://localhost:9000", bucket="backups"
+            )
+        elif mutation == "digest":
+            row.sha256 = "c" * 64
+        elif mutation == "token":
+            row.token = None
+        elif mutation == "missing-row":
+            meta.path = "missing.tar.gz"
+            meta.source_ref = backup._source_ref(
+                location=meta.location,
+                namespace=meta.namespace,
+                path=meta.path,
+                provider_ref=meta.provider_ref,
+            )
+        elif mutation == "missing-digest":
+            row.sha256 = None
+        elif mutation == "missing-target":
+            destination.backend.storage_target = None
+        elif mutation == "wrong-transport":
+            destination.backend.storage_target = (
+                destination.backend.storage_target.model_copy(
+                    update={"transport": "webdav"}
+                )
+            )
+        elif mutation == "destination":
+            monkeypatch.setattr(
+                backup_destination, "destination_for_ownership", lambda _: None
+            )
+        elif mutation == "uncommitted":
+            row.state = StorageObjectState.PENDING
+        elif mutation == "source":
+            meta.source_ref = "different-source"
+        else:
+            meta.location = "opendal:webdav"
+        db_session.add(row)
+        db_session.commit()
+
+        assert gc_planner.find_backup_witness() is None
+        assert calls == []
+
+    @pytest.mark.parametrize(
+        "mutation", ["domain", "target", "archive", "invalid", "compatibility"]
+    )
+    def test_changed_opendal_witness_preserves_quarantined_candidates(
+        self, db_session, monkeypatch, mutation
+    ):
+        _, meta, declaration, destination, verification, _ = self._source(
+            db_session, monkeypatch
+        )
+        admin = build_user(db_session, "opendal-gc-admin", superuser=True)
+        candidate = _expired_model(db_session, "opendal-gc-candidate")
+        run = gc_planner.create_plan(
+            db_session, retention_days=30, requested_by=admin.id
+        )
+        gc_planner.approve_plan(db_session, run.id, run.digest, admin.id)
+        run.quarantine_until = utcnow() - timedelta(seconds=1)
+        if mutation == "domain":
+            declaration.failure_domain = "changed-domain"
+            db_session.add(declaration)
+        elif mutation == "target":
+            destination.backend.storage_target = s3_target(
+                endpoint="https://changed.example.test", bucket="backups"
+            )
+        elif mutation == "archive":
+            meta.archive_sha256 = "c" * 64
+        elif mutation == "invalid":
+            verification.valid = False
+        else:
+            verification.app_compatible = False
+        db_session.add(run)
+        db_session.commit()
+
+        with pytest.raises(gc_planner.GcSafetyError):
+            gc_planner.finalize_plan(db_session, run.id)
+
+        db_session.expire_all()
+        assert db_session.get(Model, candidate.id) is not None
+        assert db_session.get(GcRun, run.id).state == GcRunState.BLOCKED
+
+    @pytest.mark.parametrize("invalid", ["content", "compatibility"])
+    def test_failed_opendal_verification_cannot_witness_gc(
+        self, db_session, monkeypatch, invalid
+    ):
+        _, _, _, _, verification, calls = self._source(db_session, monkeypatch)
+        if invalid == "content":
+            verification.valid = False
+        else:
+            verification.app_compatible = False
+        assert gc_planner.find_backup_witness() is None
+        assert len(calls) == 1
+
+    def test_evidence_changed_during_opendal_verification_is_rejected(
+        self, db_session, monkeypatch
+    ):
+        _, _, declaration, _, verification, _ = self._source(db_session, monkeypatch)
+
+        def verify(*_args, **_kwargs):
+            declaration.revision = "c" * 32
+            db_session.add(declaration)
+            db_session.commit()
+            return verification
+
+        monkeypatch.setattr(backup, "verify_backup", verify)
+        assert gc_planner.find_backup_witness() is None

--- a/docs/storage-data-safety.md
+++ b/docs/storage-data-safety.md
@@ -173,3 +173,12 @@ The implementation is covered at integration and end-to-end boundaries for:
 Provider deletion semantics remain separate contract tests. See
 [Provider Support](./provider-support.md#storage-and-library-source-compatibility)
 and [Release Validation](./release-validation.md).
+
+
+### OpenDAL S3 backup witnesses
+
+A verified backup in an OpenDAL S3 connection can satisfy GC's independent-backup requirement. PrintStash resolves the exact source reference, committed ownership, archive digest and current target before verification. The active Vault must still have Verified storage capabilities.
+
+Custom S3 targets require an administrator-declared failure domain bound to the current target identity. Different profiles, prefixes or credentials do not establish independence, and a declaration cannot override known shared storage. Approval records the evidence; finalization verifies the same archive and rechecks the evidence after quarantine. A removed profile, edited target, changed declaration, changed archive or incompatible backup blocks finalization and preserves the candidates.
+
+This eligibility does not grant backup deletion, promote the destination's maturity, or enable witnesses from other remote transports.


### PR DESCRIPTION
## Summary

OpenDAL S3 backup connections can now supply a GC witness when the exact committed archive has current evidence of storage independence. Resolve the source reference and ownership against the configured destination, verify its digest and compatibility, and bind the approval to the existing target/domain evidence. Finalization resolves and verifies that same archive again after quarantine.

Custom endpoints still require administrator declarations; known shared storage remains ineligible. Other remote transports remain ineligible. Witness eligibility does not grant deletion or promote a provider's maturity.

## Validation

- Six new eligibility/finalization tests failed before implementation.
- 2,063 GC, capability and repository hygiene checks passed, including 21 new OpenDAL selection/drift cases. Ruff and Pyright passed.
- The real S3 E2E passed: upload, remote-only backup, preview, refused undeclared approval, administrator declaration, approval, refused premature finalization, elapsed quarantine, finalization, and surviving archive verification. The Docker bridge endpoint simulates separately administered storage; no identity or backup verification is mocked.
- All CI gates passed on the final rebased commit, including backend full/coverage, both image architectures, frontend and real-backend E2E. The final focused GC/capability run passed 90 cases.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | selects independent OpenDAL S3 | Happy | Committed exact source and declared domain | Witness pins source, digest and evidence after verification | Integration | ✅ test_independent_opendal_s3_archive_can_witness_gc |
| 2 | refuses unprovable sources | Error | Missing/changed ownership, digest, source, target, declaration or unsupported transport | No witness or verification authorization | Integration | ✅ test_unprovable_opendal_source_never_authorizes_gc |
| 3 | refuses invalid verification | Error | Invalid content or incompatible archive | No witness | Integration | ✅ test_failed_opendal_verification_cannot_witness_gc |
| 4 | rechecks evidence after verification | Edge | Declaration changes during verification | No witness | Integration | ✅ test_evidence_changed_during_opendal_verification_is_rejected |
| 5 | blocks changed quarantine evidence | Error | Target, domain, digest, validity or compatibility changes | Candidate remains and plan blocks | Integration | ✅ test_changed_opendal_witness_preserves_quarantined_candidates |
| 6 | finalizes real S3-backed GC | Happy | Exact API-created archive, declared domain and elapsed quarantine | Only candidate removed; unrelated file and verifiable replica remain | E2E | ✅ test_independent_s3_replica_authorizes_only_quarantined_gc_candidates |
| 7 | requires declaration and quarantine | Edge | Unknown domain, then approved unelapsed quarantine | Both transitions refuse deletion | E2E | ✅ test_independent_s3_replica_authorizes_only_quarantined_gc_candidates |
| 8 | explains witness revalidation | Edge | Eligible native or OpenDAL S3 source | Operation still requires GC verification | Integration | ✅ test_independent_backup_still_requires_gc_reverification |
