### PR TITLE
test(tasks): verify grouped upload progress directly

### DIFF
--- a/docs/task-center-progress-coverage.md
+++ b/docs/task-center-progress-coverage.md
@@ -1,0 +1,15 @@
+# Grouped upload progress coverage
+
+The grouped upload must retain one task while its server jobs are pending or
+running. Its progress represents the complete expected upload, including jobs
+that have not yet been submitted. Previously these intermediate states were
+executed incidentally by upload UI tests; their assertions only checked the
+request or final completion.
+
+| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
+|---|----------------------|----------|----------------------|-----------------------------|------|--------|
+| T001 | reports grouped progress across unfinished jobs | Happy | Completed mesh, G-code at 40%, three expected jobs | One running task, 47%, current G-code detail | Frontend unit | ✅ `frontend/src/lib/__tests__/task-center.test.ts::reports grouped progress across unfinished jobs` |
+| T002 | keeps unknown grouped progress pending | Edge | Linked pending job without progress | One pending task, zero progress, current filename | Frontend unit | ✅ `frontend/src/lib/__tests__/task-center.test.ts::keeps unknown grouped progress pending` |
+| T003 | reports a failed grouped upload | Error | One linked server job fails | One failed task, complete progress, literal failure detail | Frontend unit | ✅ `frontend/src/lib/__tests__/task-center.test.ts::reports a failed grouped upload` |
+
+Validation: app 2,171 tests, domain 60, UI 198 passed. The app library branch coverage rose to 85.41%, so its two-sided floor is raised from 84.9% to 85.2%. No runtime code changes.

--- a/frontend/scripts/coverage-gate.mjs
+++ b/frontend/scripts/coverage-gate.mjs
@@ -57,7 +57,7 @@ const SUITES = [
     areas: [
       // The tested core: formatters, stores, query hooks, the api client. This is
       // the area where a unit test is the right tier, so it carries the real floor.
-      { prefix: "src/lib/", statements: 93.4, branches: 84.9 },
+      { prefix: "src/lib/", statements: 93.4, branches: 85.2 },
       // The bulk of the app, and where the remaining debt is. Route-level
       // behaviour is covered by Playwright, which v8 cannot see; component-level
       // behaviour is being brought up module by module.

--- a/frontend/src/lib/__tests__/task-center.test.ts
+++ b/frontend/src/lib/__tests__/task-center.test.ts
@@ -23,6 +23,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { anIngestJob } from "@/test-support/factories";
 import type { IngestJobSource } from "@/lib/task-center";
 import type { IngestJobStatus } from "@/types";
 
@@ -213,6 +214,101 @@ describe("clearCompletedTasks", () => {
 });
 
 describe("groupUploadJobs", () => {
+  it("reports grouped progress across unfinished jobs", async () => {
+    const taskId = tc.createTask({ title: "Upload Benchy", expectedJobCount: 3 });
+    tc.linkTaskToJob(taskId, "mesh-job");
+    tc.linkTaskToJob(taskId, "gcode-job");
+    listIngestJobs.mockResolvedValue([
+      anIngestJob({
+        job_id: "mesh-job",
+        state: "completed",
+        model_id: 1,
+        file_id: 1,
+        error: null,
+        started_at: null,
+        finished_at: null,
+      }),
+      anIngestJob({
+        job_id: "gcode-job",
+        state: "running",
+        model_id: 1,
+        file_id: null,
+        error: null,
+        started_at: null,
+        finished_at: null,
+        progress: 40,
+        current_item: "Benchy.gcode",
+        processed: 2,
+        total: 5,
+      }),
+    ]);
+
+    await tc.syncImportJobs();
+
+    expect(tc.listTasks()).toHaveLength(1);
+    expect(tc.listTasks()[0]).toMatchObject({
+      id: taskId,
+      status: "running",
+      progress: 47,
+      currentItem: "Benchy.gcode",
+      detail: "running 2/5 · Benchy.gcode · continues in background",
+    });
+  });
+
+  it("keeps unknown grouped progress pending", async () => {
+    const taskId = tc.createTask({ title: "Upload Benchy", expectedJobCount: 2 });
+    tc.linkTaskToJob(taskId, "mesh-job");
+    listIngestJobs.mockResolvedValue([
+      anIngestJob({
+        job_id: "mesh-job",
+        state: "pending",
+        model_id: null,
+        file_id: null,
+        error: null,
+        started_at: null,
+        finished_at: null,
+        current_item: "Benchy.stl",
+      }),
+    ]);
+
+    await tc.syncImportJobs();
+
+    expect(tc.listTasks()).toHaveLength(1);
+    expect(tc.listTasks()[0]).toMatchObject({
+      id: taskId,
+      status: "pending",
+      progress: 0,
+      currentItem: "Benchy.stl",
+      detail: "pending · Benchy.stl · continues in background",
+    });
+  });
+
+  it("reports a failed grouped upload", async () => {
+    const taskId = tc.createTask({ title: "Upload Benchy", expectedJobCount: 2 });
+    tc.linkTaskToJob(taskId, "mesh-job");
+    listIngestJobs.mockResolvedValue([
+      anIngestJob({
+        job_id: "mesh-job",
+        state: "failed",
+        model_id: null,
+        file_id: null,
+        error: "The source file could not be read",
+        started_at: null,
+        finished_at: null,
+      }),
+    ]);
+
+    await tc.syncImportJobs();
+
+    expect(tc.listTasks()).toHaveLength(1);
+    expect(tc.listTasks()[0]).toMatchObject({
+      id: taskId,
+      status: "failed",
+      progress: 100,
+      detail: "The source file could not be read",
+    });
+  });
+
   it("removes a duplicate pending row persisted by an older client", async () => {
     localStorage.setItem(
       "printstash:import-tasks:v1",


### PR DESCRIPTION
The frontend coverage gate on merged main observed fewer branch hits in the Task Center than the PR run. Grouped upload progress was exercised incidentally by UI uploads, whose assertions checked requests or completion rather than intermediate task states.

Add direct, awaited checks for mixed completed/running progress, pending jobs with unknown progress, and failed grouped uploads. Use the shared ingestion-job fixture and fake clock. No runtime code changes. The resulting library branch coverage is 85.41%, so raise the two-sided floor from 84.9% to 85.2%.

Validation: 2,171 app tests, 60 domain tests and 198 UI tests passed with coverage; every floor held. Formatting, lint and typechecking passed. The changed tests also passed independently (39). The production security-diff gate does not apply to this test-only change.

| # | Behaviour (test name) | Category | Precondition / input | Observable outcome asserted | Tier | Status |
|---|----------------------|----------|----------------------|-----------------------------|------|--------|
| T001 | reports grouped progress across unfinished jobs | Happy | Completed mesh, G-code at 40%, three expected jobs | One running task, 47%, current G-code detail | Frontend unit | ✅ `frontend/src/lib/__tests__/task-center.test.ts::reports grouped progress across unfinished jobs` |
| T002 | keeps unknown grouped progress pending | Edge | Linked pending job without progress | One pending task, zero progress, current filename | Frontend unit | ✅ `frontend/src/lib/__tests__/task-center.test.ts::keeps unknown grouped progress pending` |
| T003 | reports a failed grouped upload | Error | One linked server job fails | One failed task, complete progress, literal failure detail | Frontend unit | ✅ `frontend/src/lib/__tests__/task-center.test.ts::reports a failed grouped upload` |

