### PR TITLE
docs(release): align status with published 0.13.0 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@
 
 ## 0.13.0
 
+[Published September 4, 2026](https://github.com/xiao-villamor/PrintStash/releases/tag/v0.13.0).
+
 **Back up before upgrading. This release includes additive database migrations
 and storage configuration/safety changes. Existing S3-compatible buckets must
 be provisioned before startup; review [UPGRADE.md](./UPGRADE.md).**

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ usable for local libraries and Moonraker/Klipper workflows, with Docker Compose
 as the primary install path. SQLite plus local disk is the default; Postgres and
 S3/R2-compatible storage are optional.
 
-PrintStash 0.13.0 is merged to `main` and has passed CI. The release tag and
-images are still pending. It adds runtime-probed storage safety tiers, reusable
+PrintStash [0.13.0 is published](https://github.com/xiao-villamor/PrintStash/releases/tag/v0.13.0),
+with full and lite API images and a frontend image for amd64 and arm64. It adds runtime-probed storage safety tiers, reusable
 remote storage connections, paired-browser marketplace capture with Model
 Source provenance, richer Bambu LAN history evidence, Multipart Models, and
 safer 3MF/STL preview handling. Read the
 [0.13.0 changelog](./CHANGELOG.md#0130) and
-[upgrade notes](./UPGRADE.md#0130-notes) before testing an upgrade. Keep 0.12.1
-in service until the 0.13.0 tag and images are published.
+[upgrade notes](./UPGRADE.md#0130-notes) before upgrading. Changes on `main`
+after that release are listed under [Unreleased](./CHANGELOG.md#unreleased).
 
 Hardware reports, parser fixtures, install notes, docs fixes, and UX feedback
 are welcome in

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -14,6 +14,9 @@ are documented in
 
 ## Clean Install
 
+The checks below establish release readiness. After publication, also complete
+the [publication check](#publication-check) before announcing availability.
+
 ```bash
 cp .env.example .env
 docker compose up -d --build
@@ -27,6 +30,23 @@ Expected:
 - health components include database, storage, backup, and printer providers
 - Docker containers, networks, volumes, and default SQLite path use PrintStash
   naming for new installs
+
+## Publication Check
+
+- Confirm that the GitHub release is published, not a draft, and points to the
+  intended version tag. A local tag or a green branch build is not publication.
+- Inspect the versioned GHCR manifests for `printstash-api`,
+  `printstash-api-lite`, and `printstash-frontend`. All three must contain
+  `linux/amd64` and `linux/arm64`; do not use `latest` as the evidence for a
+  specific release.
+- Check the published image revision against the tag's commit and retain the
+  successful publication workflow URL in the release validation notes.
+- Read the README project status, roadmap opening, changelog, and upgrade notes
+  together. Remove pending-tag/image or release-candidate wording for the
+  published version. Keep later work under `Unreleased` and preserve backup
+  instructions.
+- If any artifact remains unavailable, describe exactly what is pending rather
+  than announcing the entire release as installable.
 
 ## Upgrade From Existing SQLite Volume
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,10 +8,12 @@ Roadmap feedback belongs in
 [the public roadmap discussion](https://github.com/xiao-villamor/PrintStash/discussions/1).
 Issues are better for confirmed bugs or scoped implementation work.
 
-## Release candidate: 0.13.0, storage safety and capture provenance
+## Published: 0.13.0, storage safety and capture provenance
 
-The latest tagged release remains 0.12.1. Version 0.13.0 is merged to `main` and
-has passed CI; its release tag and images are still pending. The app is useful
+[Version 0.13.0 is published](https://github.com/xiao-villamor/PrintStash/releases/tag/v0.13.0),
+including full and lite API images and a frontend image for amd64 and arm64.
+Changes merged afterward remain under [Unreleased](../CHANGELOG.md#unreleased)
+until their own release is published. The app is useful
 for local-first 3D print library workflows and installs through Docker Compose.
 SQLite plus local filesystem storage remain the default path. Postgres,
 S3/R2-compatible storage, cloud backups, and provider adapters are optional.


### PR DESCRIPTION
## Summary

The README and roadmap still describe 0.13.0 as awaiting its tag and images, although the release and all three multi-architecture images are published. Align the installation guidance with that publication and keep subsequent work explicitly under Unreleased.

Add a publication check to the release validation guide covering remote release state, versioned manifests, commit identity, and documentation consistency.

## Validation

- Confirmed the published GitHub release and GHCR manifests for API, API lite, and frontend on amd64 and arm64 during planning.
- `git diff --check` passed. Documentation-only change; application suites are not applicable.

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | Published release status is consistent | Happy | Published v0.13.0 and versioned manifests | README, roadmap and changelog identify the published release | Documentation | ⏭️ N/A — checked against remote publication evidence |
