### PR TITLE
docs(known-limitations): channel secrets are encrypted at rest since v0.10.0

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -152,9 +152,9 @@ manufacturing platform.
 - Notifications are opt-in, off by default, and superuser-managed.
 - Channels cover print completed/failed/cancelled and printer-offline events,
   delivered to generic webhooks, Discord, Telegram, or ntfy.
-- Channel secrets (webhook URLs, bot tokens, signing secrets) are stored
-  unencrypted in the database, like the other configured secrets. Keep your
-  install on a trusted network.
+- Channel secrets (webhook URLs, bot tokens, signing secrets) are encrypted at
+  rest in the database, like the other configured secrets, and read APIs mask
+  them. Keep your install on a trusted network.
 - Delivery is at-least-once: a retried or recovered send can arrive more than
   once, so receivers should de-duplicate on the `Idempotency-Key` header.
 - The dispatcher is built for the supported single-process deployment. Its


### PR DESCRIPTION
## What

Fixes a stale statement in `docs/known-limitations.md`: the Notifications section says channel secrets (webhook URLs, bot tokens, signing secrets) are "stored unencrypted in the database, like the other configured secrets."

That stopped being true at v0.10.0. Migration `e2d4f6a8b0c1` ("encrypt persisted integration credentials", landed 2026-07-14 in the v0.10.0 release commit f78604be86) encrypts `notification_channels.config_json` at rest alongside printer credentials and system-config secrets. The model declares it as `EncryptedText` (`backend/app/db/models.py`, `NotificationChannel.config_json`), and the notification read endpoints mask secret-bearing config rather than returning it (`backend/app/api/v1/notifications.py`).

## Evidence

- Migration: `backend/alembic/versions/e2d4f6a8b0c1_encrypt_persisted_credentials.py` (encrypts `notification_channels.config_json`)
- Introduced by commit f78604be86 (v0.10.0, 2026-07-14)
- Model: `NotificationChannel.config_json` uses `EncryptedText` at `backend/app/db/models.py`
- API: `backend/app/api/v1/notifications.py` masks secret values on reads
- Found by the weekly blog curation audit (2026-09-06/07), which had already corrected the same claim on the marketing blog

## Change

Channel secrets are now described as encrypted at rest, with read APIs masking them, matching the other configured secrets already covered in this file.