### PR TITLE
test(storage): make stale WebDAV validator fixtures deterministic

### DIFF
--- a/backend/tests/contract/services/storage_opendal/test_webdav_cleanup.py
+++ b/backend/tests/contract/services/storage_opendal/test_webdav_cleanup.py
@@ -21,13 +21,14 @@ class TestWebDAVCleanupEvidence:
             assert client.put(key, content=b"original").is_success
             set_mtime("object", 1234)
             etag = client.head(key).headers["etag"]
-            assert client.put(key, content=b"replaced").is_success
+            # Different sizes force a new validator even within one timestamp tick.
+            assert client.put(key, content=b"replacement").is_success
             set_mtime("object", 1235)
             assert client.head(key).headers["etag"] != etag
             response = client.delete(key, headers={"If-Match": etag})
             print(provider, "stale-delete", response.status_code)
             assert response.status_code == 412
-            assert client.get(key).content == b"replaced"
+            assert client.get(key).content == b"replacement"
 
     def test_conditional_delete_retry_is_missing(self, cleanup_endpoint):
         provider, root, auth, set_mtime = cleanup_endpoint
@@ -49,7 +50,8 @@ class TestWebDAVCleanupEvidence:
             assert client.put(key, content=b"original").is_success
             set_mtime("object", 1234)
             etag = client.head(key).headers["etag"]
-            assert client.put(key, content=b"replaced").is_success
+            # Different sizes force a new validator even within one timestamp tick.
+            assert client.put(key, content=b"replacement").is_success
             set_mtime("object", 1235)
             assert client.head(key).headers["etag"] != etag
             response = client.request(
@@ -59,7 +61,7 @@ class TestWebDAVCleanupEvidence:
             )
             print(provider, "stale-move", response.status_code)
             assert response.status_code == 412
-            assert client.get(key).content == b"replaced"
+            assert client.get(key).content == b"replacement"
             assert client.get(quarantine).status_code == 404
 
     def test_quarantine_survives_client_interruption(self, cleanup_endpoint):


### PR DESCRIPTION
Merged after [all final CI checks passed](https://github.com/xiao-villamor/PrintStash/actions/runs/33996613455).

Two rapid equal-length writes can reuse a Nextcloud ETag, so the stale-validator contract tests occasionally stop before exercising DELETE or MOVE. Use different-length replacement bytes to establish a stale validator deterministically. Keep the ETag inequality, HTTP 412 and exact surviving-byte assertions; existing same-content and colliding-validator cases remain unchanged.

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | Stale DELETE preserves replacement | Edge | Nextcloud/WsgiDAV, changed validator | 412 and replacement bytes survive | Contract | ✅ `tests/contract/services/storage_opendal/test_webdav_cleanup.py::TestWebDAVCleanupEvidence::test_stale_conditional_delete_preserves_replacement` |
| 2 | Stale MOVE preserves replacement | Edge | Nextcloud/WsgiDAV, changed validator | 412, replacement survives, quarantine absent | Contract | ✅ `tests/contract/services/storage_opendal/test_webdav_cleanup.py::TestWebDAVCleanupEvidence::test_stale_quarantine_move_preserves_replacement` |

Validation: all 19 pinned-server WebDAV cleanup contracts passed locally (86.01s); Ruff and diff whitespace checks passed. CI is running. This is test-only; no production behavior changes.
