### PR TITLE
Fix i18n maintainability and locale authoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Interface text, accessible labels, errors, plural counts and offline screens
   use shared language catalogs. Dates and numbers follow the selected language;
   the language menu supports adding further locales without a two-language toggle.
+  Catalogs are static, typo-friendly sources with guarded imperative feedback and
+  a safe scaffold command for adding complete language drafts.
 
 - Backend code is organized by capability, with separate startup, storage,
   backup recovery and library query modules. G-code Revision deletion uses a

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,6 +1,8 @@
 # Frontend localization
 
-All application copy belongs to the catalogs in `frontend/src/locales`. The English catalog defines message identifiers; every supported language must provide the same identifiers and interpolation parameters. Existing descriptive identifiers and explicit source-message identifiers share one catalog. English source text inside `uiText(...)` is a checked message identifier, not an untranslated DOM fallback.
+All application copy belongs to the static catalogs in `frontend/src/locales`. Catalogs are hardcoded JSON, imported into the application bundle and reviewed in source control; PrintStash never downloads UI text or rewrites it at runtime. The English catalog defines message identifiers; every supported language must provide the same identifiers and interpolation parameters.
+
+Prefer stable semantic identifiers such as `printer.cooldownSuccess` for new copy. Correct spelling or wording in the catalog value without renaming the identifier, so a typo fix is one edit and does not churn every component. Older source-message identifiers remain supported, but never duplicate their English value as a component fallback: the catalog is the single source of truth.
 
 Use `useI18n().t(key, values)` in React or `uiText(key, values)` in display helpers. Components using imperative helpers subscribe through `useUiLocale()` so a language change updates their output, including dialogs rendered in portals. Keep user names, tags, filenames, paths, descriptions and license content as interpolation values or ordinary React text; never pass them through a phrase translator.
 
@@ -14,9 +16,9 @@ The UI no longer relies on a MutationObserver rewriting arbitrary text nodes. Lo
 
 ## Adding a language
 
-1. Copy `frontend/src/locales/en.json` to a catalog named with its BCP 47 language tag and translate every message. Preserve interpolation names. Translate system-owned labels and abbreviated card labels too; keep brands and standard units when appropriate.
-2. Import the catalog in `frontend/src/locales/catalogs.ts` and add its native name, direction and messages to `localeDefinitions`. The menu and offline/manifest assets derive from this registry.
-3. Use the CLDR plural categories needed by the language, always including `other`. Run the catalog and JSX guard tests, typecheck and the localization browser flow.
+1. From `frontend/`, run `pnpm i18n:add -- <BCP-47 tag> "<native name>" <ltr|rtl>`, for example `pnpm i18n:add -- fr "Français" ltr`. The command canonicalizes the tag, refuses invalid or duplicate registrations, creates a complete hardcoded JSON catalog and adds its static import to `catalogs.ts`.
+2. Translate every `TODO(<tag>):` value in the new catalog. Preserve interpolation names. Translate system-owned labels and abbreviated card labels too; keep brands and standard units when appropriate. Draft markers deliberately fail validation, so an unfinished language cannot pass unnoticed.
+3. Use the CLDR plural categories needed by the language, always including `other`. Run `pnpm i18n:check`, `pnpm typecheck` and the localization browser flow. The catalog guard verifies exact keys, plural shapes, interpolation parameters, non-empty values, encoded HTML entities and unfinished draft markers.
 4. Review narrow screens, long translations and screen-reader labels in the new language. For an RTL language, verify layout direction in the browser before releasing it; setting the document direction alone is not an RTL layout audit.
 
 Technical diagnostics, filenames, user descriptions and provider-owned configuration dumps are data and remain unchanged. New provider-authored UI labels need corresponding catalog entries; unknown API errors use localized recovery copy.
@@ -65,3 +67,10 @@ Focused checks exercise the observable behaviors below. The repository guard als
 | 36 | translates legacy controlled task titles | Edge | Persisted task predates message descriptors | Known controlled title renders in Spanish | Frontend unit | ✅ `src/lib/__tests__/task-center.test.ts::translates legacy controlled task titles` |
 | 37 | localizes failed task error details | Error | Persisted failed task contains a known error code | Detail renders as the Spanish recovery message | Frontend unit | ✅ `src/lib/__tests__/task-center.test.ts::localizes failed task error details` |
 | 38 | links the default localized web manifest | Happy | English document initial load | Manifest link selects the English asset and the linked manifest has the installable shape | Playwright | ✅ `tests/e2e/pwa.spec.ts::the web app manifest is served with the expected shape` |
+| 39 | rejects hardcoded imperative presentation copy | Error | Toast or configured helper text contains a raw authored string | Repository guard reports the source | Frontend unit | ✅ `tests/repo/i18n-coverage.test.ts::rejects hardcoded imperative presentation copy` |
+| 40 | rejects encoded entities and unfinished drafts | Error | A catalog value contains an HTML entity or `TODO(locale):` marker | Catalog validation fails with its locale and key | Frontend unit | ✅ `tests/repo/i18n-coverage.test.ts::validates every key, plural form and parameter in %s` |
+| 41 | scaffolds a complete static language | Happy | Valid BCP 47 tag, native name and direction | Complete JSON draft and static registry import are created | Frontend unit | ✅ `tests/repo/locale-authoring.test.ts::creates a complete statically registered hardcoded draft` |
+| 42 | rejects invalid and duplicate locale requests | Error | Invalid tag/direction or an existing catalog | No existing locale is overwritten | Frontend unit | ✅ `tests/repo/locale-authoring.test.ts` |
+| 43 | localizes configured signing-secret guidance | Happy | Spanish channel-creation form | HMAC placeholder is shown in Spanish | Frontend unit | ✅ `src/components/__tests__/notifications-panel.test.tsx::localizes explanatory configuration placeholders` |
+| 44 | localizes imperative success feedback | Happy | Spanish revision update or printer cooldown | Success toast uses the active catalog | Frontend unit | ✅ `src/components/model-detail/__tests__/revisions-tab.test.tsx::localizes a successful revision update`; `src/components/__tests__/printer-detail.test.tsx::localizes the cooldown confirmation` |
+| 45 | pluralizes folder batch feedback | Edge | One selected folder is renamed | Singular catalog form reports one renamed folder | Frontend unit | ✅ `src/components/__tests__/model-grid.test.tsx::renames the folders the user picked` |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,8 @@
     "test:perf": "playwright test --config=playwright.performance.config.ts",
     "test:perf:react-compiler": "PERF_BUILD_MODE=react-compiler playwright test --config=playwright.performance.config.ts",
     "test:frontend": "node scripts/frontend-smoke.mjs",
+    "i18n:add": "node scripts/scaffold-locale.mjs",
+    "i18n:check": "vitest run tests/repo/i18n-coverage.test.ts tests/repo/locale-authoring.test.ts tests/repo/localization-assets.test.ts src/lib/__tests__/locale.test.ts",
     "media:readme": "node scripts/generate-readme-media.mjs",
     "lint:fix": "oxlint --fix --deny-warnings",
     "format": "oxfmt .",

