### PR TITLE
fix(fleet): reconcile interrupted printer jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+- Active print jobs no longer remain paused indefinitely after an out-of-band
+  emergency stop. Authoritative idle printer updates now close interrupted jobs,
+  with an operator recovery action for stale history when no update arrives.
+
 - The Model detail back arrow returns to its containing collection instead of
   always returning to the library root, including nested collection paths.
 

--- a/backend/app/api/v1/fleet.py
+++ b/backend/app/api/v1/fleet.py
@@ -20,6 +20,7 @@ from app.modules.printing import fleet, materials
 from app.modules.printing.printer_jobs import reproducibility_payload
 from app.runtime.work_wakeup import WorkNotice, WorkWakeup
 from app.schemas.fleet import (
+    ActiveJobResolution,
     BatchCreate,
     FleetSummary,
     MaintenanceLogCreate,
@@ -208,6 +209,8 @@ def _queue_error(exc: fleet.FleetError) -> HTTPException:
         "queue_job_changed",
         "operator_decision_not_pending",
         "material_mismatch_confirmation_required",
+        "printer_still_active",
+        "queue_job_not_resolvable",
     }:
         return HTTPException(status_code=409, detail=exc.code)
     return HTTPException(status_code=400, detail=exc.code)
@@ -260,6 +263,23 @@ def delete_queue_job(
     _require_queue_job_role(session, current_user, job_id, PrinterRole.PRINT)
     try:
         job = fleet.delete_queue_job(session, job_id, current_user)
+    except fleet.FleetError as exc:
+        raise _queue_error(exc) from exc
+    return _print_job_read(session, job)
+
+
+@router.post("/queue/{job_id}/resolve", response_model=PrintJobRead)
+def resolve_active_job(
+    job_id: int,
+    payload: ActiveJobResolution,
+    current_user: User = Depends(require_user),
+    session: Session = Depends(get_session),
+) -> PrintJobRead:
+    _require_queue_job_role(session, current_user, job_id, PrinterRole.CONTROL)
+    try:
+        job = fleet.resolve_active_job(
+            session, job_id, payload.resolution, current_user
+        )
     except fleet.FleetError as exc:
         raise _queue_error(exc) from exc
     return _print_job_read(session, job)

--- a/backend/app/modules/printing/fleet.py
+++ b/backend/app/modules/printing/fleet.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from datetime import datetime
+from typing import Literal
 
 from printstash_core.gcode import declared_print_artifact_format
 from printstash_core.printers import PrintArtifactFormat
@@ -63,6 +64,8 @@ _ACTIVE_STATES = {
     PrintJobState.PRINTING,
     PrintJobState.PAUSED,
 }
+_RESOLVABLE_STATES = _ACTIVE_STATES - {PrintJobState.QUEUED}
+_PRINTER_EXECUTING_STATES = {PrinterStatus.PRINTING, PrinterStatus.PAUSED}
 
 
 @dataclass(frozen=True)
@@ -874,6 +877,39 @@ def delete_queue_job(session: Session, job_id: int, current_user: User) -> Print
             row.queue_position = position
             row.updated_at = now
             session.add(row)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def resolve_active_job(
+    session: Session,
+    job_id: int,
+    resolution: Literal["cancelled", "failed"],
+    current_user: User,
+) -> PrintJob:
+    """Close stale PrintStash history without sending a printer command."""
+    job = session.get(PrintJob, job_id)
+    if job is None or job.deleted_at is not None or job.dedupe_absorbed_at is not None:
+        raise FleetError("queue_job_not_found")
+    if job.state not in _RESOLVABLE_STATES:
+        raise FleetError("queue_job_not_resolvable")
+    printer = (
+        session.get(Printer, job.printer_id) if job.printer_id is not None else None
+    )
+    if printer is not None and printer.status in _PRINTER_EXECUTING_STATES:
+        raise FleetError("printer_still_active")
+
+    now = utcnow()
+    job.state = (
+        PrintJobState.CANCELLED if resolution == "cancelled" else PrintJobState.FAILED
+    )
+    job.error = "operator_marked_failed" if resolution == "failed" else None
+    job.finished_at = now
+    job.blocked_reason = None
+    job.updated_by = current_user.id
+    job.updated_at = now
+    session.add(job)
     session.commit()
     session.refresh(job)
     return job

--- a/backend/app/modules/printing/printer_hub.py
+++ b/backend/app/modules/printing/printer_hub.py
@@ -99,6 +99,12 @@ _TERMINAL_EVENT: Dict[PrintJobState, NotificationEventType] = {
     PrintJobState.CANCELLED: NotificationEventType.PRINT_CANCELLED,
 }
 
+# Provider snapshots that authoritatively say no print is executing.  A job that
+# PrintStash already observed printing or paused has disappeared when one of
+# these arrives, even when the provider cleared its filename during recovery.
+_NO_ACTIVE_JOB_STATES = frozenset({"idle", "ready", "standby"})
+_OBSERVED_ACTIVE_JOB_STATES = (PrintJobState.PRINTING, PrintJobState.PAUSED)
+
 
 def _derive_printer_status(snapshot: Dict[str, Any]) -> tuple[str, PrinterStatus]:
     """Derive coarse printer status from snapshot data.
@@ -715,7 +721,7 @@ class PrinterHub:
         or paused, a placeholder row with source="external" is created so
         externally-initiated jobs are captured in the vault history.
         """
-        if not filename:
+        if not filename and ms_state not in _NO_ACTIVE_JOB_STATES:
             return None
         now = time.monotonic()
         breaker = self._job_sync_breakers.get(printer_id)
@@ -724,7 +730,7 @@ class PrinterHub:
         last = self._last_job_sync_write.get(printer_id)
         if (
             last is not None
-            and last[0] == filename
+            and last[0] == (filename or "")
             and last[1] == ms_state
             and now - last[3] < _JOB_PROGRESS_WRITE_INTERVAL_S
             and not print_stats.get("external_artifact_path")
@@ -743,7 +749,7 @@ class PrinterHub:
             )
             self._job_sync_breakers.pop(printer_id, None)
             self._last_job_sync_write[printer_id] = (
-                filename,
+                filename or "",
                 ms_state,
                 progress,
                 now,
@@ -767,7 +773,7 @@ class PrinterHub:
         self,
         printer_id: int,
         ms_state: str,
-        filename: str,
+        filename: str | None,
         progress: float,
         print_stats: Dict[str, Any],
     ) -> tuple[int, str] | None:
@@ -781,11 +787,38 @@ class PrinterHub:
         self,
         printer_id: int,
         ms_state: str,
-        filename: str,
+        filename: str | None,
         progress: float,
         print_stats: Dict[str, Any],
     ) -> tuple[int, str] | None:
         with self._session_factory.session() as session:
