### PR TITLE
fix(deployment): use light API in simple compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- The simple Docker Compose deployment now uses the light API image.
+
 - The browser extension is now named PrintStash in the browser, help and store
   listing. Its connection settings and extension identity are unchanged.
 

--- a/backend/tests/repo/test_simple_compose.py
+++ b/backend/tests/repo/test_simple_compose.py
@@ -51,13 +51,19 @@ class TestSimpleCompose:
         assert set(simple_config["services"]) == {"frontend", "api"}
         assert not simple_config["services"]["api"].get("env_file")
 
-    @pytest.mark.parametrize("service", ["api", "frontend"], ids=str)
-    def test_uses_prebuilt_full_images(
-        self, simple_config: dict[str, Any], service: str
+    @pytest.mark.parametrize(
+        ("service", "image"),
+        [
+            pytest.param("api", "printstash-api-lite", id="api-lite"),
+            pytest.param("frontend", "printstash-frontend", id="frontend"),
+        ],
+    )
+    def test_uses_prebuilt_images(
+        self, simple_config: dict[str, Any], service: str, image: str
     ) -> None:
         config = simple_config["services"][service]
 
-        assert config["image"] == f"ghcr.io/xiao-villamor/printstash-{service}:latest"
+        assert config["image"] == f"ghcr.io/xiao-villamor/{image}:latest"
         assert "build" not in config
 
     @pytest.mark.parametrize(

--- a/docker-compose.simple.yml
+++ b/docker-compose.simple.yml
@@ -11,7 +11,7 @@ services:
         condition: service_healthy
 
   api:
-    image: ghcr.io/xiao-villamor/printstash-api:${PRINTSTASH_VERSION:-latest}
+    image: ghcr.io/xiao-villamor/printstash-api-lite:${PRINTSTASH_VERSION:-latest}
     restart: unless-stopped
     environment:
       VAULT_SETUP_MODE: trusted_network

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,8 +1,9 @@
 # Deployment and optional settings
 
 For a new local installation, use [docker-compose.simple.yml](../docker-compose.simple.yml).
-It starts the full API and web UI with SQLite and local storage. The short file
-uses the images' built-in defaults; you only add settings you need.
+It starts the light API and web UI with SQLite and local storage. The short file
+uses the images' built-in defaults; you only add settings you need. The light API
+omits browser automation and STEP tessellation.
 
 ## Install
 
@@ -262,7 +263,7 @@ at `http://localhost:3000/api/v1/health` (use your chosen host/port).
 
 | File | Purpose |
 | --- | --- |
-| **`docker-compose.simple.yml`** | **Recommended for a new local install.** Full images, two services, minimal configuration. |
+| **`docker-compose.simple.yml`** | **Recommended for a new local install.** Light API image, two services, minimal configuration. |
 | `docker-compose.yml` | Existing configurable deployment with opt-in PostgreSQL and S3 profiles. |
 | `docker-compose.light.yml` | Smaller API image without browser automation or STEP tessellation; exposes advanced variables. |
 | `docker-compose.prod.yml` | Standalone configuration for a TLS reverse proxy, with localhost binding and log rotation. |


### PR DESCRIPTION
## Summary

- Use `printstash-api-lite` in `docker-compose.simple.yml`, preserving the optional version tag.
- Update deployment documentation and changelog to describe the light API default.

## Testing

- [x] Backend full suite not needed: deployment image selection only. `uv run pytest tests/repo/test_simple_compose.py -q`: 19 passed; focused Ruff check passed.
- [x] Frontend checks not needed: no frontend changes.
- [x] Compose configuration rendered by regression tests; no running deployment changed.

## Coverage matrix

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | Uses prebuilt images | Happy | Default settings | API resolves to `printstash-api-lite:latest`; frontend retains its image | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_uses_prebuilt_images` |
| 2 | Accepts optional image tag | Edge | Custom version | Requested tag retained on both images | Repo | ✅ `repo/test_simple_compose.py::TestSimpleCompose::test_accepts_optional_image_tag` |

### Tier check

Existing `repo/` Compose regression test updated. No new test files, endpoints, entities, or fixtures.

### Self-check

- [x] Each test covers one behaviour.
- [x] No skips or xfails added.

## Notes

The light API omits browser automation and STEP tessellation. No schema, storage, or printer-provider changes.
