### PR TITLE
fix(extension): use PrintStash as the display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- The browser extension is now named PrintStash in the browser, help and store
+  listing. Its connection settings and extension identity are unchanged.
+
 ### Added
 
 - Successful browser-extension CI jobs provide the validated Chrome Web Store

--- a/browser-extension/CHROME-WEB-STORE.md
+++ b/browser-extension/CHROME-WEB-STORE.md
@@ -1,4 +1,4 @@
-# Publicar PrintStash Model Importer en Chrome Web Store
+# Publicar PrintStash en Chrome Web Store
 
 Este documento prepara una primera publicación. La extensión requiere una
 instancia de PrintStash; no incluye un servidor ni crea una cuenta de alojamiento.
@@ -43,7 +43,7 @@ ni inicia un navegador y no sustituye esta prueba.
 
 ## Textos de la ficha
 
-**Name:** PrintStash Model Importer
+**Name:** PrintStash
 
 **Summary:** Send models from MakerWorld, Printables, Thingiverse, or direct file links to PrintStash.
 
@@ -54,8 +54,8 @@ ni inicia un navegador y no sustituye esta prueba.
 ```text
 Bring the models you find online into your own PrintStash library.
 
-PrintStash Model Importer connects your browser to a self-hosted PrintStash
-server. Send a supported model page or direct file link to Pending Imports,
+The PrintStash browser extension connects your browser to your self-hosted
+PrintStash server. Send a supported model page or direct file link to Pending Imports,
 then review the files before adding them to your library.
 
 • Pair your browser with a one-time code from PrintStash Settings → Imports.

--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,4 +1,4 @@
-# PrintStash Model Importer
+# PrintStash
 
 This Manifest V3 Chrome and Firefox extension recognizes MakerWorld, Printables, and
 Thingiverse model pages, Printables collections, and direct model/archive file

--- a/browser-extension/entrypoints/help/index.html
+++ b/browser-extension/entrypoints/help/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Help &amp; privacy — PrintStash Model Importer</title>
+    <title>Help &amp; privacy — PrintStash</title>
   </head>
   <body class="help-page">
     <main>
       <header class="header">
         <img class="brand-mark" src="/icon.svg" alt="" width="36" height="36" />
         <div>
-          <h1>PrintStash Model Importer</h1>
+          <h1>PrintStash</h1>
           <p class="section-description">Help &amp; privacy</p>
         </div>
       </header>
@@ -71,9 +71,9 @@
       <section aria-labelledby="privacy">
         <h2 id="privacy">Privacy policy</h2>
         <p>
-          This policy covers PrintStash Model Importer. The extension sends the models you choose to
-          the PrintStash server you configure. It has no advertising, analytics or telemetry
-          service.
+          This policy covers the PrintStash browser extension. The extension sends the models you
+          choose to the PrintStash server you configure. It has no advertising, analytics or
+          telemetry service.
         </p>
         <h3>Data used by the extension</h3>
         <p>

--- a/browser-extension/entrypoints/popup/index.html
+++ b/browser-extension/entrypoints/popup/index.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Import model to PrintStash</title>
+    <title>PrintStash</title>
   </head>
   <body>
     <main>
       <header class="header">
         <img class="brand-mark" src="/icon.svg" alt="" width="36" height="36" />
         <div>
-          <p class="eyebrow">PrintStash</p>
-          <h1>Model importer</h1>
+          <p class="eyebrow">Browser extension</p>
+          <h1>PrintStash</h1>
           <p class="release-version" id="runtime-marker">Version</p>
         </div>
       </header>

--- a/browser-extension/tests/e2e/loaded-extension.e2e.ts
+++ b/browser-extension/tests/e2e/loaded-extension.e2e.ts
@@ -54,7 +54,7 @@ declare const chrome: {
   scripting?: { executeScript?: unknown };
 };
 
-const EXTENSION_NAME = "PrintStash Model Importer";
+const EXTENSION_NAME = "PrintStash";
 const FIREFOX_ADDON_ID = "printstash-model-importer@printstash.local";
 
 describe("loaded extension", () => {
@@ -105,7 +105,7 @@ describe("loaded extension", () => {
     await browser.switchToWindow(handle);
 
     assert.match(await browser.getUrl(), /^(?:chrome|moz)-extension:\/\/[^/]+\/help\.html$/);
-    assert.equal(await browser.$("h1").getText(), "PrintStash Model Importer");
+    assert.equal(await browser.$("h1").getText(), "PrintStash");
     assert.equal(await browser.$("#privacy").getText(), "Privacy policy");
     assert.match(
       await browser.$("body").getText(),

--- a/browser-extension/tests/store/package.store.ts
+++ b/browser-extension/tests/store/package.store.ts
@@ -15,7 +15,7 @@ describe("Chrome Web Store ZIP", () => {
   it("packages a production MV3 manifest at the ZIP root", () => {
     expect(manifest.manifest_version).toBe(3);
     expect(manifest.version).toBe(metadata.version);
-    expect(manifest.name).toBe("PrintStash Model Importer");
+    expect(manifest.name).toBe("PrintStash");
     expect(manifest.description.length).toBeGreaterThan(0);
     expect(manifest.description.length).toBeLessThanOrEqual(132);
     expect(manifest.action.default_popup).toBe("popup.html");

--- a/browser-extension/wxt.config.ts
+++ b/browser-extension/wxt.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
     },
   },
   manifest: ({ browser }) => ({
-    name: "PrintStash Model Importer",
+    name: "PrintStash",
     description:
       "Send models from MakerWorld, Printables, Thingiverse, or direct file links to PrintStash.",
     permissions: ["activeTab", "scripting", "storage"],
@@ -35,7 +35,7 @@ export default defineConfig({
           }
         : undefined,
     action: {
-      default_title: "Import model to PrintStash",
+      default_title: "PrintStash",
       default_icon: {
         16: "icon-16.png",
         32: "icon-32.png",


### PR DESCRIPTION
## Summary

- Rename the browser extension to **PrintStash**, the name selected by the user, in the manifest, toolbar title, popup, help and Chrome Web Store listing.
- Update the existing package and installed-browser assertions to require the new name. Clarify that the bundled privacy policy covers the browser extension.

## Testing

- [x] Backend full gate: not needed for this name-only extension change.
- [x] Frontend checks: not needed; browser-extension checks run below.
- [x] Manual notes: `pnpm package:chrome` passed formatting, lint, types, 159 behavior tests, all three browser builds and 10 package tests. Both installed-Chrome E2E tests passed against files extracted from the generated ZIP. Browser inspection confirmed the popup title, heading and runtime manifest name are PrintStash, with no horizontal overflow or page errors. Store screenshots were regenerated from that installation.

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|----------------------|----------|----------------------|-----------------------------|------|--------|
| 1 | packages a production MV3 manifest at the ZIP root | Happy | New Chrome ZIP | Manifest name is PrintStash | Integration | ✅ `browser-extension/tests/store/package.store.ts::packages a production MV3 manifest at the ZIP root` |
| 2 | displays PrintStash in the popup | Happy | Installed ZIP opened in Chrome | Popup title and heading display PrintStash | Playwright | ✅ Browser readback and regenerated screenshots; no new test for this copy-only change |
| 3 | opens packaged help from the installed popup | Happy | Open Help & privacy | Help heading is PrintStash | E2E | ✅ `browser-extension/tests/e2e/loaded-extension.e2e.ts::opens packaged help from the installed popup` |

## Notes

Display-name change only. Package filename, version, Firefox add-on ID, permissions and stored connection configuration retain their existing values. The public policy name is updated in a separate printstash-landing change. No schema, API, storage or provider behavior changes.