--- a/frontend/scripts/scaffold-locale.mjs
+++ b/frontend/scripts/scaffold-locale.mjs
@@ -1,0 +1,94 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function canonicalLocale(value) {
+  try {
+    const locale = Intl.getCanonicalLocales(value)[0];
+    if (locale && /^[A-Za-z0-9-]+$/.test(locale)) return locale;
+  } catch {
+    // Intl owns BCP 47 parsing; callers receive one stable authoring error.
+  }
+  throw new Error(`Invalid locale tag: ${value}`);
+}
+
+function draftMessage(value, locale) {
+  if (value instanceof Object)
+    return Object.fromEntries(
+      Object.entries(value).map(([form, message]) => [form, draftMessage(message, locale)]),
+    );
+  return `TODO(${locale}): ${String(value)}`;
+}
+
+function importName(locale) {
+  return `catalog${locale
+    .split("-")
+    .map((part) => `${part[0].toUpperCase()}${part.slice(1).toLowerCase()}`)
+    .join("")}`;
+}
+
+/**
+ * Create a complete, bundled locale draft and register its static JSON import.
+ * Draft markers deliberately fail the catalog guard until every value is reviewed.
+ */
+export function scaffoldLocale({ rootDir, locale: rawLocale, name, direction }) {
+  if (direction !== "ltr" && direction !== "rtl")
+    throw new Error('Direction must be either "ltr" or "rtl".');
+  if (!name?.trim()) throw new Error("A native language name is required.");
+
+  const locale = canonicalLocale(rawLocale);
+  const localesDir = join(rootDir, "src/locales");
+  const sourcePath = join(localesDir, "en.json");
+  const catalogPath = join(localesDir, `${locale}.json`);
+  const registryPath = join(localesDir, "catalogs.ts");
+  if (existsSync(catalogPath)) throw new Error(`Locale ${locale} already exists.`);
+
+  const registry = readFileSync(registryPath, "utf8");
+  const specifier = `./${locale}.json`;
+  if (registry.includes(specifier)) throw new Error(`Locale ${locale} already exists.`);
+
+  const source = JSON.parse(readFileSync(sourcePath, "utf8"));
+  const draft = Object.fromEntries(
+    Object.entries(source).map(([key, message]) => [key, draftMessage(message, locale)]),
+  );
+  const identifier = importName(locale);
+  const importLine = `import ${identifier} from ${JSON.stringify(specifier)} with { type: "json" };\n`;
+  const lastImport = [...registry.matchAll(/^import .*;\n/gm)].at(-1);
+  if (!lastImport) throw new Error("Could not find the static locale imports in catalogs.ts.");
+  const importEnd = lastImport.index + lastImport[0].length;
+  const withImport = `${registry.slice(0, importEnd)}${importLine}${registry.slice(importEnd)}`;
+  const key = /^[A-Za-z_$][\w$]*$/.test(locale) ? locale : JSON.stringify(locale);
+  const definition = `  ${key}: { name: ${JSON.stringify(name.trim())}, direction: ${JSON.stringify(direction)}, messages: ${identifier} },\n`;
+  if (!withImport.includes("} satisfies Record"))
+    throw new Error("Could not find localeDefinitions in catalogs.ts.");
+  const nextRegistry = withImport.replace("} satisfies Record", `${definition}} satisfies Record`);
+
+  writeFileSync(catalogPath, `${JSON.stringify(draft, null, 2)}\n`);
+  writeFileSync(registryPath, nextRegistry);
+  return { locale, catalogPath, registryPath };
+}
+
+const invokedPath = process.argv[1];
+if (invokedPath && fileURLToPath(import.meta.url) === invokedPath) {
+  const args = process.argv.slice(2);
+  if (args[0] === "--") args.shift();
+  const [locale, name, direction = "ltr"] = args;
+  if (!locale || !name) {
+    console.error('Usage: pnpm i18n:add -- <BCP-47 tag> "<native name>" [ltr|rtl]');
+    process.exitCode = 1;
+  } else {
+    try {
+      const result = scaffoldLocale({
+        rootDir: dirname(dirname(invokedPath)),
+        locale,
+        name,
+        direction,
+      });
+      console.log(`Created ${result.catalogPath}`);
+      console.log(`Translate every TODO(${result.locale}) marker, then run pnpm i18n:check.`);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    }
+  }
+}

--- a/frontend/src/components/__tests__/model-grid.test.tsx
+++ b/frontend/src/components/__tests__/model-grid.test.tsx
@@ -916,6 +916,7 @@ describe("ModelBrowser", () => {
           name: "Spares",
         }),
       );
+      expect(await screen.findByText("Renamed 1 folder")).toBeInTheDocument();
     });
 
     it("offers no tagging when a folder is in the selection", async () => {
@@ -1315,6 +1316,7 @@ describe("ModelBrowser", () => {
           name: "PLA only",
         }),
       );
+      expect(await screen.findByText("Saved view renamed")).toBeInTheDocument();
     });
 
     it("duplicates a view under a name nobody is using", async () => {

--- a/frontend/src/components/__tests__/notifications-panel.test.tsx
+++ b/frontend/src/components/__tests__/notifications-panel.test.tsx
@@ -116,9 +116,13 @@ function stubDeps(over: Partial<NotificationsPanelDeps> = {}): NotificationsPane
   };
 }
 
