### PR TITLE
feat(deploy): add minimal compose setup with optional settings guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- A minimal, standalone Compose file for local deployment, with optional settings
+  and customization examples in a separate deployment guide.
+
 ### Fixed
 
 - Backup deletion refuses destinations without an exact owned-object deletion operation, including manually confirmed requests. Unsupported retention keeps replicas and ownership evidence intact without repeated provider-error warnings. Mutable S3 null versions use conditional ETags.

--- a/README.md
+++ b/README.md
@@ -224,127 +224,36 @@ Storage and migration guides:
 > set your own `VAULT_JWT_SECRET`.
 > See [Security](#security).
 
-Requirements: Docker and Docker Compose. Prebuilt images are published for
-`linux/amd64` and `linux/arm64` (Raspberry Pi 4/5, ARM NAS, Apple-silicon VMs).
-The full image supports STEP/STP preview and thumbnail generation on both
-architectures.
-
-A modest host is enough. As a starting point:
-
-| Resource | Minimum | Comfortable |
-| --- | --- | --- |
-| RAM | 1 GB | 2 GB+ |
-| CPU | 1 core | 2+ cores |
-| Disk | ~1 GB for images | + room for your library |
-
-SQLite + local disk is the default; thumbnailing large meshes is the most
-memory-hungry step, so give it 2 GB if you upload big STLs. Storage grows with
-your library — the files themselves dominate, the database stays small.
-
-The default `docker-compose.yml` pulls prebuilt images from GHCR — no build step.
+Install Docker with the Compose plugin, then download the
+[**simple Compose file**](./docker-compose.simple.yml) and start PrintStash:
 
 ```bash
-git clone https://github.com/xiao-villamor/PrintStash.git
-cd PrintStash
-
+mkdir -p printstash && cd printstash
+curl -fsSL https://raw.githubusercontent.com/xiao-villamor/PrintStash/main/docker-compose.simple.yml -o docker-compose.yml
 docker compose up -d
 ```
 
-There is nothing to edit before that first start. Every variable in the Compose
-file has a working default, so `.env` is optional; copy `.env.example` to `.env`
-when you actually want to change something. In particular you do **not** need to
-invent a JWT secret: the placeholder in the Compose file is public, so the API
-refuses to sign with it and instead generates a real secret on first boot and
-stores it in its own database (see 0.8.4 in the [changelog](CHANGELOG.md)). Set
-`VAULT_JWT_SECRET` yourself only when you want to own that value.
-
-If you only want to run it, the Compose file is the single file you need:
-
-```bash
-mkdir printstash && cd printstash
-curl -O https://raw.githubusercontent.com/xiao-villamor/PrintStash/main/docker-compose.yml
-docker compose up -d
-```
-
-For the smallest SQLite/local-files deployment, use
-`docker-compose.light.yml`. Its API image omits browser automation and STEP
-tessellation but keeps STL/OBJ/3MF thumbnail generation:
-
-```bash
-docker compose -f docker-compose.light.yml up -d
-```
-
-### Bind-mounted data directories
-
-The API image starts with the unprivileged `10001:10001` identity. If you
-replace the named volumes with host bind mounts, set `PUID` and `PGID` to the
-numeric owner that should access those directories; the entrypoint repairs
-ownership before running migrations and the server:
-
-```bash
-PUID=1000 PGID=1000 docker compose up -d
-```
-
-Both values must be positive numeric Linux IDs. The default `10001:10001` is
-used when they are omitted. Changing either value on a later restart safely
-re-keys ownership of the mounted data directories.
-
-For a hardened production setup (API kept internal, frontend bound to localhost
-behind your own TLS reverse proxy), use the production compose instead. That file
-declares `VAULT_JWT_SECRET` as required and refuses to start without it, on the
-grounds that a deliberately exposed host should not run on a secret nobody chose:
-
-```bash
-echo "VAULT_JWT_SECRET=$(openssl rand -hex 32)" >> .env
-docker compose -f docker-compose.prod.yml up -d
-```
-
-To build the images from source instead of pulling (contributors), layer the
-build overlay: `docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build`.
-
-**Pin a version** for reproducible deploys. The compose files read
-`PRINTSTASH_VERSION` (the image tag); set it in `.env` and bump it to upgrade:
-
-```bash
-echo "PRINTSTASH_VERSION=0.12.1" >> .env   # pin the current release; omit to track latest
-```
-
-By default the compose files track `latest`. Pin `PRINTSTASH_VERSION` when you
-want deliberate upgrades. See [Upgrading](https://www.printstash.org/docs/guides/upgrading/).
-
-Open:
-
-| Service | URL |
-| --- | --- |
-| Web UI | http://localhost:3000 |
-| Health check | http://localhost:3000/api/v1/health |
-
-The `api` service only exposes port 8000 on the internal Compose network, so it
-is not reachable from the host. The frontend's nginx proxies `/api/v1` to it, which
-is why the health check answers on port 3000. The Swagger and ReDoc pages are not
-proxied, so seeing them means publishing the port yourself from a
-`docker-compose.override.yml`:
-
-```yaml
-services:
-  api:
-    ports:
-      - "127.0.0.1:8000:8000"
-```
-
-On first launch the web UI creates the first admin account, gated by a **setup
-token**, because the endpoint that creates the very first account cannot require a
-login. With `VAULT_SETUP_TOKEN` unset, the API generates one per process and logs
-it while the vault is unconfigured:
+Open **[http://localhost:3000](http://localhost:3000)** (or
+`http://<server-ip>:3000` from another machine). Get the first-login setup token:
 
 ```bash
 docker compose logs api | grep "setup token"
 ```
 
-Paste that into the wizard at `http://localhost:3000/setup`. The token is
-per process, so restarting the `api` container before you finish invalidates it;
-set `VAULT_SETUP_TOKEN` in `.env` if you want a stable one. There is no default
-username or password.
+Paste it into the setup wizard to create your admin account. There is no default
+username or password. Restarting the API before setup generates a new token.
+
+The simple deployment uses the full prebuilt images, SQLite, and persistent
+Docker volumes. No `.env`, build step, PostgreSQL, or S3 service is needed.
+Images support `linux/amd64` and `linux/arm64`. Start with 1 GB RAM; 2 GB or
+more helps with large meshes.
+
+**From a Git checkout**, use `docker compose -f docker-compose.simple.yml up -d`
+and include `-f docker-compose.simple.yml` in subsequent Compose commands.
+
+For ports, version pinning, host folders, upload limits, SSO, HTTPS, updates,
+and the purpose of the other Compose files, see
+[**Deployment and optional settings**](./docs/deployment.md).
 
 ## Screenshots
 

--- a/backend/tests/repo/test_simple_compose.py
+++ b/backend/tests/repo/test_simple_compose.py
@@ -1,0 +1,154 @@
+"""The standalone deployment works without a checkout or environment file.
+
+Removing optional settings must preserve persistent state, private API access,
+and startup ordering. Documentation fragments must compose into that same stack.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.paths import REPO_ROOT
+
+
+@pytest.fixture
+def compose_dir(tmp_path: Path) -> Path:
+    (tmp_path / "docker-compose.yml").write_text(
+        (REPO_ROOT / "docker-compose.simple.yml").read_text()
+    )
+    return tmp_path
+
+
+def _render(directory: Path, **environment: str) -> dict[str, Any]:
+    result = subprocess.run(
+        ["docker", "compose", "--env-file", "/dev/null", "config", "--format", "json"],
+        cwd=directory,
+        env={"PATH": os.environ["PATH"], **environment},
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    return json.loads(result.stdout)
+
+
+@pytest.fixture
+def simple_config(compose_dir: Path) -> dict[str, Any]:
+    return _render(compose_dir)
+
+
+class TestSimpleCompose:
+    def test_runs_only_the_app_without_configuration(
+        self, simple_config: dict[str, Any]
+    ) -> None:
+        assert set(simple_config["services"]) == {"frontend", "api"}
+        assert not simple_config["services"]["api"].get("env_file")
+
+    @pytest.mark.parametrize("service", ["api", "frontend"], ids=str)
+    def test_uses_prebuilt_full_images(
+        self, simple_config: dict[str, Any], service: str
+    ) -> None:
+        config = simple_config["services"][service]
+
+        assert config["image"] == f"ghcr.io/xiao-villamor/printstash-{service}:latest"
+        assert "build" not in config
+
+    @pytest.mark.parametrize(
+        ("volume", "target"),
+        [
+            pytest.param("printstash_data", "/data/files", id="uploads"),
+            pytest.param("printstash_thumbs", "/data/thumbs", id="thumbnails"),
+            pytest.param("printstash_db", "/data/db", id="database-credentials"),
+            pytest.param("printstash_staging", "/data/staging", id="pending-imports"),
+            pytest.param("printstash_backups", "/data/backups", id="backups"),
+        ],
+    )
+    def test_persists_application_state(
+        self, simple_config: dict[str, Any], volume: str, target: str
+    ) -> None:
+        mounts = simple_config["services"]["api"]["volumes"]
+
+        assert {mount["target"]: mount["source"] for mount in mounts}[target] == volume
+        assert volume in simple_config["volumes"]
+        assert (
+            next(mount for mount in mounts if mount["target"] == target)["type"]
+            == "volume"
+        )
+
+    def test_exposes_only_the_web_port(self, simple_config: dict[str, Any]) -> None:
+        services = simple_config["services"]
+
+        assert not services["api"].get("ports")
+        assert [
+            (p["published"], p["target"]) for p in services["frontend"]["ports"]
+        ] == [("3000", 3000)]
+
+    def test_waits_for_api_health(self, simple_config: dict[str, Any]) -> None:
+        services = simple_config["services"]
+
+        assert (
+            services["frontend"]["depends_on"]["api"]["condition"] == "service_healthy"
+        )
+        assert services["api"]["healthcheck"]["test"] == [
+            "CMD",
+            "curl",
+            "-fsS",
+            "http://localhost:8000/api/v1/health",
+        ]
+        assert not services["api"].get("entrypoint")
+        assert not services["api"].get("command")
+
+    def test_supervises_settings_restart(self, simple_config: dict[str, Any]) -> None:
+        api = simple_config["services"]["api"]
+
+        assert api["environment"]["VAULT_RESTART_ENABLED"] == "true"
+        assert api["restart"] == "unless-stopped"
+
+    def test_accepts_optional_image_tag(self, compose_dir: Path) -> None:
+        config = _render(compose_dir, PRINTSTASH_VERSION="test-release")
+
+        assert {s["image"].rsplit(":", 1)[1] for s in config["services"].values()} == {
+            "test-release"
+        }
+
+    def test_accepts_optional_web_port(self, compose_dir: Path) -> None:
+        config = _render(compose_dir, PRINTSTASH_HTTP_PORT="8080")
+
+        assert config["services"]["frontend"]["ports"][0]["published"] == "8080"
+
+    def test_ignores_unwired_host_database_setting(self, compose_dir: Path) -> None:
+        config = _render(compose_dir, VAULT_DB_URL="sqlite:///./ephemeral.sqlite")
+
+        assert "VAULT_DB_URL" not in config["services"]["api"]["environment"]
+
+    @pytest.mark.parametrize(
+        "fragment",
+        re.findall(
+            r"```yaml\n(services:\n.*?)```",
+            (REPO_ROOT / "docs/deployment.md").read_text(),
+            re.DOTALL,
+        ),
+        ids=["session-lifetime", "setup-token", "host-folders", "upload-limit"],
+    )
+    def test_documented_overrides_preserve_startup(
+        self, compose_dir: Path, fragment: str
+    ) -> None:
+        (compose_dir / "docker-compose.override.yml").write_text(fragment)
+
+        config = _render(compose_dir, VAULT_SETUP_TOKEN="test-setup-token")
+
+        assert set(config["services"]) == {"frontend", "api"}
+        assert (
+            config["services"]["api"]["environment"]["VAULT_RESTART_ENABLED"] == "true"
+        )
+        assert (
+            config["services"]["frontend"]["depends_on"]["api"]["condition"]
+            == "service_healthy"
+        )

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -1,0 +1,36 @@
+# Quick start: docker compose -f docker-compose.simple.yml up -d
+# Optional settings: docs/deployment.md
+services:
+  frontend:
+    image: ghcr.io/xiao-villamor/printstash-frontend:${PRINTSTASH_VERSION:-latest}
+    restart: unless-stopped
+    ports:
+      - "${PRINTSTASH_HTTP_PORT:-3000}:3000"
+    depends_on:
+      api:
+        condition: service_healthy
+
+  api:
+    image: ghcr.io/xiao-villamor/printstash-api:${PRINTSTASH_VERSION:-latest}
+    restart: unless-stopped
+    environment:
+      VAULT_RESTART_ENABLED: "true"
+    volumes:
+      - printstash_data:/data/files
+      - printstash_thumbs:/data/thumbs
+      - printstash_db:/data/db
+      - printstash_staging:/data/staging
+      - printstash_backups:/data/backups
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/api/v1/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  printstash_data:
+  printstash_thumbs:
+  printstash_db:
+  printstash_staging:
+  printstash_backups:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,278 @@
+# Deployment and optional settings
+
+For a new local installation, use [docker-compose.simple.yml](../docker-compose.simple.yml).
+It starts the full API and web UI with SQLite and local storage. The short file
+uses the images' built-in defaults; you only add settings you need.
+
+## Install
+
+Install Docker with the Compose plugin, then:
+
+```bash
+mkdir -p printstash && cd printstash
+curl -fsSL https://raw.githubusercontent.com/xiao-villamor/PrintStash/main/docker-compose.simple.yml -o docker-compose.yml
+docker compose up -d
+```
+
+Open `http://localhost:3000` or `http://<server-ip>:3000`. Retrieve the setup token
+with `docker compose logs api | grep "setup token"` and paste it into the wizard.
+There is no default account. The API generates a new token on each start until
+setup is complete. Database migrations run automatically at startup.
+
+All commands below assume you saved the simple file as `docker-compose.yml`.
+From a repository checkout, keep its original name and use
+`docker compose -f docker-compose.simple.yml` instead of `docker compose`.
+
+## Add an optional setting
+
+Add API settings under `services.api.environment` in your downloaded file.
+Keep `VAULT_RESTART_ENABLED: "true"`, which lets Settings restart the supervised
+API. For example, to retain remembered logins for seven days:
+
+```yaml
+services:
+  api:
+    environment:
+      VAULT_RESTART_ENABLED: "true"
+      VAULT_REMEMBER_ME_DAYS: "7"
+```
+
+This is a fragment to merge into the existing `api` service, **not a replacement
+for the whole file**. Keep its image, volumes, and health check. Quote environment
+values, especially booleans and numbers. After editing, apply the change:
+
+```bash
+docker compose up -d
+```
+
+Alternatively, save a fragment as `docker-compose.override.yml` beside the
+downloaded `docker-compose.yml`; Compose loads it automatically. When using the
+original filename in a Git checkout, select both files explicitly:
+
+```bash
+docker compose -f docker-compose.simple.yml -f docker-compose.override.yml up -d
+```
+
+A `.env` file supplies values for `${VARIABLE}` expressions in Compose. It does
+**not** automatically pass every variable to the API. The simple file only
+interpolates `PRINTSTASH_VERSION` and `PRINTSTASH_HTTP_PORT`. For another setting,
+add it to `api.environment`, either directly as above or by reference:
+
+```yaml
+services:
+  api:
+    environment:
+      VAULT_SETUP_TOKEN: ${VAULT_SETUP_TOKEN:?set VAULT_SETUP_TOKEN in .env}
+```
+
+Then put `VAULT_SETUP_TOKEN=your-own-random-token` in `.env`. Keep files containing
+credentials private and outside version control. Do not copy the entire example
+environment just to get started.
+
+## Port and image version
+
+These are the only optional variables already wired into the simple file:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `PRINTSTASH_HTTP_PORT` | `3000` | Web port on the Docker host. |
+| `PRINTSTASH_VERSION` | `latest` | Image tag, shared by the API and frontend. |
+
+For example, put this in `.env` beside the downloaded Compose file:
+
+```dotenv
+PRINTSTASH_HTTP_PORT=8080
+```
+
+Run `docker compose up -d` and open `http://<server-ip>:8080`.
+To pin a release, add `PRINTSTASH_VERSION=<published-image-tag>` using a tag from
+[Releases](https://github.com/xiao-villamor/PrintStash/releases). Use the same tag
+for both images; update it deliberately when upgrading.
+
+## Data and host folders
+
+The simple file persists all application state in named Docker volumes:
+
+| Volume | Container path | Contents |
+| --- | --- | --- |
+| `printstash_data` | `/data/files` | Uploaded files |
+| `printstash_thumbs` | `/data/thumbs` | Thumbnails |
+| `printstash_db` | `/data/db` | SQLite database and generated credentials key |
+| `printstash_staging` | `/data/staging` | Pending uploads and imports |
+| `printstash_backups` | `/data/backups` | Local backup archives |
+
+Docker prefixes these names with the Compose project name, normally the directory
+name. Keep that directory/project name when updating so the app finds its data.
+`docker compose down` preserves volumes; **`docker compose down -v` deletes them**.
+
+For host folders, replace the API's `volumes` list with bind mounts and add the
+host owner's numeric IDs to its existing `environment` mapping:
+
+```yaml
+services:
+  api:
+    environment:
+      VAULT_RESTART_ENABLED: "true"
+      PUID: "1000"
+      PGID: "1000"
+    volumes:
+      - ./data/files:/data/files
+      - ./data/thumbs:/data/thumbs
+      - ./data/db:/data/db
+      - ./data/staging:/data/staging
+      - ./data/backups:/data/backups
+```
+
+Use `id -u` and `id -g` on the host to find the intended owner. Both IDs must be
+positive; omitted IDs default to `10001:10001`. The entrypoint repairs ownership
+before running migrations as the unprivileged user. Replacing named volumes with
+empty host folders does not move existing data: back up and migrate it first.
+
+To index an existing library folder, add a mount such as
+`/path/to/library:/library:ro` to the API's existing volume list, then add
+`/library` as a Library source in the app. Remove `:ro` only if you want the app
+to write into that folder.
+
+## Upload limits
+
+The default per-file limit is 512 MiB. If you change it, set both the API limit
+and the frontend's whole-request limit. Allow at least 16 MiB of multipart
+headroom. For 1 GiB uploads:
+
+```yaml
+services:
+  frontend:
+    environment:
+      NGINX_CLIENT_MAX_BODY_SIZE: "1040m"
+  api:
+    environment:
+      VAULT_MAX_UPLOAD_MB: "1024"
+```
+
+Use `NGINX_CLIENT_MAX_BODY_SIZE` on the frontend, not on the API. An external
+reverse proxy must also allow the larger request body. In the simple file,
+`VAULT_MAX_REQUEST_MB` alone has no effect; that interpolation belongs to the
+older Compose files.
+
+## API settings reference
+
+Add only the settings you need under `services.api.environment`.
+These defaults apply when the setting is omitted.
+
+### Login and sessions
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VAULT_SETUP_TOKEN` | Generated while unconfigured | Stable first-admin setup token if supplied. |
+| `VAULT_JWT_SECRET` | Generated and stored in the database | Manage your own signing secret; generate with `openssl rand -hex 32`. |
+| `VAULT_SECRETS_KEY` | Generated key file in `/data/db` | External key for stored credentials. Preserve it with backups; changing it requires a planned key migration. |
+| `VAULT_SESSION_COOKIE_SECURE` | `false` | Set `true` when accessed through HTTPS. |
+| `VAULT_ACCESS_TOKEN_EXPIRE_MINUTES` | `60` | Ordinary login lifetime in minutes. |
+| `VAULT_REMEMBER_ME_DAYS` | `2` | Remembered login lifetime in days. |
+
+### OpenID Connect / SSO
+
+Local login works without an identity provider. To enable OIDC, configure these
+on the API for your provider:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VAULT_OIDC_ENABLED` | `false` | Enable OIDC login. |
+| `VAULT_OIDC_ISSUER_URL` | Empty | Provider issuer URL. |
+| `VAULT_OIDC_CLIENT_ID` | Empty | Registered client ID. |
+| `VAULT_OIDC_CLIENT_SECRET` | Empty | Registered client secret. |
+| `VAULT_OIDC_REDIRECT_URI` | Empty | Explicit callback URL; otherwise derived from the request. |
+| `VAULT_OIDC_SCOPES` | `openid profile email groups` | Requested scopes. |
+| `VAULT_OIDC_USERNAME_CLAIM` | `preferred_username` | Username claim. |
+| `VAULT_OIDC_GROUPS_CLAIM` | `groups` | Group membership claim. |
+| `VAULT_OIDC_ADMIN_GROUPS` | `printstash-admins` | Groups granted administrator access. |
+| `VAULT_OIDC_DISPLAY_NAME` | `Single sign-on` | Login button text. |
+| `VAULT_OIDC_ALLOW_INSECURE_HTTP` | `false` | Allow HTTP provider endpoints for local testing only. |
+
+### Imports, capacity, and diagnostics
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `VAULT_MAX_UPLOAD_MB` | `512` | Per-file upload cap; also adjust the frontend as above. |
+| `VAULT_PORTABLE_MANIFEST_MAX_MB` | `128` | Portable archive manifest cap. |
+| `VAULT_STAGING_MAX_PENDING` | `32` | Pending staging capacity. |
+| `VAULT_STAGING_MAX_ACTIVE_PER_USER` | `4` | Concurrent active staging operations per user. |
+| `VAULT_STAGING_MAX_GB` | `4` | Staging disk budget. |
+| `VAULT_STAGING_MIN_FREE_GB` | `1` | Minimum free disk space for staging. |
+| `VAULT_INGEST_WORKER_COUNT` | `2` | Ingestion worker count. |
+| `VAULT_MEDIA_WORKER_TIMEOUT_SECONDS` | `180` | Media worker timeout. |
+| `VAULT_SQLITE_SYNCHRONOUS` | `NORMAL` | SQLite durability mode. |
+| `VAULT_LOG_LEVEL` | `INFO` | API logging level. |
+| `VAULT_BACKUP_RETENTION_DAYS` | `30` | Local backup retention in days. |
+| `VAULT_RESTART_ENABLED` | `true` in simple Compose | Enables supervised restart from Settings; the app default outside Compose is `false`. |
+
+Storage paths already match the persistent mounts. Leave `VAULT_DATA_DIR`,
+`VAULT_THUMB_DIR`, `VAULT_DB_URL`, `VAULT_STAGING_DIR`, and `VAULT_BACKUP_DIR` at
+their defaults unless you also adjust the mounts. A database path outside the
+persistent volume can lose state on container replacement.
+
+For remote storage, see [Storage providers](./storage-providers.md).
+The full image includes the optional storage dependencies. PostgreSQL/S3 services
+are not required for a local installation. For more environment settings, see
+[.env.example](../.env.example); the application defaults are defined in
+[Settings](../backend/app/core/config.py).
+
+## HTTPS and reverse proxies
+
+Use the simple deployment on a trusted network. For remote access, put it behind
+your TLS reverse proxy and access controls. Edit the frontend port mapping in the
+base file to bind it to localhost:
+
+```yaml
+ports:
+  - "127.0.0.1:${PRINTSTASH_HTTP_PORT:-3000}:3000"
+```
+
+Replace the existing mapping; adding another port through an override may leave
+the original public binding in place. Add `VAULT_SESSION_COOKIE_SECURE: "true"`
+to the API for HTTPS. The API has no host port; the frontend proxies API requests
+and WebSockets. If configuring `FORWARDED_ALLOW_IPS` on the API, trust only your
+controlled proxy peers; see [Known limitations](./known-limitations.md).
+
+The standalone [production Compose](../docker-compose.prod.yml) includes a
+localhost binding and log rotation, and requires an explicitly configured
+`VAULT_JWT_SECRET`. See [Security](../SECURITY.md).
+
+## Stop, update, and troubleshoot
+
+Run these in the install directory:
+
+```bash
+# Status and logs
+docker compose ps
+docker compose logs --tail=100 api
+
+# Stop while preserving data
+docker compose down
+
+# Update to the selected image tag (latest unless pinned)
+docker compose pull && docker compose up -d
+```
+
+Read [UPGRADE.md](../UPGRADE.md) and make a backup before updating. Check health
+at `http://localhost:3000/api/v1/health` (use your chosen host/port).
+
+## Which Compose file should I use?
+
+| File | Purpose |
+| --- | --- |
+| **`docker-compose.simple.yml`** | **Recommended for a new local install.** Full images, two services, minimal configuration. |
+| `docker-compose.yml` | Existing configurable deployment with opt-in PostgreSQL and S3 profiles. |
+| `docker-compose.light.yml` | Smaller API image without browser automation or STEP tessellation; exposes advanced variables. |
+| `docker-compose.prod.yml` | Standalone configuration for a TLS reverse proxy, with localhost binding and log rotation. |
+| `docker-compose.build.yml` | Source-build overlay for the original `docker-compose.yml`. |
+| `docker-compose.light.build.yml` | Source-build overlay for the light file. |
+| `docker-compose.manual-test.yml` | Maintainer testing stack. |
+| `docker-compose.migrate-minio.yml` | Migration helper for existing MinIO installations. |
+
+Existing installations can keep their current file. Do not start two stacks
+against the same data. If switching to the simple file, back up first, stop the
+old stack without removing volumes, keep the same Compose project name, and
+carry over your custom mounts and settings. The simple file retains the five
+local volume keys used by the existing stacks. Moving from PostgreSQL or remote
+primary storage requires a separate data migration; copying this file is not one.


### PR DESCRIPTION
## Summary

- Add a 36-line standalone `docker-compose.simple.yml` using the full prebuilt images, SQLite, five persistent volumes, and one explicit API setting. New installs can download this file as `docker-compose.yml` and run `docker compose up -d`.
- Make this the README quick start and move advanced configuration into `docs/deployment.md`, with optional settings, copyable examples, `.env` versus container environment guidance, and a table explaining the existing Compose files.
- Preserve the existing deployment files and add Compose configuration regression tests.

## Testing

- [x] `cd backend && ./scripts/test.sh full` green, or not needed — full application suite not run; changes are deployment configuration, documentation, and repository tests only.
- [x] `cd frontend && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` green, or not needed — no frontend code changes.
- [x] Manual test notes included, or not needed.

Validation performed:
- `cd backend && .venv/bin/pytest tests/repo/test_simple_compose.py tests/repo/test_proxy_config.py tests/repo/test_test_hygiene.py -q` — **2022 passed**.
- Ruff on the new test file and `git diff --check` passed. Local guide links resolve.
- Started the actual Compose stack in an isolated project using cached full GHCR images and a temporary host port. Confirmed the web UI, proxied health endpoint, first-admin setup, and authenticated API access. Recreated both containers and confirmed the account and original authenticated session survived. Removed the temporary containers and their test volumes afterward. This did not test a fresh registry pull.
- An initial `uv run` attempt could not fetch build requirements under the network sandbox; validation used the existing virtual environment directly.

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|----------------------|----------|----------------------|-----------------------------|------|--------|
| 1 | runs_only_the_app_without_configuration | Happy | Standalone file, no .env | Only frontend and API services | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_runs_only_the_app_without_configuration` |
| 2 | uses_prebuilt_full_images | Happy | API and frontend | Full GHCR images, no build | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_uses_prebuilt_full_images` |
| 3 | persists_application_state | Happy | Five application directories | Named volumes for every persistent path | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_persists_application_state` |
| 4 | exposes_only_the_web_port | Happy | Default deployment | Web on 3000; API not published | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_exposes_only_the_web_port` |
| 5 | waits_for_api_health | Happy | Startup dependency | Frontend waits for API health; image startup retained | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_waits_for_api_health` |
| 6 | supervises_settings_restart | Happy | Restart enabled | API has unless-stopped supervisor | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_supervises_settings_restart` |
| 7 | accepts_optional_image_tag | Edge | PRINTSTASH_VERSION=test-release | Both images use selected tag | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_accepts_optional_image_tag` |
| 8 | accepts_optional_web_port | Edge | PRINTSTASH_HTTP_PORT=8080 | Frontend publishes 8080 | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_accepts_optional_web_port` |
| 9 | ignores_unwired_host_database_setting | Edge | Host VAULT_DB_URL points outside volume | Host variable not injected into API | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_ignores_unwired_host_database_setting` |
| 10 | documented_overrides_preserve_startup | Happy | Session, token, bind mount, upload examples | Merged configuration preserves startup | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_documented_overrides_preserve_startup` |

### Tier check

- [x] `repo/` — deployment configuration invariants, rendered through real Docker Compose.
- Application unit/integration/contract/e2e tiers: not added; no application capability changed. The deployment lifecycle was exercised manually against real containers as described above.

### Self-check

- [x] New test file has a contract header.
- [x] Tests each name one behavior; no conjunction names or skipped tests.
- [x] Endpoint authentication rows: not applicable; no endpoint changes.

### Fixtures and factories

- [x] No application entities or database rows constructed by the new repository tests. Their local fixture prepares an isolated Compose directory.
- [x] Entity, factory, and scenario changes: not applicable.

## Notes

No schema, API, printer-provider, or existing deployment behavior changes. The simple file uses image defaults and preserves the existing five local volume keys. Existing users can keep their current Compose file. The guide explains retaining the project name and migrating custom configuration when switching; PostgreSQL or remote-primary-storage migration is outside this change.

The documentation page is in this repository. Publishing its equivalent on the separate `printstash-landing` documentation site requires a separate repository change.