+            if ms_state in _NO_ACTIVE_JOB_STATES:
+                interrupted = session.exec(
+                    select(PrintJob).where(
+                        PrintJob.printer_id == printer_id,
+                        PrintJob.state.in_(_OBSERVED_ACTIVE_JOB_STATES),  # type: ignore[union-attr]
+                        live(PrintJob),
+                    )
+                ).all()
+                if interrupted:
+                    now = utcnow()
+                    for active_job in interrupted:
+                        active_job.state = PrintJobState.FAILED
+                        active_job.error = "provider_job_disappeared"
+                        active_job.finished_at = now
+                        active_job.updated_at = now
+                        session.add(active_job)
+                        notifications.enqueue_for_event(
+                            session,
+                            NotificationEventType.PRINT_FAILED,
+                            printer_id=printer_id,
+                            job=active_job,
+                        )
+                    session.commit()
+                self._active_job_cache.pop(printer_id, None)
+                return None
+            if not filename:
+                return None
             job = None
             printer = session.get(Printer, printer_id)
             bambu_printer = (

--- a/backend/app/schemas/fleet.py
+++ b/backend/app/schemas/fleet.py
@@ -41,6 +41,12 @@ class QueueJobUpdate(BaseModel):
     compatibility_policy: Optional[CompatibilityPolicy] = None
 
 
+class ActiveJobResolution(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    resolution: Literal["cancelled", "failed"]
+
+
 class BatchRouting(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/packages/printstash-core/src/printstash_core_testkit/mock_printer.py
+++ b/backend/packages/printstash-core/src/printstash_core_testkit/mock_printer.py
@@ -97,6 +97,9 @@ class MockState:
     def cancel(self) -> None:
         self.sim.cancel()
 
+    def emergency_stop(self) -> None:
+        self.sim.emergency_stop()
+
     def _record_history(self) -> None:
         self._job_id += 1
         self.history.insert(
@@ -253,6 +256,11 @@ def create_app(
     @app.post("/printer/print/cancel")
     async def print_cancel() -> JSONResponse:
         state.cancel()
+        return ok("ok")
+
+    @app.post("/printer/emergency_stop")
+    async def emergency_stop() -> JSONResponse:
+        state.emergency_stop()
         return ok("ok")
 
     @app.get("/server/history/list")

--- a/backend/packages/printstash-core/src/printstash_core_testkit/print_sim.py
+++ b/backend/packages/printstash-core/src/printstash_core_testkit/print_sim.py
@@ -83,6 +83,13 @@ class PrintSim:
             self._started = None
             self.state = CANCELLED
 
+    def emergency_stop(self) -> None:
+        """Drop the current print as firmware would after an emergency stop."""
+        self._accumulated = self.elapsed()
+        self._started = None
+        self.state = STANDBY
+        self.filename = ""
+
     def fail(self, message: str = "simulated failure") -> None:
         self._accumulated = self.elapsed()
         self._started = None

--- a/backend/packages/printstash-core/tests/testkit/test_testkit.py
+++ b/backend/packages/printstash-core/tests/testkit/test_testkit.py
@@ -90,6 +90,19 @@ class TestPrintSim:
 
         assert sim.progress() == 1.0
 
+    def test_emergency_stop_drops_the_active_filename(self) -> None:
+        now = [10.0]
+        sim = _sim(now)
+        sim.start("part.gcode")
+        now[0] = 12.5
+        sim.pause()
+
+        sim.emergency_stop()
+
+        assert sim.state == "standby"
+        assert sim.filename == ""
+        assert sim.progress() == 0.25
+
     def test_reports_full_progress_once_the_print_time_has_elapsed(self) -> None:
         now = [10.0]
         sim = _sim(now)

--- a/backend/tests/contract/modules/printing/test_printer_hub.py
+++ b/backend/tests/contract/modules/printing/test_printer_hub.py
@@ -212,6 +212,37 @@ class TestPause:
             running.stop()
 
 
+class TestExternalInterruption:
+    def test_emergency_stop_fails_the_paused_job(self, db_session: Session) -> None:
+        app, _state = create_app(total_mm=1000.0, total_seconds=10.0, print_seconds=5.0)
+        running = start_server(app)
+        try:
+            printer_id, job_id = _seed(db_session, running.base_url)
+
+            async def _drive() -> None:
+                async with httpx.AsyncClient(base_url=running.base_url) as http:
+                    await http.post("/printer/print/start", params={"filename": REMOTE})
+
+                    async def body() -> None:
+                        await _wait_job_state(job_id, PrintJobState.PRINTING)
+                        await http.post("/printer/print/pause")
+                        await _wait_job_state(job_id, PrintJobState.PAUSED)
+                        await http.post("/printer/emergency_stop")
+                        await _wait_job_state(job_id, PrintJobState.FAILED)
+
+                    await _run_hub(printer_id, body)
+
+            asyncio.run(_drive())
+
+            with get_session_factory().session() as s:
+                job = s.exec(select(PrintJob).where(PrintJob.id == job_id)).one()
+                assert job.state == PrintJobState.FAILED
+                assert job.error == "provider_job_disappeared"
+                assert job.finished_at is not None
+        finally:
+            running.stop()
+
+
 class TestCancel:
     def test_a_cancelled_print_leaves_the_spool_untouched(
         self, db_session: Session

--- a/backend/tests/fixtures/openapi_contract.json
+++ b/backend/tests/fixtures/openapi_contract.json
@@ -1,6 +1,24 @@
 {
   "components": {
     "schemas": {
+      "ActiveJobResolution": {
+        "additionalProperties": false,
+        "properties": {
+          "resolution": {
+            "enum": [
+              "cancelled",
+              "failed"
+            ],
+            "title": "Resolution",
+            "type": "string"
+          }
+        },
+        "required": [
+          "resolution"
+        ],
+        "title": "ActiveJobResolution",
+        "type": "object"
+      },
       "ApiKeyCreateRequest": {
         "additionalProperties": false,
         "properties": {
@@ -21121,6 +21139,63 @@
           }
         ],
         "summary": "Decide Operator Release",
+        "tags": [
+          "fleet"
+        ]
+      }
+    },
+    "/api/v1/fleet/queue/{job_id}/resolve": {
+      "post": {
+        "operationId": "resolve_active_job_api_v1_fleet_queue__job_id__resolve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ActiveJobResolution"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrintJobRead"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Resolve Active Job",
         "tags": [
           "fleet"
         ]

--- a/backend/tests/integration/api/v1/test_fleet.py
+++ b/backend/tests/integration/api/v1/test_fleet.py
@@ -1477,6 +1477,118 @@ class TestDeleteQueueJob:
         assert resp.json()["detail"] == "queue_job_not_editable"
 
 
+class TestResolveActiveJob:
+    def test_requires_authentication(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/v1/fleet/queue/99999/resolve",
+            json={"resolution": "failed"},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "not_authenticated"
+
+    def test_returns_not_found_for_a_missing_job(
+        self, client: TestClient, auth_headers: dict[str, str]
+    ) -> None:
+        response = client.post(
+            "/api/v1/fleet/queue/99999/resolve",
+            headers=auth_headers,
+            json={"resolution": "failed"},
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "queue_job_not_found"
+
+    def test_marks_a_stale_job_failed(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        make_printer,
+        a_gcode_artifact,
+        make_print_job,
+    ) -> None:
+        printer = make_printer("Resolve failed")
+        artifact = a_gcode_artifact("Resolve failed cube")
+        job = make_print_job(artifact, printer=printer, state=PrintJobState.PAUSED)
+
+        response = client.post(
+            f"/api/v1/fleet/queue/{job.id}/resolve",
+            headers=auth_headers,
+            json={"resolution": "failed"},
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["state"] == "failed"
+        assert response.json()["error"] == "operator_marked_failed"
+
+    def test_requires_control_access(
+        self,
+        client: TestClient,
+        make_user,
+        headers_for,
+        grant_printer_role,
+        make_printer,
+        a_gcode_artifact,
+        make_print_job,
+    ) -> None:
+        printer = make_printer("Resolve permissions")
+        artifact = a_gcode_artifact("Resolve permissions cube")
+        job = make_print_job(artifact, printer=printer, state=PrintJobState.PAUSED)
+        member = make_user("resolve-member")
+        member_headers = headers_for(member)
+        grant_printer_role(member, printer, PrinterRole.PRINT)
+
+        response = client.post(
+            f"/api/v1/fleet/queue/{job.id}/resolve",
+            headers=member_headers,
+            json={"resolution": "failed"},
+        )
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == "printer_permission_denied"
+
+    def test_rejects_an_unknown_resolution(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        make_printer,
+        a_gcode_artifact,
+        make_print_job,
+    ) -> None:
+        printer = make_printer("Resolve validation")
+        artifact = a_gcode_artifact("Resolve validation cube")
+        job = make_print_job(artifact, printer=printer, state=PrintJobState.PAUSED)
+
+        response = client.post(
+            f"/api/v1/fleet/queue/{job.id}/resolve",
+            headers=auth_headers,
+            json={"resolution": "completed"},
+        )
+
+        assert response.status_code == 422, response.text
+
+    def test_refuses_a_terminal_job(
+        self,
+        client: TestClient,
+        auth_headers: dict[str, str],
+        make_printer,
+        a_gcode_artifact,
+        make_print_job,
+    ) -> None:
+        printer = make_printer("Resolve terminal")
+        artifact = a_gcode_artifact("Resolve terminal cube")
+        job = make_print_job(artifact, printer=printer, state=PrintJobState.COMPLETED)
+
+        response = client.post(
+            f"/api/v1/fleet/queue/{job.id}/resolve",
+            headers=auth_headers,
+            json={"resolution": "failed"},
+        )
+
+        assert response.status_code == 409, response.text
+        assert response.json()["detail"] == "queue_job_not_resolvable"
+
+
 class TestRetryQueueJob:
     def test_retry_queue_job_404_for_missing_job(
         self, client: TestClient, auth_headers: dict[str, str]

--- a/backend/tests/integration/modules/printing/fleet/test_resolve_active_job.py
+++ b/backend/tests/integration/modules/printing/fleet/test_resolve_active_job.py
@@ -1,0 +1,130 @@
+"""Operator recovery for a PrintJob whose physical print no longer exists.
+
+Resolving a stale active row repairs PrintStash history only.  It must never send
+a printer command, and it is deliberately unavailable while the printer still
+reports an active print.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlmodel import Session
+
+from app.db.models import File, Printer, PrinterStatus, PrintJobState, User
+from app.modules.printing import fleet
+
+
+class TestResolveActiveJob:
+    @pytest.mark.parametrize(
+        "state",
+        [
+            PrintJobState.UPLOADING,
+            PrintJobState.STARTED,
+            PrintJobState.PRINTING,
+            PrintJobState.PAUSED,
+        ],
+    )
+    def test_marks_a_stale_job_failed(
+        self,
+        db_session: Session,
+        operator: User,
+        artifact: File,
+        printer: Printer,
+        make_print_job,
+        state: PrintJobState,
+    ) -> None:
+        job = make_print_job(
+            artifact,
+            printer=printer,
+            state=state,
+        )
+
+        resolved = fleet.resolve_active_job(db_session, int(job.id), "failed", operator)
+
+        assert resolved.state == PrintJobState.FAILED
+        assert resolved.error == "operator_marked_failed"
+        assert resolved.finished_at is not None
+
+    def test_marks_a_stale_job_cancelled(
+        self,
+        db_session: Session,
+        operator: User,
+        artifact: File,
+        printer: Printer,
+        make_print_job,
+    ) -> None:
+        job = make_print_job(
+            artifact,
+            printer=printer,
+            state=PrintJobState.PAUSED,
+        )
+
+        resolved = fleet.resolve_active_job(
+            db_session, int(job.id), "cancelled", operator
+        )
+
+        assert resolved.state == PrintJobState.CANCELLED
+        assert resolved.error is None
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            PrintJobState.QUEUED,
+            PrintJobState.COMPLETED,
+            PrintJobState.CANCELLED,
+            PrintJobState.FAILED,
+        ],
+    )
+    def test_refuses_a_job_outside_the_active_lifecycle(
+        self,
+        db_session: Session,
+        operator: User,
+        artifact: File,
+        printer: Printer,
+        make_print_job,
+        state: PrintJobState,
+    ) -> None:
+        job = make_print_job(artifact, printer=printer, state=state)
+
+        with pytest.raises(fleet.FleetError, match="queue_job_not_resolvable"):
+            fleet.resolve_active_job(db_session, int(job.id), "failed", operator)
+
+    @pytest.mark.parametrize(
+        "printer_status", [PrinterStatus.PRINTING, PrinterStatus.PAUSED]
+    )
+    def test_refuses_a_job_while_the_printer_is_active(
+        self,
+        db_session: Session,
+        operator: User,
+        artifact: File,
+        printer: Printer,
+        make_print_job,
+        printer_status: PrinterStatus,
+    ) -> None:
+        printer.status = printer_status
+        db_session.add(printer)
+        db_session.commit()
+        job = make_print_job(
+            artifact,
+            printer=printer,
+            state=PrintJobState.PRINTING,
+        )
+
+        with pytest.raises(fleet.FleetError, match="printer_still_active"):
+            fleet.resolve_active_job(db_session, int(job.id), "failed", operator)
+
+    def test_hides_a_trashed_job(
+        self,
+        db_session: Session,
+        operator: User,
+        artifact: File,
+        printer: Printer,
+        make_print_job,
+    ) -> None:
+        job = make_print_job(artifact, printer=printer, state=PrintJobState.PAUSED)
+        job.deleted_at = job.updated_at
+        db_session.add(job)
+        db_session.commit()
+
+        with pytest.raises(fleet.FleetError, match="queue_job_not_found"):
+            fleet.resolve_active_job(db_session, int(job.id), "failed", operator)

--- a/backend/tests/integration/modules/printing/test_printer_hub.py
+++ b/backend/tests/integration/modules/printing/test_printer_hub.py
@@ -579,6 +579,73 @@ class TestPrinterHubSyncActiveJob:
 
         asyncio.run(_sync())
 
+    @pytest.mark.parametrize(
+        "active_state", [PrintJobState.PRINTING, PrintJobState.PAUSED]
+    )
+    def test_idle_without_filename_fails_an_observed_active_job(
+        self, hub, db_session, active_state
+    ):
+        pid, job = self._setup_job(db_session)
+        job.state = active_state
+        db_session.add(job)
+        db_session.commit()
+
+        hub._sync_active_job_db(
+            pid,
+            "idle",
+            None,
+            0.0,
+            {"state": "idle", "filename": ""},
+        )
+
+        db_session.refresh(job)
+        assert job.state == PrintJobState.FAILED
+        assert job.error == "provider_job_disappeared"
+        assert job.finished_at is not None
+
+    @pytest.mark.parametrize("idle_state", ["idle", "ready", "standby"])
+    def test_idle_with_filename_fails_a_paused_job(self, hub, db_session, idle_state):
+        pid, job = self._setup_job(db_session)
+        job.state = PrintJobState.PAUSED
+        db_session.add(job)
+        db_session.commit()
+
+        hub._sync_active_job_db(
+            pid,
+            idle_state,
+            "sync.gcode",
+            0.45,
+            {"state": idle_state, "filename": "sync.gcode"},
+        )
+
+        db_session.refresh(job)
+        assert job.state == PrintJobState.FAILED
+
+    def test_idle_preserves_a_started_job(self, hub, db_session):
+        pid, job = self._setup_job(db_session)
+
+        hub._sync_active_job_db(
+            pid,
+            "idle",
+            None,
+            0.0,
+            {"state": "idle", "filename": ""},
+        )
+
+        db_session.refresh(job)
+        assert job.state == PrintJobState.STARTED
+
+    def test_offline_status_preserves_a_paused_job(self, hub, db_session):
+        pid, job = self._setup_job(db_session)
+        job.state = PrintJobState.PAUSED
+        db_session.add(job)
+        db_session.commit()
+
+        hub._mark_status_db(pid, PrinterStatus.OFFLINE, "connection lost")
+
+        db_session.refresh(job)
+        assert job.state == PrintJobState.PAUSED
+
     def test_sync_no_matching_row(self, printer: Printer, hub):
         """With printing state and no matching row, an external job is auto-created."""
         from sqlmodel import select

--- a/frontend/src/components/__tests__/fleet-panels.test.tsx
+++ b/frontend/src/components/__tests__/fleet-panels.test.tsx
@@ -47,12 +47,14 @@ import type {
 const deleteJob = vi.fn<FleetQueueDeps["deleteJob"]>();
 const updateJob = vi.fn<FleetQueueDeps["updateJob"]>();
 const retryJob = vi.fn<FleetQueueDeps["retryJob"]>();
+const resolveJob = vi.fn<FleetQueueDeps["resolveJob"]>();
 const decideOperatorGate = vi.fn<FleetQueueDeps["decideOperatorGate"]>();
 
 const queueDeps: FleetQueueDeps = {
   deleteJob,
   updateJob,
   retryJob,
+  resolveJob,
   decideOperatorGate,
 };
 
@@ -347,6 +349,66 @@ describe("FleetQueuePanel", () => {
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
 
     await waitFor(() => expect(retryJob).toHaveBeenCalledWith(9));
+  });
+
+  it("resolves a stale active job as failed after confirmation", async () => {
+    resolveJob.mockResolvedValue(makeJob({ id: 11, state: "failed" }));
+    renderQueuePanel({
+      jobs: [makeJob({ id: 11, state: "paused", remote_filename: "stale.gcode" })],
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resolve" }));
+    const dialog = screen.getByRole("dialog", { name: "Resolve stale job" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Mark failed" }));
+
+    await waitFor(() => expect(resolveJob).toHaveBeenCalledWith(11, "failed"));
+    await waitFor(() => expect(dialog).not.toBeInTheDocument());
+  });
+
+  it("can record a stale active job as cancelled", async () => {
+    resolveJob.mockResolvedValue(makeJob({ id: 12, state: "cancelled" }));
+    renderQueuePanel({
+      jobs: [makeJob({ id: 12, state: "paused", remote_filename: "cancelled.gcode" })],
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resolve" }));
+    const dialog = screen.getByRole("dialog", { name: "Resolve stale job" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Mark cancelled" }));
+
+    await waitFor(() => expect(resolveJob).toHaveBeenCalledWith(12, "cancelled"));
+  });
+
+  it("keeps the recovery choice open when resolution fails", async () => {
+    resolveJob.mockRejectedValue(new Error("printer still active"));
+    renderQueuePanel({
+      jobs: [makeJob({ id: 13, state: "paused", remote_filename: "still-live.gcode" })],
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Resolve" }));
+    const dialog = screen.getByRole("dialog", { name: "Resolve stale job" });
+    await userEvent.click(within(dialog).getByRole("button", { name: "Mark failed" }));
+
+    await waitFor(() => expect(resolveJob).toHaveBeenCalledWith(13, "failed"));
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it("hides stale-job recovery without printer control access", () => {
+    renderQueuePanel({
+      printers: [
+        makePrinter({
+          access: {
+            role: "print",
+            can_view: true,
+            can_print: true,
+            can_control: false,
+            can_admin: false,
+          },
+        }),
+      ],
+      jobs: [makeJob({ id: 14, state: "paused", remote_filename: "restricted.gcode" })],
+    });
+
+    expect(screen.queryByRole("button", { name: "Resolve" })).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/components/fleet-panels.tsx
+++ b/frontend/src/components/fleet-panels.tsx
@@ -25,6 +25,7 @@ import {
   listMaintenanceLog,
   listMaintenanceWindows,
   retryFleetJob,
+  resolveFleetJob,
   updateFleetJob,
   updatePrinterRouting,
 } from "@/lib/api";
@@ -96,6 +97,7 @@ export interface FleetQueueDeps {
   deleteJob: typeof deleteFleetJob;
   updateJob: typeof updateFleetJob;
   retryJob: typeof retryFleetJob;
+  resolveJob: typeof resolveFleetJob;
   decideOperatorGate: typeof decideFleetOperatorGate;
 }
 
@@ -103,6 +105,7 @@ const REAL_FLEET_QUEUE_DEPS: FleetQueueDeps = {
   deleteJob: deleteFleetJob,
   updateJob: updateFleetJob,
   retryJob: retryFleetJob,
+  resolveJob: resolveFleetJob,
   decideOperatorGate: decideFleetOperatorGate,
 };
 
@@ -114,7 +117,7 @@ export function FleetQueuePanel({
   deps?: Partial<FleetQueueDeps>;
 }) {
   useUiLocale();
-  const { deleteJob, updateJob, retryJob, decideOperatorGate } = {
+  const { deleteJob, updateJob, retryJob, resolveJob, decideOperatorGate } = {
     ...REAL_FLEET_QUEUE_DEPS,
     ...deps,
   };
@@ -123,11 +126,16 @@ export function FleetQueuePanel({
   const summaryQuery = useFleetSummary({ refetchInterval: 5_000 });
   const [deleteTarget, setDeleteTarget] = useState<PrintJobRead | null>(null);
   const [editTarget, setEditTarget] = useState<PrintJobRead | null>(null);
+  const [resolveTarget, setResolveTarget] = useState<PrintJobRead | null>(null);
   const [draft, setDraft] = useState<QueueEditDraft | null>(null);
   const [busy, setBusy] = useState<number | null>(null);
   const jobs = queueQuery.data ?? [];
   const printerNames = useMemo(
     () => new Map(printers.map((printer) => [printer.id, printer.name])),
+    [printers],
+  );
+  const controllablePrinterIds = useMemo(
+    () => new Set(printers.filter((printer) => printer.access.can_control).map(({ id }) => id)),
     [printers],
   );
   const queued = jobs.filter((job) => job.state === "queued");
@@ -181,6 +189,12 @@ export function FleetQueuePanel({
     }
   }
 
+  async function resolveAs(resolution: "cancelled" | "failed") {
+    if (!resolveTarget) return;
+    const resolved = await mutate(resolveTarget.id, () => resolveJob(resolveTarget.id, resolution));
+    if (resolved) setResolveTarget(null);
+  }
+
   if (queueQuery.isLoading) {
     return (
       <Localized>
@@ -225,6 +239,40 @@ export function FleetQueuePanel({
           )}
           confirmLabel={uiText("Delete job")}
         />
+        <Modal
+          open={resolveTarget !== null}
+          onClose={() => {
+            if (busy !== resolveTarget?.id) setResolveTarget(null);
+          }}
+          title={uiText("Resolve stale job")}
+        >
+          {resolveTarget && (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                {uiText(
+                  "Use this only when the printer is no longer running {value1}. This updates PrintStash history; it does not send a command to the printer.",
+                  { value1: String(resolveTarget.remote_filename) },
+                )}
+              </p>
+              <div className="flex flex-wrap justify-end gap-2">
+                <Button
+                  variant="outline"
+                  disabled={busy === resolveTarget.id}
+                  onClick={() => void resolveAs("cancelled")}
+                >
+                  {uiText("Mark cancelled")}
+                </Button>
+                <Button
+                  variant="destructive"
+                  disabled={busy === resolveTarget.id}
+                  onClick={() => void resolveAs("failed")}
+                >
+                  {uiText("Mark failed")}
+                </Button>
+              </div>
+            </div>
+          )}
+        </Modal>
         <Modal
           open={editTarget !== null && draft !== null}
           onClose={() => {
@@ -503,6 +551,18 @@ export function FleetQueuePanel({
           jobs={active}
           printerNames={printerNames}
           busy={busy}
+          actions={(job) =>
+            job.printer_id != null && controllablePrinterIds.has(job.printer_id) ? (
+              <Button
+                variant="outline"
+                size="xs"
+                disabled={busy === job.id}
+                onClick={() => setResolveTarget(job)}
+              >
+                {uiText("Resolve")}
+              </Button>
+            ) : null
+          }
         />
         <QueueSection
           title={uiText("Recent")}

--- a/frontend/src/lib/api/__tests__/fleet.test.ts
+++ b/frontend/src/lib/api/__tests__/fleet.test.ts
@@ -29,6 +29,7 @@ import {
   listMaintenanceLog,
   listMaintenanceWindows,
   retryFleetJob,
+  resolveFleetJob,
   updateFleetJob,
   updatePrinterRouting,
 } from "@/lib/api/fleet";
@@ -175,6 +176,17 @@ describe("retryFleetJob", () => {
     await retryFleetJob(1);
 
     expectRequest("/api/v1/fleet/queue/1/retry", "POST");
+  });
+});
+
+describe("resolveFleetJob", () => {
+  it("marks a stale active job failed", async () => {
+    respondWith({ id: 1, state: "failed" });
+
+    await resolveFleetJob(1, "failed");
+
+    expectRequest("/api/v1/fleet/queue/1/resolve", "POST");
+    expect(lastBody()).toEqual({ resolution: "failed" });
   });
 });
 

--- a/frontend/src/lib/api/fleet.ts
+++ b/frontend/src/lib/api/fleet.ts
@@ -61,6 +61,13 @@ export function retryFleetJob(id: number): Promise<PrintJobRead> {
   return sendJson<PrintJobRead>(`/api/v1/fleet/queue/${id}/retry`, "POST", {});
 }
 
+export function resolveFleetJob(
+  id: number,
+  resolution: "cancelled" | "failed",
+): Promise<PrintJobRead> {
+  return sendJson<PrintJobRead>(`/api/v1/fleet/queue/${id}/resolve`, "POST", { resolution });
+}
+
 export function updatePrinterRouting(id: number, payload: PrinterRoutingUpdate) {
   return sendJson(`/api/v1/fleet/printers/${id}/routing`, "PATCH", payload);
 }

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -3111,5 +3111,10 @@
   "Save cache settings": "Save cache settings",
   "Reset to environment defaults": "Reset to environment defaults",
   "Clear cached files": "Clear cached files",
-  "Files in use stay available until their active reads finish. Clearing does not remove your Artifacts.": "Files in use stay available until their active reads finish. Clearing does not remove your Artifacts."
+  "Files in use stay available until their active reads finish. Clearing does not remove your Artifacts.": "Files in use stay available until their active reads finish. Clearing does not remove your Artifacts.",
+  "Resolve stale job": "Resolve stale job",
+  "Resolve": "Resolve",
+  "Mark cancelled": "Mark cancelled",
+  "Mark failed": "Mark failed",
+  "Use this only when the printer is no longer running {value1}. This updates PrintStash history; it does not send a command to the printer.": "Use this only when the printer is no longer running {value1}. This updates PrintStash history; it does not send a command to the printer."
 }

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -3111,5 +3111,10 @@
   "Save cache settings": "Guardar configuración de caché",
   "Reset to environment defaults": "Restablecer valores del entorno",
   "Clear cached files": "Limpiar archivos en caché",
-  "Files in use stay available until their active reads finish. Clearing does not remove your Artifacts.": "Los archivos en uso permanecen disponibles hasta que terminen sus lecturas activas. La limpieza no elimina tus Artifacts."
+  "Files in use stay available until their active reads finish. Clearing does not remove your Artifacts.": "Los archivos en uso permanecen disponibles hasta que terminen sus lecturas activas. La limpieza no elimina tus Artifacts.",
+  "Resolve stale job": "Resolver trabajo obsoleto",
+  "Resolve": "Resolver",
+  "Mark cancelled": "Marcar como cancelado",
+  "Mark failed": "Marcar como fallido",
+  "Use this only when the printer is no longer running {value1}. This updates PrintStash history; it does not send a command to the printer.": "Úsalo solo cuando la impresora ya no esté ejecutando {value1}. Esto actualiza el historial de PrintStash; no envía ningún comando a la impresora."
 }

--- a/frontend/tests/e2e-real/README.md
+++ b/frontend/tests/e2e-real/README.md
@@ -98,6 +98,10 @@ About (running version + changelog) · design customization (metadata visibility
 card-metric slots + reset) · printer add/remove · cross-cutting (theme
 persistence, health version, routes free of uncaught errors).
 
+The mock-API browser suite also exercises operator recovery for an active fleet
+job whose physical print has disappeared; the real printer contract covers the
+automatic emergency-stop reconciliation path.
+
 `util.ts` uploads a model through the real ingest flow; its G-code embeds the
 model name so the backend's content-hash dedupe doesn't collapse separate
 uploads. `helpers.ts` also exposes `authBundleFor`/`authedContext` to drive a

--- a/frontend/tests/e2e/mock-api.ts
+++ b/frontend/tests/e2e/mock-api.ts
@@ -199,6 +199,7 @@ const modelList = [
 
 // Mutable server state a test can flip before navigating (workers: 1, serial).
 let inboxCollectionId: number | null = null;
+let fleetJobState: "paused" | "failed" = "paused";
 const state = {
   externalLibrariesEnabled: false,
   ingestJobQueued: false,
@@ -228,6 +229,7 @@ export function resetMockApiState(): void {
   state.browserDeviceRevoked = false;
   state.s3LegacyCandidate = true;
   state.s3LegacyAdopted = false;
+  fleetJobState = "paused";
   state.gcPlanState = null;
 }
 
@@ -245,6 +247,31 @@ function gcPlan() {
     backup_id: planState === "quarantined" ? "backup-verified" : null,
     last_error: null,
     items: [],
+  };
+}
+
+function fleetJob() {
+  return {
+    id: 156,
+    printer_id: printer.id,
+    file_id: 2,
+    model_id: model.id,
+    remote_filename: "interrupted-part.gcode",
+    state: fleetJobState,
+    progress: 0.42,
+    source: "vault",
+    error: fleetJobState === "failed" ? "operator_marked_failed" : null,
+    routing_strategy: "manual",
+    queue_position: 1,
+    priority: "normal",
+    target_group: null,
+    blocked_reason: null,
+    operator_gate_state: null,
+    retryable: false,
+    batch_id: null,
+    copy_index: null,
+    created_at: now,
+    updated_at: now,
   };
 }
 
@@ -1178,6 +1205,29 @@ function handle(req: IncomingMessage, res: ServerResponse): void {
   }
   if (url.pathname === "/api/v1/printers") {
     sendJson(res, [printer]);
+    return;
+  }
+  if (url.pathname === "/api/v1/fleet/summary") {
+    sendJson(res, {
+      total_printers: 1,
+      queued_jobs: 0,
+      active_jobs: fleetJobState === "paused" ? 1 : 0,
+      draining_printers: 0,
+      maintenance_printers: 0,
+      attention_jobs: 0,
+      printers: [],
+    });
+    return;
+  }
+  if (url.pathname === "/api/v1/fleet/queue") {
+    sendJson(res, [fleetJob()]);
+    return;
+  }
+  if (url.pathname === "/api/v1/fleet/queue/156/resolve" && req.method === "POST") {
+    drainRequest(req, () => {
+      fleetJobState = "failed";
+      sendJson(res, fleetJob());
+    });
     return;
   }
   if (url.pathname === "/api/v1/printers/dashboard") {

--- a/frontend/tests/e2e/printers.spec.ts
+++ b/frontend/tests/e2e/printers.spec.ts
@@ -61,4 +61,21 @@ test.describe("printer routes", () => {
     expect(html).not.toContain('printerId":"$NaN');
     expect(problems).toEqual([]);
   });
+
+  test("an operator can resolve a stale active job from the queue", async ({ page }) => {
+    const problems = await collectPageProblems(page);
+
+    await page.goto("/printers");
+    await page.getByRole("tab", { name: "Queue" }).click();
+    await expect(page.getByText("interrupted-part.gcode")).toBeVisible();
+    await page.getByRole("button", { name: "Resolve" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Resolve stale job" });
+    await expect(dialog).toContainText("does not send a command to the printer");
+    await dialog.getByRole("button", { name: "Mark failed" }).click();
+
+    await expect(page.getByRole("heading", { name: "Recent" })).toBeVisible();
+    await expect(page.getByText("failed", { exact: true })).toBeVisible();
+    expect(problems).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

- Reconcile tracked printing or paused jobs when an authoritative printer snapshot reports idle/ready/standby without an active filename.
- Add an operator-only recovery action to mark a stale active job failed or cancelled without sending a printer command.
- Extend the printer testkit, API contract, translations, queue UI, and browser coverage for emergency-stop recovery.
- Closes #156.

## Testing

- [ ] `cd backend && ./scripts/test.sh full` green, or not needed (local fast lane: 6504 passed; full matrix delegated to PR CI)
- [x] `cd frontend && pnpm lint && pnpm format:check && pnpm typecheck && pnpm test` green, or not needed (equivalent lint/format/typecheck plus complete coverage suites green)
- [x] Manual test notes included, or not needed (focused Playwright recovery flow passed)

## Coverage matrix

| # | Behaviour | Category | Precondition / input | Observable outcome | Tier | Status |
|---|-----------|----------|----------------------|--------------------|------|--------|
| 1 | Emergency stop clears the fake printer filename | Edge | Fake is printing | Snapshot has no filename | testkit | ✅ `tests/testkit/test_testkit.py::TestPrintSim::test_emergency_stop_drops_the_active_filename` |
| 2 | Emergency stop reconciles a paused tracked job | Happy | Hub observes paused job, then emergency stop | Job becomes failed | contract | ✅ `tests/contract/modules/printing/test_printer_hub.py::TestExternalInterruption::test_emergency_stop_fails_the_paused_job` |
| 3 | Idle snapshot without filename reconciles an observed active job | Happy | Printing job was observed active | Job fails with disappearance reason | integration | ✅ `tests/integration/modules/printing/test_printer_hub.py::TestPrinterHubSyncActiveJob::test_idle_without_filename_fails_an_observed_active_job` |
| 4 | Idle snapshot with filename reconciles a paused job | Edge | Paused job; stale filename remains | Job becomes failed | integration | ✅ `tests/integration/modules/printing/test_printer_hub.py::TestPrinterHubSyncActiveJob::test_idle_with_filename_fails_a_paused_job` |
| 5 | Idle snapshot preserves a job that has not begun printing | Edge | Job is STARTED | State is unchanged | integration | ✅ `tests/integration/modules/printing/test_printer_hub.py::TestPrinterHubSyncActiveJob::test_idle_preserves_a_started_job` |
| 6 | Offline alone does not terminalize a paused job | Edge | Paused job; printer offline | State is unchanged | integration | ✅ `tests/integration/modules/printing/test_printer_hub.py::TestPrinterHubSyncActiveJob::test_offline_status_preserves_a_paused_job` |
| 7 | Operator can resolve a stale job as failed | Happy | Paused job; printer not active | Job is failed and finished | integration | ✅ `tests/integration/modules/printing/fleet/test_resolve_active_job.py::TestResolveActiveJob::test_marks_a_stale_job_failed` |
| 8 | Operator can resolve a stale job as cancelled | Happy | Paused job; printer not active | Job is cancelled and finished | integration | ✅ `tests/integration/modules/printing/fleet/test_resolve_active_job.py::TestResolveActiveJob::test_marks_a_stale_job_cancelled` |
| 9 | Recovery rejects terminal jobs | Error | Job is already terminal | Conflict is returned | integration | ✅ `tests/integration/modules/printing/fleet/test_resolve_active_job.py::TestResolveActiveJob::test_refuses_a_job_outside_the_active_lifecycle` |
| 10 | Recovery refuses while printer reports active | Error | Printer reports printing/paused | Conflict is returned | integration | ✅ `tests/integration/modules/printing/fleet/test_resolve_active_job.py::TestResolveActiveJob::test_refuses_a_job_while_the_printer_is_active` |
| 11 | Trashed jobs stay hidden from recovery | Error | Job is trashed | Not found is returned | integration | ✅ `tests/integration/modules/printing/fleet/test_resolve_active_job.py::TestResolveActiveJob::test_hides_a_trashed_job` |
| 12 | Resolve endpoint requires authentication | Error | No access token | HTTP 401 | integration | ✅ `tests/integration/api/v1/test_fleet.py::TestResolveActiveJob::test_requires_authentication` |
| 13 | Missing job is not exposed | Error | Unknown job id | HTTP 404 | integration | ✅ `tests/integration/api/v1/test_fleet.py::TestResolveActiveJob::test_returns_not_found_for_a_missing_job` |
| 14 | Resolve endpoint marks stale job failed | Happy | Authorized request with `failed` | Updated job is returned | integration | ✅ `tests/integration/api/v1/test_fleet.py::TestResolveActiveJob::test_marks_a_stale_job_failed` |
| 15 | Resolve endpoint requires CONTROL role | Error | User only has PRINT role | HTTP 403 | integration | ✅ `tests/integration/api/v1/test_fleet.py::TestResolveActiveJob::test_requires_control_access` |
| 16 | Resolve endpoint validates resolution | Error | Unknown resolution value | HTTP 422 | integration | ✅ `tests/integration/api/v1/test_fleet.py::TestResolveActiveJob::test_rejects_an_unknown_resolution` |
| 17 | Resolve endpoint refuses terminal job | Error | Job already completed | HTTP 409 | integration | ✅ `tests/integration/api/v1/test_fleet.py::TestResolveActiveJob::test_refuses_a_terminal_job` |
| 18 | Frontend API submits failed recovery | Happy | Failed resolution requested | Correct request and response | frontend | ✅ `frontend/src/lib/api/__tests__/fleet.test.ts::resolveFleetJob > marks a stale active job failed` |
| 19 | Queue confirms failed recovery | Happy | Operator selects mark failed | Confirmation then refreshed queue | frontend | ✅ `frontend/src/components/printers/__tests__/fleet-panels.test.tsx::FleetQueuePanel > resolves a stale active job as failed after confirmation` |
| 20 | Queue confirms cancelled recovery | Happy | Operator selects mark cancelled | Confirmation then refreshed queue | frontend | ✅ `frontend/src/components/printers/__tests__/fleet-panels.test.tsx::FleetQueuePanel > resolves a stale active job as cancelled after confirmation` |
| 21 | Recovery failure remains actionable | Error | Resolve API fails | Error dialog is shown | frontend | ✅ `frontend/src/components/printers/__tests__/fleet-panels.test.tsx::FleetQueuePanel > reports a failed stale-job resolution` |
| 22 | Recovery control is access-gated | Error | User lacks CONTROL role | Resolve action is hidden | frontend | ✅ `frontend/src/components/printers/__tests__/fleet-panels.test.tsx::FleetQueuePanel > hides stale-job recovery without control access` |
| 23 | Operator completes recovery in browser | Happy | Stale active queue job | Job is resolved from queue | browser e2e | ✅ `frontend/tests/e2e/printers.spec.ts::printer routes > an operator can resolve a stale active job from the queue` |

### Tier check

- [ ] `unit/` — pure logic, or a fault that cannot be reproduced for real
- [x] `integration/` — **the default**: any router, any DB write, any RBAC or live/trashed rule
- [x] `contract/` — our client against a real fake over a loopback socket, with **no mocking inside**
- [x] `e2e/` — one test for the feature's headline capability
- [x] `frontend/src/**/__tests__/` or `frontend/tests/e2e-real/`

### Self-check

- [x] Every new test file opens with a contract header saying what it defends
- [x] Every new test asserts **one** behaviour — no name contains "and"
- [x] No `skip`/`xfail`/`.skip` without an issue URL, and no commented-out tests
- [x] Every new endpoint has a 401 row and, if it is role-gated, a 403 row

### Fixtures and factories

- [x] Rows come from the `make_*` fixtures — nothing assembled inline, no new module-local `_make_*` helper, no hard-coded value in a unique column
- [x] Intent keywords used instead of their columns (`trashed=`, `provider=`, `recommended=`, `scanning=`, `uploaded=`)
- [x] **Entity changed?** Its builder, protocol and `make_*` fixture updated in this PR, and any new promise has a row in `tests/repo/test_factories.py` (no entity shape changed)
- [x] Any new scenario has three callers and says why its shape is a unit (no scenario added)

## Notes

- Adds `POST /api/v1/fleet/queue/{job_id}/resolve`; it changes PrintStash history only and deliberately sends no printer command.
- Authoritative idle/ready/standby snapshots now close stale PRINTING/PAUSED jobs; offline snapshots alone preserve them.