-function renderPanel(over: Partial<NotificationsPanelDeps> = {}, canEdit = true) {
+function renderPanel(
+  over: Partial<NotificationsPanelDeps> = {},
+  canEdit = true,
+  locale: import("@/lib/locale").Locale = "en",
+) {
   const deps = stubDeps(over);
-  const result = renderApp(<NotificationsPanel canEdit={canEdit} deps={deps} />);
+  const result = renderApp(<NotificationsPanel canEdit={canEdit} deps={deps} />, { locale });
   return { ...result, deps };
 }
 
@@ -340,6 +344,17 @@ describe("NotificationsPanel", () => {
       await user.selectOptions(screen.getByRole("combobox"), "telegram");
 
       expect(screen.getByPlaceholderText("123456:ABC-DEF…")).toBeInTheDocument();
+    });
+
+    it("localizes explanatory configuration placeholders", async () => {
+      const user = userEvent.setup();
+      renderPanel({}, true, "es");
+
+      await user.click(await screen.findByRole("button", { name: "Añadir canal" }));
+
+      expect(
+        screen.getByPlaceholderText("se usa para firmar la carga útil con HMAC"),
+      ).toBeInTheDocument();
     });
 
     it("drops config typed for the previous target", async () => {

--- a/frontend/src/components/__tests__/printer-detail.test.tsx
+++ b/frontend/src/components/__tests__/printer-detail.test.tsx
@@ -401,6 +401,19 @@ describe("PrinterDetailPage", () => {
       );
     });
 
+    it("localizes the cooldown confirmation", async () => {
+      const user = userEvent.setup();
+      renderPrinter({
+        locale: "es",
+        routes: { "POST /api/v1/printers/4/temperature": json({ ok: true }) },
+      });
+      await screen.findByText("Voron");
+
+      await user.click(screen.getByRole("button", { name: "Enfriar" }));
+
+      expect(await screen.findByText("Enfriando")).toBeInTheDocument();
+    });
+
     it("offers no presets on a printer that takes no G-code", async () => {
       // Bambu in LAN mode accepts jobs but not raw commands, so a preheat
       // button there is a button that answers 409.

--- a/frontend/src/components/gcode-viewer.tsx
+++ b/frontend/src/components/gcode-viewer.tsx
@@ -170,7 +170,6 @@ class GcodeErrorBoundary extends React.Component<
 function viewerCopy(
   i18n: ReturnType<typeof useOptionalI18n>,
   key: MessageKey,
-  _fallback: string,
   values?: Record<string, string>,
 ): string {
   return i18n?.t(key, values) ?? uiText(key, values);
@@ -270,28 +269,18 @@ export function GcodeViewer({
     };
   }, [url, toolpathParser, retry]);
 
-  const loadingCopy = viewerCopy(i18n, "viewer.loadingToolpath", "Loading toolpath…");
-  const renderFailedCopy = viewerCopy(i18n, "viewer.renderFailed", "G-code render failed");
+  const loadingCopy = viewerCopy(i18n, "viewer.loadingToolpath");
+  const renderFailedCopy = viewerCopy(i18n, "viewer.renderFailed");
   const errors = {
-    limit: [
-      "viewer.segmentLimit",
-      "This preview exceeds the one-million-segment limit. Download the original to inspect it in your slicer.",
-    ],
-    resource: [
-      "viewer.resourceLimit",
-      "This preview exceeds the server's size or time limit. Download the original to inspect it in your slicer.",
-    ],
-    busy: ["viewer.converterBusy", "Other previews are being prepared. Try again shortly."],
-    invalid: [
-      "viewer.invalidToolpath",
-      "This file could not be validated as a supported toolpath. The original remains available.",
-    ],
-    load: ["viewer.loadFailed", "Unable to load the toolpath preview."],
-  } as const;
-  const [errorKey, errorFallback] = errors[errorKind ?? "load"];
-  const errorCopy = viewerCopy(i18n, errorKey, errorFallback);
-  const noDataCopy = viewerCopy(i18n, "viewer.noToolpathData", "No toolpath data");
-  const noToolpathCopy = viewerCopy(i18n, "viewer.noToolpathFound", "No toolpath found in file");
+    limit: "viewer.segmentLimit",
+    resource: "viewer.resourceLimit",
+    busy: "viewer.converterBusy",
+    invalid: "viewer.invalidToolpath",
+    load: "viewer.loadFailed",
+  } satisfies Record<NonNullable<LoadedToolpath["errorKind"]>, MessageKey>;
+  const errorCopy = viewerCopy(i18n, errors[errorKind ?? "load"]);
+  const noDataCopy = viewerCopy(i18n, "viewer.noToolpathData");
+  const noToolpathCopy = viewerCopy(i18n, "viewer.noToolpathFound");
 
   if (loading) {
     return (
@@ -317,7 +306,7 @@ export function GcodeViewer({
             setRetry((value) => value + 1);
           }}
         >
-          {viewerCopy(i18n, "viewer.retry", "Try preview again")}
+          {viewerCopy(i18n, "viewer.retry")}
         </Button>
       </div>
     );
@@ -355,14 +344,14 @@ export function GcodeViewer({
         <div className="bg-surface-container-lowest/90 backdrop-blur border border-outline-variant rounded px-3 py-2 flex flex-col gap-1.5">
           <div className="flex items-center justify-between gap-2">
             <span className="font-mono text-3xs uppercase tracking-wider text-muted-foreground">
-              {viewerCopy(i18n, "viewer.layer", "Layer {current} / {total}", {
+              {viewerCopy(i18n, "viewer.layer", {
                 current: String(currentLayer + 1),
                 total: String(data.totalLayers),
               })}
               {data.layerRanges[currentLayer] && (
                 <>
                   {" · "}
-                  {viewerCopy(i18n, "viewer.z", "Z {value} mm", {
+                  {viewerCopy(i18n, "viewer.z", {
                     value: formatNumber(data.layerRanges[currentLayer].z, {
                       minimumFractionDigits: 2,
                       maximumFractionDigits: 2,
@@ -379,7 +368,6 @@ export function GcodeViewer({
                 aria-label={viewerCopy(
                   i18n,
                   showTravel ? "viewer.hideTravel" : "viewer.showTravel",
-                  showTravel ? "Hide travel moves" : "Show travel moves",
                 )}
                 className={`font-mono text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded border transition-colors ${
                   showTravel
@@ -387,25 +375,21 @@ export function GcodeViewer({
                     : "border-outline-variant text-muted-foreground hover:text-foreground"
                 }`}
               >
-                {viewerCopy(i18n, "viewer.travel", "Travel")}
+                {viewerCopy(i18n, "viewer.travel")}
               </button>
               {printerBedMm && (
                 <button
                   type="button"
                   onClick={() => setShowBed((v) => !v)}
                   aria-pressed={showBed}
-                  aria-label={viewerCopy(
-                    i18n,
-                    showBed ? "viewer.hideBed" : "viewer.showBed",
-                    showBed ? "Hide build plate" : "Show build plate",
-                  )}
+                  aria-label={viewerCopy(i18n, showBed ? "viewer.hideBed" : "viewer.showBed")}
                   className={`font-mono text-3xs uppercase tracking-wider px-1.5 py-0.5 rounded border transition-colors ${
                     showBed
                       ? "border-blue-500 dark:border-blue-400 text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30"
                       : "border-outline-variant text-muted-foreground hover:text-foreground"
                   }`}
                 >
-                  {viewerCopy(i18n, "viewer.bed", "Bed {x}×{y}", {
+                  {viewerCopy(i18n, "viewer.bed", {
                     x: String(printerBedMm.x),
                     y: String(printerBedMm.y),
                   })}
@@ -414,7 +398,7 @@ export function GcodeViewer({
             </div>
           </div>
           <input
-            aria-label={viewerCopy(i18n, "viewer.currentLayer", "Current layer")}
+            aria-label={viewerCopy(i18n, "viewer.currentLayer")}
             type="range"
             min={0}
             max={data.totalLayers - 1}

--- a/frontend/src/components/model-detail/__tests__/revisions-tab.test.tsx
+++ b/frontend/src/components/model-detail/__tests__/revisions-tab.test.tsx
@@ -161,6 +161,19 @@ describe("RevisionsTab", () => {
         }),
       );
     });
+
+    it("localizes a successful revision update", async () => {
+      const user = userEvent.setup();
+      renderRevisions({
+        locale: "es",
+        routes: { "PATCH /api/v1/models/1/files/20/revision": json(aModel()) },
+      });
+      await user.click((await screen.findAllByRole("button", { name: "Editar revisión" }))[0]);
+
+      await user.click(screen.getByRole("button", { name: "Guardar" }));
+
+      expect(await screen.findByText("Revisión actualizada")).toBeInTheDocument();
+    });
   });
 
   describe("deleting a revision", () => {

--- a/frontend/src/components/model-detail/source-tab.tsx
+++ b/frontend/src/components/model-detail/source-tab.tsx
@@ -52,31 +52,31 @@ const sourceTabApi: SourceTabApi = {
 };
 
 const LABELS = {
-  title: ["source.field.title", "Title"],
-  description: ["source.field.description", "Description"],
-  instructions: ["source.field.instructions", "Instructions"],
-  creator_name: ["source.field.creatorName", "Creator"],
-  creator_id: ["source.field.creatorId", "Creator ID"],
-  creator_url: ["source.field.creatorUrl", "Creator profile"],
-  license_code: ["source.field.licenseCode", "License code"],
-  license_url: ["source.field.licenseUrl", "License URL"],
-  license_text: ["source.field.licenseText", "License"],
-  attribution_text: ["source.field.attributionText", "Attribution"],
-  published_at: ["source.published", "Published"],
-  updated_at: ["source.updated", "Updated"],
-} satisfies Record<ProvenanceFieldRead["field_name"], [MessageKey, string]>;
+  title: "source.field.title",
+  description: "source.field.description",
+  instructions: "source.field.instructions",
+  creator_name: "source.field.creatorName",
+  creator_id: "source.field.creatorId",
+  creator_url: "source.field.creatorUrl",
+  license_code: "source.field.licenseCode",
+  license_url: "source.field.licenseUrl",
+  license_text: "source.field.licenseText",
+  attribution_text: "source.field.attributionText",
+  published_at: "source.published",
+  updated_at: "source.updated",
+} satisfies Record<ProvenanceFieldRead["field_name"], MessageKey>;
 
 const ORIGIN_LABELS = {
-  confirmed: ["source.origin.confirmed", "Source"],
-  inferred: ["source.origin.inferred", "Inferred"],
-  user: ["source.origin.user", "Edited"],
-} satisfies Record<ProvenanceOrigin, [MessageKey, string]>;
+  confirmed: "source.origin.confirmed",
+  inferred: "source.origin.inferred",
+  user: "source.origin.user",
+} satisfies Record<ProvenanceOrigin, MessageKey>;
 
 function provenanceOriginLabel(
   origin: ProvenanceOrigin,
   i18n: ReturnType<typeof useOptionalI18n>,
 ): string {
-  const [key] = ORIGIN_LABELS[provenanceOriginKey(origin)];
+  const key = ORIGIN_LABELS[provenanceOriginKey(origin)];
   return i18n?.t(key) ?? uiText(key);
 }
 
@@ -101,10 +101,9 @@ function SourceField({
 }) {
   useUiLocale();
   const i18n = useOptionalI18n();
-  const t = (key: MessageKey, _fallback: string, values?: Record<string, string>) =>
+  const t = (key: MessageKey, values?: Record<string, string>) =>
     i18n?.t(key, values) ?? uiText(key, values);
-  const [labelKey, labelFallback] = LABELS[field.field_name];
-  const label = t(labelKey, labelFallback);
+  const label = t(LABELS[field.field_name]);
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(field.effective_value);
   const [restoreOpen, setRestoreOpen] = useState(false);
@@ -137,7 +136,7 @@ function SourceField({
         ? { name: field.effective_value }
         : { description: field.effective_value };
     void updateModel(modelId, payload)
-      .then(() => toast.success(t("source.modelUpdated", "Model updated")))
+      .then(() => toast.success(t("source.modelUpdated")))
       .catch(toast.error);
   };
   return (
@@ -155,11 +154,11 @@ function SourceField({
           <Input
             value={value}
             onChange={(event) => setValue(event.target.value)}
-            aria-label={t("source.override", `${label} override`, { label })}
+            aria-label={t("source.override", { label })}
           />
           <div className="flex flex-wrap gap-2">
             <Button size="xs" onClick={save}>
-              {t("source.save", "Save")}
+              {t("source.save")}
             </Button>
             <Button
               size="xs"
@@ -169,11 +168,11 @@ function SourceField({
                 setEditing(false);
               }}
             >
-              {t("source.cancel", "Cancel")}
+              {t("source.cancel")}
             </Button>
             {field.user_override_set && (
               <Button size="xs" variant="ghost" onClick={() => setRestoreOpen(true)}>
-                {t("source.restore", "Restore captured value")}
+                {t("source.restore")}
               </Button>
             )}
           </div>
@@ -194,8 +193,8 @@ function SourceField({
             ) : (
               field.effective_value ||
               (field.field_name.startsWith("license")
-                ? t("source.notSupplied", "Not supplied by source")
-                : t("source.notSuppliedGeneric", "Not supplied"))
+                ? t("source.notSupplied")
+                : t("source.notSuppliedGeneric"))
             )}
           </div>
           {canEdit && (
@@ -213,10 +212,10 @@ function SourceField({
               <Button
                 size="xs"
                 variant="ghost"
-                aria-label={t("source.editField", `Edit ${label}`, { field: label })}
+                aria-label={t("source.editField", { field: label })}
                 onClick={() => setEditing(true)}
               >
-                {t("source.edit", "Edit")}
+                {t("source.edit")}
               </Button>
             </div>
           )}
@@ -233,12 +232,9 @@ function SourceField({
       <ConfirmModal
         open={restoreOpen}
         onClose={() => setRestoreOpen(false)}
-        title={t("source.restoreTitle", "Restore captured value?")}
-        description={t(
-          "source.restoreDescription",
-          "This discards your correction and restores the value captured from the source.",
-        )}
-        confirmLabel={t("source.restoreConfirm", "Restore")}
+        title={t("source.restoreTitle")}
+        description={t("source.restoreDescription")}
+        confirmLabel={t("source.restoreConfirm")}
         onConfirm={restore}
       />
     </div>
@@ -496,7 +492,7 @@ export function SourceTab({
 }) {
   useUiLocale();
   const i18n = useOptionalI18n();
-  const t = (key: MessageKey, _fallback: string, values?: Record<string, string>) =>
+  const t = (key: MessageKey, values?: Record<string, string>) =>
     i18n?.t(key, values) ?? uiText(key, values);
   const [data, setData] = useState<ModelProvenanceRead | null>(null);
   const [failed, setFailed] = useState(false);
@@ -514,15 +510,7 @@ export function SourceTab({
       </div>
     );
   if (failed || !data?.sources.length)
-    return (
-      <EmptyState
-        title={t("source.emptyTitle", "No captured source")}
-        description={t(
-          "source.emptyDescription",
-          "This Model has no structured source snapshot yet.",
-        )}
-      />
-    );
+    return <EmptyState title={t("source.emptyTitle")} description={t("source.emptyDescription")} />;
   return (
     <div className="@container/source space-y-8">
       {data.sources.map((source) => {
@@ -535,19 +523,19 @@ export function SourceTab({
                 id={`source-heading-${source.id}`}
                 className="mb-4 border-b border-outline-variant pb-1 text-lg font-semibold text-on-surface"
               >
-                {t("source.title", "Source")}
+                {t("source.title")}
               </h2>
               <dl
                 className="overflow-hidden rounded border border-outline-variant bg-surface"
                 data-testid="source-identity-panel"
               >
-                <SourceIdentityRow label={t("source.provider", "Provider")}>
+                <SourceIdentityRow label={t("source.provider")}>
                   <span className="inline-flex flex-wrap items-center justify-start gap-2 @lg/source:justify-end">
                     <span className="capitalize">{source.provider}</span>
-                    <Badge variant="secondary">{t("source.capturedStatus", "Captured")}</Badge>
+                    <Badge variant="secondary">{t("source.capturedStatus")}</Badge>
                   </span>
                 </SourceIdentityRow>
-                <SourceIdentityRow label={t("source.url", "Source URL")}>
+                <SourceIdentityRow label={t("source.url")}>
                   {canonicalUrl ? (
                     <a
                       href={canonicalUrl}
@@ -562,16 +550,16 @@ export function SourceTab({
                     <span className="break-all text-muted-foreground">{source.canonical_url}</span>
                   )}
                 </SourceIdentityRow>
-                <SourceIdentityRow label={t("source.sourceId", "Source ID")}>
-                  {source.source_item_id || t("source.notSuppliedGeneric", "Not supplied")}
+                <SourceIdentityRow label={t("source.sourceId")}>
+                  {source.source_item_id || t("source.notSuppliedGeneric")}
                 </SourceIdentityRow>
-                <SourceIdentityRow label={t("source.revision", "Revision")}>
-                  {source.source_revision || t("source.notSuppliedGeneric", "Not supplied")}
+                <SourceIdentityRow label={t("source.revision")}>
+                  {source.source_revision || t("source.notSuppliedGeneric")}
                 </SourceIdentityRow>
-                <SourceIdentityRow label={t("source.captured", "Captured")}>
+                <SourceIdentityRow label={t("source.captured")}>
                   {new Date(source.first_captured_at).toLocaleDateString(i18n?.locale)}
                 </SourceIdentityRow>
-                <SourceIdentityRow label={t("source.checked", "Last checked")} last>
+                <SourceIdentityRow label={t("source.checked")} last>
                   {new Date(source.last_checked_at).toLocaleDateString(i18n?.locale)}
                 </SourceIdentityRow>
               </dl>
@@ -583,7 +571,7 @@ export function SourceTab({
                   id={`metadata-heading-${source.id}`}
                   className="mb-4 border-b border-outline-variant pb-1 text-lg font-semibold text-on-surface"
                 >
-                  {t("source.metadata", "Captured metadata")}
+                  {t("source.metadata")}
                 </h2>
                 <div className="overflow-hidden rounded border border-outline-variant bg-surface">
                   <SourceTags tags={source.tags ?? []} last={source.fields.length === 0} />

--- a/frontend/src/components/model-detail/use-revision-updater.ts
+++ b/frontend/src/components/model-detail/use-revision-updater.ts
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { deleteFileRevision, updateFileRevision } from "@/lib/api";
+import { uiText } from "@/lib/locale";
 import { toast } from "@/lib/toast";
 import { useRequireAuth } from "@/lib/use-require-auth";
 import { FileRead, FileRevisionUpdate, ModelRead } from "@/types";
@@ -23,7 +24,7 @@ export function useRevisionUpdater(modelId: number, onModel: (model: ModelRead) 
     setSaving(file.id);
     try {
       onModel(await updateFileRevision(modelId, file.id, patch));
-      toast.success("Revision updated");
+      toast.success(uiText("revision.updateSuccess"));
       return true;
     } catch (e) {
       toast.error(e);
@@ -41,7 +42,7 @@ export function useRevisionUpdater(modelId: number, onModel: (model: ModelRead) 
     setSaving(file.id);
     try {
       onModel(await deleteFileRevision(modelId, file.id));
-      toast.success("Revision deleted");
+      toast.success(uiText("revision.deleteSuccess"));
       return true;
     } catch (e) {
       toast.error(e);

--- a/frontend/src/components/model-grid.tsx
+++ b/frontend/src/components/model-grid.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { knownUiText } from "@/lib/locale";
+import { knownUiText, uiText, type MessageKey } from "@/lib/locale";
 import { getErrorMessage } from "@/lib/errors";
 import { filterValueText } from "@/lib/filter-labels";
 
-import { uiText } from "@/lib/locale";
 import { useUiLocale } from "@/lib/i18n";
 
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
@@ -967,11 +966,11 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
         tag: [...selectedTags].sort(),
       });
 
-  async function manageSavedView(action: () => Promise<SavedViewRead | void>, success: string) {
+  async function manageSavedView(action: () => Promise<SavedViewRead | void>, success: MessageKey) {
     try {
       await action();
       setLoadedSavedViews(await listSavedViews());
-      toast.success(success);
+      toast.success(uiText(success));
     } catch (error) {
       toast.error(error);
       throw error;
@@ -1240,7 +1239,7 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
   }, [auth.isAuthenticated, clearSelection, selectionCount]);
 
   async function runCollectionBatch(
-    verb: string,
+    success: MessageKey,
     operation: (collection: CollectionRead) => Promise<CollectionRead>,
   ) {
     setBatchBusy(true);
@@ -1256,7 +1255,7 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
         failedFolders.push(collection.path);
       }
     }
-    if (succeeded) toast.success(`${verb} ${succeeded}`);
+    if (succeeded) toast.success(uiText(success, { count: succeeded }));
     if (failed)
       toast.warning(
         uiText("{value1} skipped", { value1: String(failed) }),
@@ -2041,26 +2040,26 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
                           onUpdate={(view) =>
                             manageSavedView(
                               () => updateSavedView(view.id, { filters: currentViewFilters() }),
-                              "Saved view updated",
+                              "savedView.updateSuccess",
                             )
                           }
                           onRename={(view, name) =>
                             manageSavedView(
                               () => updateSavedView(view.id, { name }),
-                              "Saved view renamed",
+                              "savedView.renameSuccess",
                             )
                           }
                           onDuplicate={(view) =>
                             manageSavedView(
                               () => createSavedView(duplicateViewName(view.name), view.filters),
-                              "Saved view duplicated",
+                              "savedView.duplicateSuccess",
                             )
                           }
                           onDelete={(view) =>
                             manageSavedView(async () => {
                               await deleteSavedView(view.id);
                               if (activeSavedViewId === view.id) setActiveSavedViewId(null);
-                            }, "Saved view deleted")
+                            }, "savedView.deleteSuccess")
                           }
                           triggerClassName="max-w-none w-full justify-start px-2.5 py-2 text-sm"
                           triggerRole="menuitem"
@@ -2183,26 +2182,26 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
                       onUpdate={(view) =>
                         manageSavedView(
                           () => updateSavedView(view.id, { filters: currentViewFilters() }),
-                          "Saved view updated",
+                          "savedView.updateSuccess",
                         )
                       }
                       onRename={(view, name) =>
                         manageSavedView(
                           () => updateSavedView(view.id, { name }),
-                          "Saved view renamed",
+                          "savedView.renameSuccess",
                         )
                       }
                       onDuplicate={(view) =>
                         manageSavedView(
                           () => createSavedView(duplicateViewName(view.name), view.filters),
-                          "Saved view duplicated",
+                          "savedView.duplicateSuccess",
                         )
                       }
                       onDelete={(view) =>
                         manageSavedView(async () => {
                           await deleteSavedView(view.id);
                           if (activeSavedViewId === view.id) setActiveSavedViewId(null);
-                        }, "Saved view deleted")
+                        }, "savedView.deleteSuccess")
                       }
                       triggerClassName="h-10 sm:h-8"
                     />
@@ -2573,7 +2572,7 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
             canMoveToRoot={!!user?.is_superuser}
             onMoveSelection={moveSelection}
             onRenameCollections={(names) =>
-              runCollectionBatch("Renamed", (collection) =>
+              runCollectionBatch("collection.renameSuccess", (collection) =>
                 renameCollection(collection.id, names[collection.id]),
               )
             }

--- a/frontend/src/components/notifications-panel.tsx
+++ b/frontend/src/components/notifications-panel.tsx
@@ -124,7 +124,9 @@ const TARGET_FIELDS = {
       get label() {
         return uiText("Signing secret (optional)");
       },
-      placeholder: "used to HMAC-sign the payload",
+      get placeholder() {
+        return uiText("notifications.signingSecretPlaceholder");
+      },
       secret: true,
       optional: true,
     },

--- a/frontend/src/components/printer-detail.tsx
+++ b/frontend/src/components/printer-detail.tsx
@@ -1,9 +1,13 @@
 "use client";
 
-import { knownUiText } from "@/lib/locale";
+import {
+  currentLocale,
+  knownUiText,
+  uiMessage,
+  uiText,
+  type MessageDescriptor,
+} from "@/lib/locale";
 import { formatNumber } from "@/lib/format";
-import { currentLocale } from "@/lib/locale";
-import { uiText } from "@/lib/locale";
 import { useUiLocale } from "@/lib/i18n";
 
 import { useEffect, useRef, useState } from "react";
@@ -288,7 +292,7 @@ export function PrinterDetailPage({
     }
   }
 
-  async function machineAction<T>(key: string, fn: () => Promise<T>, successMsg: string) {
+  async function machineAction<T>(key: string, fn: () => Promise<T>, success: MessageDescriptor) {
     if (!auth.isAuthenticated) {
       auth.showAuthRequiredToast();
       return;
@@ -296,7 +300,7 @@ export function PrinterDetailPage({
     setMachineBusy(key);
     try {
       await fn();
-      toast.success(successMsg);
+      toast.success(uiText(success.key, success.values));
     } catch (e) {
       toast.error(e);
     } finally {
@@ -313,7 +317,7 @@ export function PrinterDetailPage({
     void machineAction(
       `set-${heater}`,
       () => setPrinterTemperature(printerId, heater, t).then(clear),
-      uiText("{value1} set to {value2}°C", {
+      uiMessage("{value1} set to {value2}°C", {
         value1: String(heater === "extruder" ? "Hotend" : "Bed"),
         value2: String(t),
       }),
@@ -327,7 +331,7 @@ export function PrinterDetailPage({
         await setPrinterTemperature(printerId, "extruder", p.hotend);
         await setPrinterTemperature(printerId, "bed", p.bed);
       },
-      uiText("Preheating for {value1}", { value1: String(p.name) }),
+      uiMessage("Preheating for {value1}", { value1: String(p.name) }),
     );
   }
 
@@ -338,7 +342,7 @@ export function PrinterDetailPage({
         await setPrinterTemperature(printerId, "extruder", 0);
         await setPrinterTemperature(printerId, "bed", 0);
       },
-      "Cooling down",
+      uiMessage("printer.cooldownSuccess"),
     );
   }
 
@@ -351,7 +355,11 @@ export function PrinterDetailPage({
   }
 
   async function confirmEmergencyStopAction() {
-    await machineAction("estop", () => emergencyStopPrinter(printerId), "Emergency stop sent");
+    await machineAction(
+      "estop",
+      () => emergencyStopPrinter(printerId),
+      uiMessage("printer.emergencyStopSuccess"),
+    );
     setConfirmEmergencyStop(false);
   }
 
@@ -842,7 +850,7 @@ export function PrinterDetailPage({
                             void machineAction(
                               "home",
                               () => homePrinter(printerId),
-                              "Homing all axes",
+                              uiMessage("printer.homeSuccess"),
                             )
                           }
                           disabled={!printer.access.can_control || machineBusy !== null}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -69,7 +69,7 @@
   "Import supported AMS or active-Spoolman state. Turn off to use manual state exclusively.": "Import supported AMS or active-Spoolman state. Turn off to use manual state exclusively.",
   "Require operator release": "Require operator release",
   "After a managed print completes, block scheduling until an operator releases or holds the printer.": "After a managed print completes, block scheduling until an operator releases or holds the printer.",
-  "Materials &amp; tools": "Materials &amp; tools",
+  "Materials &amp; tools": "Materials & tools",
   "Loaded filament truth is kept here, independently from printer groups.": "Loaded filament truth is kept here, independently from printer groups.",
   "Save state": "Save state",
   "Tool 0 nozzle diameter (mm)": "Tool 0 nozzle diameter (mm)",
@@ -330,7 +330,7 @@
   "Track filament inventory and per-print consumption with a self-hosted Spoolman instance. Off by default.": "Track filament inventory and per-print consumption with a self-hosted Spoolman instance. Off by default.",
   "Only an administrator can configure Spoolman.": "Only an administrator can configure Spoolman.",
   "Decrements the selected spool by measured filament when a print completes (Moonraker-measured prints only).": "Decrements the selected spool by measured filament when a print completes (Moonraker-measured prints only).",
-  "Connect a MakerWorld (Bambu) account so model &amp; collection imports can download files": "Connect a MakerWorld (Bambu) account so model &amp; collection imports can download files",
+  "Connect a MakerWorld (Bambu) account so model &amp; collection imports can download files": "Connect a MakerWorld (Bambu) account so model & collection imports can download files",
   "Only an administrator can connect MakerWorld.": "Only an administrator can connect MakerWorld.",
   "Your password is sent once to Bambu to obtain a session token and is never stored. MakerWorld usually emails a verification code next.": "Your password is sent once to Bambu to obtain a session token and is never stored. MakerWorld usually emails a verification code next.",
   "Sessions expire periodically — if imports start failing with a login error, disconnect and connect again.": "Sessions expire periodically — if imports start failing with a login error, disconnect and connect again.",
@@ -858,7 +858,7 @@
   "Tags updated": "Tags updated",
   "Could not update tags": "Could not update tags",
   "Create tag": "Create tag",
-  "Create tag &quot;": "Create tag &quot;",
+  "Create tag &quot;": "Create tag \"",
   "Choose an existing tag or create a new one to group and find this Model.": "Choose an existing tag or create a new one to group and find this Model.",
   "Remove tags": "Remove tags",
   "No spool": "No spool",
@@ -2873,5 +2873,19 @@
   "printer_busy": "Printer busy.",
   "path_not_allowed": "Path not allowed.",
   "backup_blob_missing": "A file needed for the backup is missing. Check the storage and try again.",
-  "export_too_large": "The export is too large. Select fewer models and try again."
+  "export_too_large": "The export is too large. Select fewer models and try again.",
+  "revision.updateSuccess": "Revision updated",
+  "revision.deleteSuccess": "Revision deleted",
+  "savedView.updateSuccess": "Saved view updated",
+  "savedView.renameSuccess": "Saved view renamed",
+  "savedView.duplicateSuccess": "Saved view duplicated",
+  "savedView.deleteSuccess": "Saved view deleted",
+  "collection.renameSuccess": {
+    "one": "Renamed {count} folder",
+    "other": "Renamed {count} folders"
+  },
+  "printer.cooldownSuccess": "Cooling down",
+  "printer.emergencyStopSuccess": "Emergency stop sent",
+  "printer.homeSuccess": "Homing all axes",
+  "notifications.signingSecretPlaceholder": "used to HMAC-sign the payload"
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -858,7 +858,7 @@
   "Tags updated": "Etiquetas actualizadas",
   "Could not update tags": "No se pudieron actualizar las etiquetas",
   "Create tag": "Crear etiqueta",
-  "Create tag &quot;": "Crear etiqueta &quot;",
+  "Create tag &quot;": "Crear etiqueta \"",
   "Choose an existing tag or create a new one to group and find this Model.": "Elige una etiqueta existente o crea una nueva para agrupar y encontrar este modelo.",
   "Remove tags": "Quitar etiquetas",
   "No spool": "Sin carrete",
@@ -2873,5 +2873,19 @@
   "printer_busy": "La impresora está ocupada.",
   "path_not_allowed": "La ruta no está permitida.",
   "backup_blob_missing": "Falta un archivo necesario para la copia de seguridad. Comprueba el almacenamiento y vuelve a intentarlo.",
-  "export_too_large": "La exportación es demasiado grande. Selecciona menos modelos y vuelve a intentarlo."
+  "export_too_large": "La exportación es demasiado grande. Selecciona menos modelos y vuelve a intentarlo.",
+  "revision.updateSuccess": "Revisión actualizada",
+  "revision.deleteSuccess": "Revisión eliminada",
+  "savedView.updateSuccess": "Vista guardada actualizada",
+  "savedView.renameSuccess": "Vista guardada renombrada",
+  "savedView.duplicateSuccess": "Vista guardada duplicada",
+  "savedView.deleteSuccess": "Vista guardada eliminada",
+  "collection.renameSuccess": {
+    "one": "Se cambió el nombre de {count} carpeta",
+    "other": "Se cambió el nombre de {count} carpetas"
+  },
+  "printer.cooldownSuccess": "Enfriando",
+  "printer.emergencyStopSuccess": "Parada de emergencia enviada",
+  "printer.homeSuccess": "Referenciando todos los ejes",
+  "notifications.signingSecretPlaceholder": "se usa para firmar la carga útil con HMAC"
 }

--- a/frontend/tests/repo/i18n-coverage.test.ts
+++ b/frontend/tests/repo/i18n-coverage.test.ts
@@ -32,6 +32,13 @@ const TECHNICAL = new Set([
   "http://printer.local:7125",
   "/api/v1/auth/login",
   "http://spoolman.local:7912",
+  "https://example.com/hook",
+  "https://discord.com/api/webhooks/…",
+  "123456:ABC-DEF…",
+  "-1001234567890",
+  "https://ntfy.sh",
+  "my-printer-alerts",
+  "tk_…",
 ]);
 const ATTRIBUTES = new Set([
   "title",
@@ -100,14 +107,47 @@ function unlocalizedCopy(source: string): string[] {
       )
         expression(node.value.expression);
     },
+    CallExpression(node) {
+      if (node.callee.type !== "MemberExpression" || node.callee.property.type !== "Identifier")
+        return;
+      if (!new Set(["success", "warning", "info", "error"]).has(node.callee.property.name)) return;
+      const object = node.callee.object;
+      const isToast =
+        (object.type === "Identifier" && object.name === "toast") ||
+        (object.type === "MemberExpression" &&
+          object.property.type === "Identifier" &&
+          object.property.name === "toast");
+      if (!isToast) return;
+      const first = node.arguments[0];
+      if (first?.type !== "SpreadElement") expression(first);
+    },
+    Property(node) {
+      const key = node.key;
+      const name =
+        key.type === "Identifier" ? key.name : key.type === "Literal" ? String(key.value) : null;
+      if (!node.computed && name !== null && ATTRIBUTES.has(name)) {
+        if (node.value.type === "Literal") {
+          if (node.value.value === null) return;
+          const value = String(node.value.value);
+          const semanticKey = /^[a-z][\w]*(?:\.[\w]+)+$/.test(value) && isMessageKey(value);
+          if (!semanticKey) add(value);
+        }
+        if (node.value.type === "TemplateLiteral")
+          node.value.quasis.forEach((part) => add(part.value.cooked ?? part.value.raw));
+        if (node.value.type === "ConditionalExpression") expression(node.value);
+      }
+    },
   }).visit(parsed.program);
   return values;
 }
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const path = join(dir, entry.name);
-    if (entry.isDirectory()) return entry.name === "__tests__" ? [] : sourceFiles(path);
-    return entry.name.endsWith(".tsx") ? [path] : [];
+    if (entry.isDirectory())
+      return new Set(["__tests__", "generated", "test-support"]).has(entry.name)
+        ? []
+        : sourceFiles(path);
+    return /\.tsx?$/.test(entry.name) && !entry.name.endsWith(".d.ts") ? [path] : [];
   });
 }
 function parameters(value: string): string[] {
@@ -127,10 +167,36 @@ describe("translationCoverage", () => {
       ),
     ).toEqual([]);
   });
+  it("rejects hardcoded imperative presentation copy", () => {
+    expect(
+      unlocalizedCopy(
+        'toast.success("Saved"); deps.toast.warning(`Skipped ${count}`); const field = { placeholder: "Helpful copy" };',
+      ),
+    ).toEqual(expect.arrayContaining(["Saved", "Skipped", "Helpful copy"]));
+    expect(
+      unlocalizedCopy(
+        'toast.success(uiText("save.success")); const field = { placeholder: uiText("form.help") };',
+      ),
+    ).toEqual([]);
+  });
   it("has no unwrapped authored JSX copy", () => {
     expect(
       sourceFiles("src").flatMap((file) =>
         unlocalizedCopy(readFileSync(file, "utf8")).map((text) => `${file}: ${text}`),
+      ),
+    ).toEqual([]);
+  });
+  it("has no hardcoded imperative presentation copy", () => {
+    expect(
+      sourceFiles("src").flatMap((file) =>
+        unlocalizedCopy(readFileSync(file, "utf8")).map((text) => `${file}: ${text}`),
+      ),
+    ).toEqual([]);
+  });
+  it("keeps catalog text out of ignored component fallbacks", () => {
+    expect(
+      sourceFiles("src").flatMap((file) =>
+        /\b_fallback\b/.test(readFileSync(file, "utf8")) ? [file] : [],
       ),
     ).toEqual([]);
   });
@@ -168,6 +234,16 @@ describe("translationCoverage", () => {
           locale,
           key,
           parameters: expected,
+        });
+        expect({ locale, key, encodedEntity: /&(?:amp|quot|apos|lt|gt);/i.test(form) }).toEqual({
+          locale,
+          key,
+          encodedEntity: false,
+        });
+        expect({ locale, key, draft: /TODO\([^)]+\):/.test(form) }).toEqual({
+          locale,
+          key,
+          draft: false,
         });
       }
     }

--- a/frontend/tests/repo/locale-authoring.test.ts
+++ b/frontend/tests/repo/locale-authoring.test.ts
@@ -1,0 +1,83 @@
+/** Static locale authoring stays deterministic, complete, and safe to rerun. */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { scaffoldLocale } from "../../scripts/scaffold-locale.mjs";
+
+const roots: string[] = [];
+
+function fixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "printstash-locale-"));
+  roots.push(root);
+  mkdirSync(join(root, "src/locales"), { recursive: true });
+  writeFileSync(
+    join(root, "src/locales/en.json"),
+    `${JSON.stringify({ greeting: "Hello {name}", files: { one: "{count} file", other: "{count} files" } }, null, 2)}\n`,
+  );
+  writeFileSync(
+    join(root, "src/locales/catalogs.ts"),
+    'import en from "./en.json" with { type: "json" };\n\nexport const localeDefinitions = {\n  en: { name: "English", direction: "ltr", messages: en },\n} satisfies Record<string, unknown>;\n',
+  );
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("locale authoring", () => {
+  it("creates a complete statically registered hardcoded draft", () => {
+    const root = fixture();
+
+    const result = scaffoldLocale({
+      rootDir: root,
+      locale: "fr",
+      name: "Français",
+      direction: "ltr",
+    });
+
+    expect(result.locale).toBe("fr");
+    expect(JSON.parse(readFileSync(join(root, "src/locales/fr.json"), "utf8"))).toEqual({
+      greeting: "TODO(fr): Hello {name}",
+      files: { one: "TODO(fr): {count} file", other: "TODO(fr): {count} files" },
+    });
+    expect(readFileSync(join(root, "src/locales/catalogs.ts"), "utf8")).toContain(
+      'import catalogFr from "./fr.json" with { type: "json" };',
+    );
+    expect(readFileSync(join(root, "src/locales/catalogs.ts"), "utf8")).toContain(
+      'fr: { name: "Français", direction: "ltr", messages: catalogFr },',
+    );
+  });
+
+  it("canonicalizes a BCP 47 language tag", () => {
+    const root = fixture();
+
+    expect(
+      scaffoldLocale({ rootDir: root, locale: "pt-br", name: "Português", direction: "ltr" })
+        .locale,
+    ).toBe("pt-BR");
+    expect(readFileSync(join(root, "src/locales/pt-BR.json"), "utf8")).toContain(
+      '"TODO(pt-BR): Hello {name}"',
+    );
+  });
+
+  it.each([
+    ["an invalid tag", "ltr"],
+    ["fr", "sideways"],
+  ])("rejects locale input %s / %s", (locale, direction) => {
+    expect(() =>
+      scaffoldLocale({ rootDir: fixture(), locale, name: "Example", direction }),
+    ).toThrow(/Invalid locale tag|Direction must/);
+  });
+
+  it("refuses to overwrite an existing locale", () => {
+    const root = fixture();
+    scaffoldLocale({ rootDir: root, locale: "fr", name: "Français", direction: "ltr" });
+
+    expect(() =>
+      scaffoldLocale({ rootDir: root, locale: "fr", name: "Français", direction: "ltr" }),
+    ).toThrow(/already exists/);
+  });
+});


### PR DESCRIPTION
## Summary

- keep displayed copy in static, bundled locale catalogs with stable semantic identifiers
- localize previously raw toast and configuration text, including plural-aware folder feedback
- add guarded locale scaffolding plus catalog checks for missing keys, placeholders, HTML entities, and unfinished drafts
- remove duplicated English fallback prose from source and G-code presentation helpers

## Validation matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|---|---|---|---|---|---|
| 1 | Guard imperative presentation copy | Error | Raw toast or configured helper text | Repository guard reports its source | Frontend unit | ✅ |
| 2 | Validate catalog values | Error | Encoded entity or unfinished draft marker | Validation names the locale and key | Frontend unit | ✅ |
| 3 | Scaffold a static locale | Happy | Valid BCP 47 tag, native name, and direction | Complete JSON draft and static import are created | Frontend unit | ✅ |
| 4 | Reject unsafe locale requests | Error | Invalid tag/direction or existing locale | Existing files are not overwritten | Frontend unit | ✅ |
| 5 | Localize configuration guidance | Happy | Spanish notification channel form | HMAC placeholder renders in Spanish | Frontend unit | ✅ |
| 6 | Localize imperative feedback | Happy | Spanish revision update or cooldown | Success toast renders in Spanish | Frontend unit | ✅ |
| 7 | Pluralize folder batch feedback | Edge | One renamed folder | Singular catalog message reports one folder | Frontend unit | ✅ |

## Checks

- `pnpm i18n:check` — 30 passed
- focused affected component suites — 224 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `playwright test tests/e2e/i18n.spec.ts` — 4 passed
- full Vitest run — 1,891 passed; its only failure was the new test title tripping the suite-hygiene conjunction cap, corrected and rerun green
- local coverage instrumentation was stopped after unrelated existing UI tests exceeded their fixed five-second timeout on this host; CI is the authoritative coverage gate
