### PR TITLE
feat(onboarding): allow dismissing the getting-started reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 
 ### Changed
 
+- The getting-started reminder can be dismissed with Don't show again. The choice
+  is remembered per user in the current browser across Settings and the empty library.
+
 - First-run setup uses a centered, responsive form with inline password visibility
   controls. Storage choices and server folders are visible immediately, with a
   clear access-check step before account creation and guidance in English and Spanish.

--- a/frontend/src/components/__tests__/getting-started-reminder.test.tsx
+++ b/frontend/src/components/__tests__/getting-started-reminder.test.tsx
@@ -1,0 +1,99 @@
+/* Dismissing the setup reminder is persistent, user-specific, and shared by its surfaces. */
+import { act, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GettingStartedReminder } from "@/components/getting-started-reminder";
+import { usePathname } from "@/lib/navigation";
+import { adminSession, memberSession, renderApp } from "@/test-support/render";
+
+function Path() {
+  return <span data-testid="path">{usePathname()}</span>;
+}
+
+beforeEach(() => localStorage.clear());
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("GettingStartedReminder", () => {
+  it("opens the guide", async () => {
+    renderApp(
+      <>
+        <GettingStartedReminder />
+        <Path />
+      </>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Resume the getting-started guide" }));
+    expect(screen.getByTestId("path")).toHaveTextContent("/getting-started");
+  });
+
+  it("persists dismissal across remounts", async () => {
+    const view = renderApp(<GettingStartedReminder />);
+    await userEvent.click(screen.getByRole("button", { name: "Don't show again" }));
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    view.unmount();
+    renderApp(<GettingStartedReminder />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("keeps dismissal specific to the current user", async () => {
+    const view = renderApp(<GettingStartedReminder />);
+    await userEvent.click(screen.getByRole("button", { name: "Don't show again" }));
+    view.unmount();
+    renderApp(<GettingStartedReminder />, {
+      auth: adminSession({
+        user: { id: 2, username: "another-admin", email: null, is_superuser: true },
+      }),
+    });
+    expect(screen.getByRole("button", { name: "Resume the getting-started guide" })).toBeVisible();
+  });
+
+  it("synchronizes visible reminders", async () => {
+    renderApp(
+      <>
+        <GettingStartedReminder />
+        <GettingStartedReminder />
+      </>,
+    );
+    await userEvent.click(screen.getAllByRole("button", { name: "Don't show again" })[0]);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("reacts to dismissal in another tab", () => {
+    renderApp(<GettingStartedReminder />);
+    act(() => {
+      localStorage.setItem("printstash.getting-started.dismissed.1", "true");
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: "printstash.getting-started.dismissed.1" }),
+      );
+    });
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("hides the reminder when persistent storage is unavailable", async () => {
+    const view = renderApp(<GettingStartedReminder />, {
+      auth: adminSession({
+        user: { id: 803, username: "storage-blocked-admin", email: null, is_superuser: true },
+      }),
+    });
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+    await userEvent.click(screen.getByRole("button", { name: "Don't show again" }));
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    view.rerender(<GettingStartedReminder />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    { label: "member", auth: memberSession() },
+    { label: "signed out", auth: adminSession({ user: null }) },
+  ])("excludes non-administrators: $label", ({ auth }) => {
+    renderApp(<GettingStartedReminder />, { auth });
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/getting-started-reminder.tsx
+++ b/frontend/src/components/getting-started-reminder.tsx
@@ -1,0 +1,62 @@
+import { useSyncExternalStore } from "react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/lib/auth-context";
+import { useI18n } from "@/lib/i18n";
+import { useRouter } from "@/lib/navigation";
+
+const CHANGE_EVENT = "printstash:getting-started-reminder-changed";
+// If browser storage is blocked, respect dismissal for the current page session.
+const sessionDismissals = new Set<number>();
+const preferenceKey = (userId: number) => `printstash.getting-started.dismissed.${userId}`;
+
+function isDismissed(userId: number | undefined): boolean {
+  if (userId === undefined) return false;
+  if (sessionDismissals.has(userId)) return true;
+  try {
+    return localStorage.getItem(preferenceKey(userId)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function subscribe(onChange: () => void): () => void {
+  window.addEventListener(CHANGE_EVENT, onChange);
+  window.addEventListener("storage", onChange);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onChange);
+    window.removeEventListener("storage", onChange);
+  };
+}
+
+export function GettingStartedReminder() {
+  const { user } = useAuth();
+  const { t } = useI18n();
+  const router = useRouter();
+  const dismissed = useSyncExternalStore(
+    subscribe,
+    () => isDismissed(user?.id),
+    () => false,
+  );
+  if (!user?.is_superuser || dismissed) return null;
+
+  function dismiss() {
+    if (!user) return;
+    try {
+      localStorage.setItem(preferenceKey(user.id), "true");
+    } catch {
+      sessionDismissals.add(user.id);
+    }
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button variant="outline" onClick={() => router.push("/getting-started")}>
+        {t("setup.resume")}
+      </Button>
+      <Button variant="ghost" onClick={dismiss}>
+        {t("setup.dismissReminder")}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/model-grid.tsx
+++ b/frontend/src/components/model-grid.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { GettingStartedReminder } from "@/components/getting-started-reminder";
+
 import { knownUiText, uiText, type MessageKey } from "@/lib/locale";
 import { getErrorMessage } from "@/lib/errors";
 import { filterValueText } from "@/lib/filter-labels";
@@ -2435,11 +2437,7 @@ export function ModelBrowser({ initial }: { initial?: BrowserInitialData }) {
                       </Button>
                     ) : (
                       <div className="flex flex-wrap items-center justify-center gap-2">
-                        {user?.is_superuser && (
-                          <Button variant="outline" onClick={() => router.push("/getting-started")}>
-                            {t("setup.resume")}
-                          </Button>
-                        )}
+                        <GettingStartedReminder />
                         <Button
                           type="button"
                           size="sm"

--- a/frontend/src/components/settings-panel.tsx
+++ b/frontend/src/components/settings-panel.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { GettingStartedReminder } from "@/components/getting-started-reminder";
+
 import { knownUiText } from "@/lib/locale";
 import { formatNumber } from "@/lib/format";
 import { currentLocale } from "@/lib/locale";
@@ -1615,11 +1617,7 @@ export function SettingsPanel() {
   return (
     <Localized>
       <div className="w-full space-y-6">
-        {user?.is_superuser && (
-          <Button variant="outline" onClick={() => router.push("/getting-started")}>
-            {t("setup.resume")}
-          </Button>
-        )}
+        <GettingStartedReminder />
         <ConfirmModal
           open={restartConfirmOpen}
           onClose={() => {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -2939,5 +2939,6 @@
   "uploads.mode.zip": "From ZIP",
   "setup.chooseFileAction": "Choose a file",
   "setup.scanPartial": "Some files could not be indexed. Review the scan in the task center or retry this folder. Models already added remain in your library.",
-  "setup.folderPathExample": "/libraries/models"
+  "setup.folderPathExample": "/libraries/models",
+  "setup.dismissReminder": "Don't show again"
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -2939,5 +2939,6 @@
   "uploads.mode.zip": "Desde ZIP",
   "setup.chooseFileAction": "Elegir un archivo",
   "setup.scanPartial": "No se pudieron añadir algunos archivos. Revisa la búsqueda en el centro de tareas o vuelve a buscar en esta carpeta. Los modelos ya añadidos siguen en tu biblioteca.",
-  "setup.folderPathExample": "/libraries/models"
+  "setup.folderPathExample": "/libraries/models",
+  "setup.dismissReminder": "No volver a mostrar"
 }

--- a/frontend/tests/e2e-real/README.md
+++ b/frontend/tests/e2e-real/README.md
@@ -73,7 +73,8 @@ server folders, keyboard step navigation, and the account → first Model flow.
 The activation route also exercises the language/theme menus, the simplified
 upload dialog, mounted-folder help, postponing/resuming, and connecting a folder
 with automatic scanning. Screenshots include the Spanish chooser and dialogs at
-mobile and desktop sizes.
+mobile and desktop sizes. Dismissing the guide reminder is checked across reloads
+and navigation between Settings and the empty library.
 
 auth (UI login, wrong-password, username + API-key login then revoke) ·
 vault (search, tag filter, list/grid toggle, empty state, narrow responsive toolbar) · collections

--- a/frontend/tests/e2e-real/onboarding/first-model.spec.ts
+++ b/frontend/tests/e2e-real/onboarding/first-model.spec.ts
@@ -204,6 +204,19 @@ test.describe("Browser onboarding", () => {
       await expect(page).toHaveURL(/\/$/);
       await page.getByRole("button", { name: "Resume the getting-started guide" }).press("Enter");
       await expect(page).toHaveURL(/\/getting-started$/);
+      await page.goto("/settings");
+      await page.getByRole("button", { name: "Don't show again", exact: true }).click();
+      await page.reload();
+      await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Resume the getting-started guide" }),
+      ).toHaveCount(0);
+      await page.goto("/");
+      await expect(page.getByRole("button", { name: "Upload files", exact: true })).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Resume the getting-started guide" }),
+      ).toHaveCount(0);
+      await page.goto("/getting-started");
       await page.getByRole("button", { name: "Upload my first files" }).press("Enter");
       await page.getByLabel("Model or G-code file").setInputFiles({
         name: "first-model.gcode",
@@ -225,7 +238,10 @@ test.describe("Browser onboarding", () => {
         page.getByRole("heading", { name: "My first model", exact: true }),
       ).toBeVisible();
       await page.goto("/settings");
-      await page.getByRole("button", { name: "Resume the getting-started guide" }).press("Enter");
+      await expect(
+        page.getByRole("button", { name: "Resume the getting-started guide" }),
+      ).toHaveCount(0);
+      await page.goto("/getting-started");
       await expect(page).toHaveURL(/\/getting-started$/);
       await page.getByRole("button", { name: "Connect an existing folder" }).press("Enter");
       await page.getByLabel("Folder name").fill("My existing folder");


### PR DESCRIPTION
## Summary

- Add **Don't show again / No volver a mostrar** beside the getting-started reminder in Settings and the empty library.
- Remember dismissal per user in the current browser, synchronize open tabs, and retain session dismissal when browser storage is blocked.

## Testing

- [x] Backend suite not needed: no backend changes.
- [ ] Full frontend suite not run. Focused component/i18n tests passed (16 tests); lint, formatting and TypeScript passed.
- [x] Real-backend Chromium onboarding lifecycle passed, including dismissal, reload, navigation, upload and folder connection. Linked dependency fonts were blocked by Vite during this run, so it validates behavior rather than typography.

Scoped reminder coverage: 92.59% lines, 90% branches; full coverage gate not run.

## Coverage matrix

Component test file: `frontend/src/components/__tests__/getting-started-reminder.test.tsx`.

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|-----------|----------|----------------------|--------------------|------|--------|
| 1 | Open guide | Happy path | Administrator clicks Resume | Guide route opens | Frontend integration | ✅ component test: `opens the guide` |
| 2 | Persist dismissal | Persistence | Dismiss then remount | Reminder stays hidden | Frontend integration | ✅ component test: `persists dismissal across remounts` |
| 3 | Isolate users | Isolation | Another administrator signs in | Their reminder remains visible | Frontend integration | ✅ component test: `keeps dismissal specific to the current user` |
| 4 | Sync mounted reminders | Consistency | Dismiss one instance | All instances hide | Frontend integration | ✅ component test: `synchronizes visible reminders` |
| 5 | Sync tabs | Synchronization | Browser storage event | Reminder hides | Frontend integration | ✅ component test: `reacts to dismissal in another tab` |
| 6 | Handle blocked storage | Failure | Storage writes throw | Session dismissal works | Frontend integration | ✅ component test: `hides the reminder when persistent storage is unavailable` |
| 7 | Limit reminder to administrators | Auth | Member or signed-out session | Controls absent | Frontend integration | ✅ component test: `excludes non-administrators: $label` |
| 8 | Preserve dismissal through reload/navigation | Headline | Dismiss in Settings and reload | Hidden in Settings and empty library; direct guide access still works | Real browser | ✅ `frontend/tests/e2e-real/onboarding/first-model.spec.ts::reaches its first Model entirely through browser controls` |

### Tier check

- [x] `frontend/src/**/__tests__/` and `frontend/tests/e2e-real/`

### Self-check

- [x] New test file includes a contract header.
- [x] Each new component test covers one behavior.
- [x] No skipped or commented-out tests.
- [x] Endpoint authorization rows: not applicable; no new endpoints.

### Fixtures and factories

Existing auth fixtures are reused. No database entities or scenario factories changed.

## Notes

Preference is local to each browser and user; it does not synchronize across devices. No schema, API, storage-backend or printer-provider changes.
