### PR TITLE
test: synchronize restart and scheduling checks

### DIFF
--- a/backend/tests/integration/core/metrics/test_r2_ops.py
+++ b/backend/tests/integration/core/metrics/test_r2_ops.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 from sqlmodel import Session
@@ -103,8 +103,10 @@ class TestMetricsEndpoint:
 
 class TestResetOrphanedScans:
     def test_reset_orphaned_scans_recovers_stranded_library(
-        self, db_session: Session
+        self, db_session: Session, monkeypatch
     ) -> None:
+        now = datetime(2026, 1, 1, 12, 0, 30, tzinfo=UTC)
+        monkeypatch.setattr(external_library, "utcnow", lambda: now)
         lib = ExternalLibrary(
             name="nas",
             root_path="/mnt/nas",
@@ -134,7 +136,7 @@ class TestResetOrphanedScans:
         assert lib.id not in external_library.libraries_due_for_scan(db_session)
 
         # Once the schedule has elapsed, it becomes eligible again as normal.
-        lib.last_scanned_at = utcnow() - timedelta(minutes=2)
+        lib.last_scanned_at = now - timedelta(minutes=2)
         db_session.add(lib)
         db_session.commit()
         assert lib.id in external_library.libraries_due_for_scan(db_session)

--- a/frontend/tests/e2e-real/scripts/start-storage-backend.sh
+++ b/frontend/tests/e2e-real/scripts/start-storage-backend.sh
@@ -81,10 +81,11 @@ trap cleanup EXIT INT TERM
 start_backend
 while kill -0 "$BACKEND_PID" 2>/dev/null; do
   if [[ -f "$RESTART_TRIGGER" ]]; then
-    rm -f "$RESTART_TRIGGER"
     kill "$BACKEND_PID"
     wait "$BACKEND_PID" || true
     start_backend
+    # Acknowledge only after the old process has exited.
+    rm -f "$RESTART_TRIGGER"
   fi
   sleep 0.2
 done

--- a/frontend/tests/e2e-real/storage/storage-provider.spec.ts
+++ b/frontend/tests/e2e-real/storage/storage-provider.spec.ts
@@ -2,6 +2,7 @@
  * The storage setup headline flow crosses the browser, real API, process restart, and WebDAV.
  * It proves the provider selected during setup becomes the probed active provider afterward.
  */
+import { existsSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -105,6 +106,7 @@ test.describe("storage provider setup", () => {
     await page.getByRole("button", { name: "I'll do this later" }).click();
 
     await writeFile(restartTrigger, "restart\n", "utf8");
+    await expect.poll(() => existsSync(restartTrigger)).toBe(false);
     await expect
       .poll(async () => {
         try {
@@ -180,6 +182,7 @@ test.describe("storage provider setup", () => {
     await page.getByRole("button", { name: "Save configuration" }).click();
 
     await writeFile(restartTrigger, "restart\n", "utf8");
+    await expect.poll(() => existsSync(restartTrigger)).toBe(false);
     await expect
       .poll(async () => {
         try {
@@ -249,6 +252,7 @@ test.describe("storage provider setup", () => {
     await page.getByRole("button", { name: "Save configuration" }).click();
 
     await writeFile(restartTrigger, "restart\n", "utf8");
+    await expect.poll(() => existsSync(restartTrigger)).toBe(false);
     await expect
       .poll(async () => {
         try {


### PR DESCRIPTION
Merged after [required CI checks passed](https://github.com/xiao-villamor/PrintStash/actions/runs/34095514364). The advisory Python 3.13 lane encountered Nextcloud ETag reuse; #137 corrects that fixture.

Storage browser tests could observe health from the old API process, then navigate during shutdown and receive 502 responses. Wait for the restart supervisor to acknowledge that the old process exited before checking new-process health. The orphaned-scan test now pins its clock so crossing a real minute boundary cannot make a scheduled scan legitimately due between assertions.

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | WebDAV settings survive restart | Edge | Setup then supervised restart | Authenticated storage settings and GC lifecycle usable | Playwright | ✅ `frontend/tests/e2e-real/storage/storage-provider.spec.ts` |
| 2 | Recovered scan waits for schedule | Edge | Stranded RUNNING scan, fixed instant | Reset scan not due until scheduled time | Integration | ✅ `backend/tests/integration/core/metrics/test_r2_ops.py::TestResetOrphanedScans::test_reset_orphaned_scans_recovers_stranded_library` |

Validation: 7 backend tests passed; real Chromium WebDAV setup, restart, storage settings and guarded GC lifecycle passed (42.5s). Ruff, frontend types/lint/format and shell syntax passed. Test infrastructure only; no production code changes.
