### PR TITLE
ci(extension): publish the validated chrome zip artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,17 @@ jobs:
           name: browser-extension-chromedriver-log
           path: ${{ runner.temp }}/printstash-chromedriver.log
 
+      - name: Upload Chrome Web Store ZIP
+        uses: actions/upload-artifact@v7
+        with:
+          path: browser-extension/.output/printstash-browser-extension-*-chrome.zip
+          # Upload the tested ZIP itself so it can go straight to the store.
+          archive: false
+          # WXT builds into .output; only the ZIP above is included.
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30
+
   e2e-real:
     name: Real-backend E2E
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 
+- Successful browser-extension CI jobs provide the validated Chrome Web Store
+  ZIP as a direct download, retained for 30 days.
+
 - The browser importer includes offline help and privacy information, with a
   validated Chrome Web Store ZIP command and a publishing guide.
 

--- a/browser-extension/CHROME-WEB-STORE.md
+++ b/browser-extension/CHROME-WEB-STORE.md
@@ -6,6 +6,16 @@ La interfaz y los textos de la ficha están en inglés.
 
 ## Generar el archivo que se sube
 
+En GitHub, abre **Actions → CI**, elige una ejecución y descarga
+`printstash-browser-extension-<version>-chrome.zip` desde **Artifacts**.
+El job **Browser extension** lo publica cuando pasan sus comprobaciones y lo
+conserva durante 30 días. El archivo descargado es el ZIP de la extensión, listo
+para subir a Chrome Web Store. Para generarlo a demanda, usa **Run workflow**
+sobre `main`. También se genera en PRs, cambios en `main` y ejecuciones de CI
+nocturnas o de release.
+
+Para generarlo en tu equipo:
+
 ```bash
 cd browser-extension
 pnpm install --frozen-lockfile

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -12,6 +12,13 @@ extension and generate `.output/printstash-browser-extension-0.13.0-chrome.zip`
 (the filename follows `package.json`). The ZIP contains the production extension
 with its manifest at the root. Chrome and Edge exclude Firefox-specific metadata.
 
+GitHub Actions also generates the ZIP on pull requests, pushes to `main`, release
+CI, nightly runs and manual runs. Open **Actions → CI**, select the run, then
+download `printstash-browser-extension-<version>-chrome.zip` from **Artifacts**.
+The **Browser extension** job publishes it only after its checks pass. This is
+the extension ZIP itself, ready to upload to Chrome Web Store, and is retained
+for 30 days. Use **Run workflow** on `main` to generate a fresh package on demand.
+
 The [publishing guide](CHROME-WEB-STORE.md) includes listing copy, permission
 justifications, privacy disclosures and reviewer instructions. **Help & privacy**
 in the popup opens the packaged help and privacy policy without a server.


### PR DESCRIPTION
## Summary

- The Browser extension CI job already generated and validated the Chrome Web Store ZIP but discarded it when the runner finished. Publish that file after the job's checks pass so it is downloadable from the run's Artifacts section.
- Upload the ZIP directly with `actions/upload-artifact@v7` and `archive: false`, preserve its versioned filename, fail when it is missing, and retain it for 30 days. Only the matching Chrome ZIP from WXT's hidden `.output` directory is included.
- Document downloads and manual runs in the extension README and publishing guide. Existing PR, main, nightly, release-CI and manual triggers remain the entrypoints.

## Testing

- [x] `cd backend && ./scripts/test.sh full` green, or not needed: no backend code changed; the PR's existing CI gate runs normally.
- [x] `cd frontend && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` green, or not needed: no frontend code changed.
- [x] Manual test notes included, or not needed: extension formatting passed; `pnpm zip:chrome && pnpm test:store` generated a production ZIP and passed all 10 package checks. `actionlint` 1.7.12 passed for the modified workflow, with shellcheck disabled. `git diff --check` passed.

The [Browser extension job](https://github.com/xiao-villamor/PrintStash/actions/runs/34103991335/job/101684685310) passed: 159 behavior tests, 10 ZIP tests, the real-backend capture test, and the installed-browser suite. The uploaded file downloaded successfully, contains 12 files with manifest.json at the root, and passes all 10 package tests after downloading. Its SHA-256 is `313cf2b4bc2554ddc306686db8ca717724b31c4638fd45e73215e3fe4e6d52cb`, matching the previously installed store-preparation package. GitHub reports expiration on 2026-10-07.

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|----------------------|----------|----------------------|-----------------------------|------|--------|
| 1 | packages a production MV3 manifest at the ZIP root | Happy | Chrome package generated by CI commands | Root manifest names the extension and matches its package version | Integration | ✅ `browser-extension/tests/store/package.store.ts::packages a production MV3 manifest at the ZIP root` |
| 2 | downloads the generated extension ZIP from GitHub Actions | Happy | Successful Browser extension job | Downloaded artifact has manifest.json at its root and passes the package checks | E2E | ✅ [Real Actions artifact readback](https://github.com/xiao-villamor/PrintStash/actions/runs/34103991335/artifacts/10011646757): downloaded the raw ZIP; all 10 package tests passed against that download |
| 3 | suppresses the upload after a failed validation step | Error | A preceding job step fails | No store ZIP is published | E2E | ⏭️ N/A — standard GitHub Actions success gating, inspected in the workflow; no custom failure logic |
| 4 | fails when the upload file is absent | Error | No Chrome ZIP matches the upload path | Upload action reports an error | Integration | ⏭️ N/A — standard upload-artifact input, checked by actionlint; no custom file-selection logic |

## Notes

No schema, API, storage, provider, extension runtime, permission or version changes. This reversible CI configuration change uses existing package tests and a real Actions artifact readback rather than adding tests that restate YAML. Thirty-day expiration is managed by GitHub.

Direct-file upload is documented in [actions/upload-artifact](https://github.com/actions/upload-artifact#upload-an-individual-file-unzipped).
